### PR TITLE
Pass proper arguments to `TestEnvironment#registerComponent`.

### DIFF
--- a/packages/htmlbars-runtime/tests/component-test.ts
+++ b/packages/htmlbars-runtime/tests/component-test.ts
@@ -15,7 +15,7 @@ function compile(template: string) {
 
 function commonSetup() {
   env = new TestEnvironment(window.document); // TODO: Support SimpleDOM
-  env.registerComponent('my-component', MyComponent, compile("<div>{{yield}}</div>"))
+  env.registerComponent('my-component', MyComponent, "<div>{{yield}}</div>")
   root = rootElement();
 }
 
@@ -65,7 +65,7 @@ QUnit.skip('creating a new component', assert => {
 });
 
 QUnit.skip('the component class is its context', assert => {
-  env.registerComponent('my-component', MyComponent, compile('<div><p>{{testing}}</p>{{yield}}</div>'))
+  env.registerComponent('my-component', MyComponent, '<div><p>{{testing}}</p>{{yield}}</div>')
   let template = compile("<my-component color='{{color}}'>hello!</my-component>");
   render(template, { color: 'red' });
 
@@ -75,7 +75,7 @@ QUnit.skip('the component class is its context', assert => {
 });
 
 QUnit.skip('attrs are available in the layout', assert => {
-  env.registerComponent('my-component', MyComponent, compile('<div><p>{{attrs.color}}</p>{{yield}}</div>'))
+  env.registerComponent('my-component', MyComponent, '<div><p>{{attrs.color}}</p>{{yield}}</div>')
   let template = compile("<my-component color='{{color}}'>hello!</my-component>");
   let result = render(template, { color: 'red' });
 
@@ -86,7 +86,7 @@ QUnit.skip('attrs are available in the layout', assert => {
 
 function testError(layout: string, expected: RegExp) {
   QUnit.skip(`'${layout}' produces an error like ${expected}`, assert => {
-    env.registerComponent('my-component', MyComponent, compile(layout));
+    env.registerComponent('my-component', MyComponent, layout);
     let template = compile("<my-component>hello!</my-component>");
     assert.throws(() => render(template), expected);
   });


### PR DESCRIPTION
`TestEnvironment#registerComponent` [expects the layout argument to be a string](https://github.com/tildeio/glimmer/blob/master/packages/htmlbars-runtime/tests/support.ts#L151) so do not attempt to compile it first.

This fixes 8 tests in https://github.com/tildeio/glimmer/blob/master/packages/htmlbars-runtime/tests/component-test.ts.
