### PR TITLE
Update imports to avoid incorrect nesting.

### DIFF
--- a/packages/htmlbars-syntax/tests/loc-node-test.ts
+++ b/packages/htmlbars-syntax/tests/loc-node-test.ts
@@ -1,4 +1,4 @@
-import { parse } from "../htmlbars-syntax";
+import { parse } from "htmlbars-syntax";
 
 QUnit.module("[htmlbars-syntax] Parser - Location Info");
 

--- a/packages/htmlbars-syntax/tests/parser-node-test.ts
+++ b/packages/htmlbars-syntax/tests/parser-node-test.ts
@@ -1,6 +1,6 @@
-import { parse as handlebarsParse } from "../htmlbars-syntax/handlebars/compiler/base";
-import { parse } from "../htmlbars-syntax";
-import b from "../htmlbars-syntax/builders";
+import { parse as handlebarsParse } from "handlebars/compiler/base";
+import { parse } from "htmlbars-syntax";
+import b from "htmlbars-syntax/lib/builders";
 import { astEqual } from "./support";
 
 QUnit.module("[htmlbars-syntax] Parser - AST");

--- a/packages/htmlbars-syntax/tests/plugin-node-test.ts
+++ b/packages/htmlbars-syntax/tests/plugin-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, Walker } from '../htmlbars-syntax';
+import { parse, Walker } from 'htmlbars-syntax';
 
 QUnit.module('[htmlbars-syntax] Plugins - AST Transforms');
 

--- a/packages/htmlbars-syntax/tests/support.ts
+++ b/packages/htmlbars-syntax/tests/support.ts
@@ -1,4 +1,4 @@
-import { parse } from '../htmlbars-syntax';
+import { parse } from 'htmlbars-syntax';
 
 function normalizeNode(obj) {
   if (obj && typeof obj === 'object') {

--- a/packages/htmlbars-syntax/tests/traversal/manipulating-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/manipulating-node-test.ts
@@ -7,7 +7,7 @@ import {
 import {
   cannotRemoveNode,
   cannotReplaceNode,
-} from 'htmlbars-syntax/traversal/errors';
+} from 'htmlbars-syntax/lib/traversal/errors';
 
 QUnit.module('[htmlbars-syntax] Traversal - manipulating');
 

--- a/packages/htmlbars-syntax/tests/traversal/visiting-keys-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-keys-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, traverse } from '../../htmlbars-syntax';
+import { parse, traverse } from 'htmlbars-syntax';
 
 function traversalEqual(node, expectedTraversal) {
   let actualTraversal = [];

--- a/packages/htmlbars-syntax/tests/traversal/visiting-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, traverse } from '../../htmlbars-syntax';
+import { parse, traverse } from 'htmlbars-syntax';
 
 function traversalEqual(node, expectedTraversal) {
   let actualTraversal = [];

--- a/packages/htmlbars-syntax/tests/traversal/walker-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/walker-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, Walker } from '../../htmlbars-syntax';
+import { parse, Walker } from 'htmlbars-syntax';
 
 function compareWalkedNodes(html, expected) {
   var ast = parse(html);

--- a/packages/htmlbars-util/tests/htmlbars-util-test.ts
+++ b/packages/htmlbars-util/tests/htmlbars-util-test.ts
@@ -1,4 +1,4 @@
-import {SafeString} from "../htmlbars-util";
+import {SafeString} from "htmlbars-util";
 
 QUnit.module('htmlbars-util');
 


### PR DESCRIPTION
After running:

```
git clone git@github.com:tildeio/glimmer.git
cd glimmer
npm install 
bower install
ember test --server --no-launch
```

The resulting build failed to load the test modules due to these imports being setup incorrectly. I am uncertain if there are local changes (to dependencies or the code itself) that @chancancode and @wycats are using to allow these tests to run properly on their systems, or if they just allow all the import errors to run on every test run (seems unlikely).
