### PR TITLE
Organize opcodes into a builder structure

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -47,6 +47,10 @@ export {
 } from './lib/opcode-builder';
 
 export {
+  default as OpcodeBuilderDSL
+} from './lib/compiled/opcodes/builder';
+
+export {
   Block,
   BlockOptions,
   Layout,

--- a/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
@@ -1,0 +1,266 @@
+import * as component from './component';
+import * as content from './content';
+import * as dom from './dom';
+import * as lists from './lists';
+import * as vm from './vm';
+import * as Syntax from '../../syntax/core';
+
+import { Opaque, InternedString } from 'glimmer-util';
+import { Insertion } from '../../upsert';
+import { Expression, CompileInto, StatementCompilationBuffer } from '../../syntax';
+import { Opcode, OpSeq } from '../../opcodes';
+import { CompiledArgs } from '../expressions/args';
+import { CompiledExpression } from '../expressions';
+import { ComponentDefinition } from '../../component/interfaces';
+import InnerOpcodeBuilder from '../../opcode-builder';
+import Environment from '../../environment';
+
+interface CompilesInto<T> {
+  compile(dsl: OpcodeBuilder, env: Environment): T;
+}
+
+class StatementCompilationBufferProxy implements StatementCompilationBuffer {
+  constructor(protected inner: StatementCompilationBuffer) {}
+
+  get component() {
+    return this.inner.component;
+  }
+
+  toOpSeq(): OpSeq {
+    return this.inner.toOpSeq();
+  }
+
+  append<T extends Opcode>(opcode: T) {
+    this.inner.append(opcode);
+  }
+
+  getLocalSymbol(name: InternedString): number {
+    return this.inner.getLocalSymbol(name);
+  }
+
+  hasLocalSymbol(name: InternedString): boolean {
+    return this.inner.hasLocalSymbol(name);
+  }
+
+  getNamedSymbol(name: InternedString): number {
+    return this.inner.getNamedSymbol(name);
+  }
+
+  hasNamedSymbol(name: InternedString): boolean {
+    return this.inner.hasNamedSymbol(name);
+  }
+
+  getBlockSymbol(name: InternedString): number {
+    return this.inner.getBlockSymbol(name);
+  }
+
+  hasBlockSymbol(name: InternedString): boolean {
+    return this.inner.hasBlockSymbol(name);
+  }
+
+  // only used for {{view.name}}
+  hasKeyword(name: InternedString): boolean {
+    return this.inner.hasKeyword(name);
+  }
+}
+
+interface OpenComponentOptions {
+  definition: ComponentDefinition<any>;
+  args: CompilesInto<CompiledArgs>;
+  shadow: InternedString[];
+  templates: Syntax.Templates;
+}
+
+
+export class BasicOpcodeBuilder extends StatementCompilationBufferProxy {
+  constructor(inner: StatementCompilationBuffer, public env: Environment) {
+    super(inner);
+  }
+
+  // components
+
+  putComponentDefinition(options: { factory: component.DynamicComponentFactory<Opaque> }) {
+    this.append(new component.PutComponentDefinitionOpcode(options));
+  }
+
+  openDynamicComponent(options: component.OpenDynamicComponentOptions) {
+    this.append(new component.OpenDynamicComponentOpcode(options));
+  }
+
+  openComponent({ definition, args, shadow, templates }: OpenComponentOptions) {
+    this.append(new component.OpenComponentOpcode({
+      definition,
+      args: args.compile(this, this.env),
+      shadow,
+      templates
+    }));
+  }
+
+  didCreateElement() {
+    this.append(new component.DidCreateElementOpcode());
+  }
+
+  shadowAttributes() {
+    this.append(new component.ShadowAttributesOpcode());
+  }
+
+  closeComponent() {
+    this.append(new component.CloseComponentOpcode());
+  }
+
+  // content
+
+  cautiousAppend() {
+    this.append(new content.CautiousAppendOpcode());
+  }
+
+  trustingAppend() {
+    this.append(new content.TrustingAppendOpcode());
+  }
+
+  // dom
+
+  text(options: { text: InternedString }) {
+    this.append(new dom.TextOpcode(options));
+  }
+
+  openPrimitiveElement(options: { tag: InternedString }) {
+    this.append(new dom.OpenPrimitiveElementOpcode(options));
+  }
+
+  openDynamicPrimitiveElement() {
+    this.append(new dom.OpenDynamicPrimitiveElementOpcode());
+  }
+
+  closeElement() {
+    this.append(new dom.CloseElementOpcode());
+  }
+
+  staticAttr(options: dom.StaticAttrOptions) {
+    this.append(new dom.StaticAttrOpcode(options));
+  }
+
+  dynamicAttrNS(options: dom.DynamicAttrNSOptions) {
+    this.append(new dom.DynamicAttrNSOpcode(options));
+  }
+
+  dynamicAttr(options: dom.SimpleAttrOptions) {
+    this.append(new dom.DynamicAttrOpcode(options));
+  }
+
+  dynamicProp(options: dom.SimpleAttrOptions) {
+    this.append(new dom.DynamicPropOpcode(options));
+  }
+
+  comment(options: dom.CommentOptions) {
+    this.append(new dom.CommentOpcode(options));
+  }
+
+  // lists
+
+  putIterator() {
+    this.append(new lists.PutIteratorOpcode());
+  }
+
+  enterList({ start, end }: { start: vm.LabelOpcode, end: vm.LabelOpcode }) {
+    this.append(new lists.EnterListOpcode(start, end));
+  }
+
+  exitList() {
+    this.append(new lists.ExitListOpcode());
+  }
+
+  enterWithKey({ start, end }: { start: vm.LabelOpcode, end: vm.LabelOpcode }) {
+    this.append(new lists.EnterWithKeyOpcode(start, end));
+  }
+
+  nextIter({ end }: { end: vm.LabelOpcode }) {
+    this.append(new lists.NextIterOpcode(end));
+  }
+
+  // vm
+
+  pushChildScope() {
+    this.append(new vm.PushChildScopeOpcode());
+  }
+
+  pushRootScope(options: vm.PushRootScopeOptions) {
+    this.append(new vm.PushRootScopeOpcode(options));
+  }
+
+  popScope() {
+    this.append(new vm.PopScopeOpcode());
+  }
+
+  pushDynamicScope() {
+    this.append(new vm.PushDynamicScopeOpcode());
+  }
+
+  popDynamicScope() {
+    this.append(new vm.PopDynamicScopeOpcode());
+  }
+
+  putNull() {
+    this.append(new vm.PutNullOpcode());
+  }
+
+  putValue({ expression }: { expression: CompilesInto<CompiledExpression<Opaque>> }) {
+    this.append(new vm.PutValueOpcode({ expression: expression.compile(this, this.env) }));
+  }
+
+  putArgs({ args }: { args: CompilesInto<CompiledArgs> }) {
+    this.append(new vm.PutArgsOpcode({ args: args.compile(this, this.env) }));
+  }
+
+  bindPositionalArgs(options: vm.BindPositionalArgsOptions) {
+    this.append(new vm.BindPositionalArgsOpcode(options));
+  }
+
+  bindNamedArgs(options: vm.BindNamedArgsOptions) {
+    this.append(new vm.BindNamedArgsOpcode(options));
+  }
+
+  bindBlocks(options: vm.BindBlocksOptions) {
+    this.append(new vm.BindBlocksOpcode(options));
+  }
+
+  bindDynamicScope({ callback }: { callback: vm.BindDynamicScopeCallback }) {
+    this.append(new vm.BindDynamicScopeOpcode(callback));
+  }
+
+  enter(options: vm.EnterOptions) {
+    this.append(new vm.EnterOpcode(options));
+  }
+
+  exit() {
+    this.append(new vm.ExitOpcode());
+  }
+
+  label(options: vm.LabelOptions): vm.LabelOpcode {
+    return new vm.LabelOpcode(options);
+  }
+
+  evaluate(options: vm.EvaluateOptions) {
+    this.append(new vm.EvaluateOpcode(options));
+  }
+
+  test() {
+    this.append(new vm.TestOpcode());
+  }
+
+  jump(options: vm.JumpOptions) {
+    this.append(new vm.JumpOpcode(options));
+  }
+
+  jumpIf(options: vm.JumpOptions) {
+    this.append(new vm.JumpIfOpcode(options));
+  }
+
+  jumpUnless(options: vm.JumpOptions) {
+    this.append(new vm.JumpUnlessOpcode(options));
+  }
+}
+
+export default class OpcodeBuilder extends BasicOpcodeBuilder {
+
+}

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -60,7 +60,7 @@ export function normalizeValue(value: Opaque): CautiousInsertion {
   return String(value);
 }
 
-abstract class AppendOpcode<T extends Insertion> extends Opcode {
+export abstract class AppendOpcode<T extends Insertion> extends Opcode {
   protected abstract normalize(reference: Reference<Opaque>): Reference<T>;
   protected abstract insert(dom: DOMHelper, cursor: Cursor, value: T): Upsert;
   protected abstract updateWith(cache: ReferenceCache<T>, bounds: Fragment, upsert: Upsert): UpdateOpcode<T>;

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -182,13 +182,19 @@ export class CloseElementOpcode extends Opcode {
   }
 }
 
+export interface StaticAttrOptions {
+  namespace: InternedString;
+  name: InternedString;
+  value: InternedString;
+}
+
 export class StaticAttrOpcode extends Opcode {
   public type = "static-attr";
   public namespace: InternedString;
   public name: InternedString;
   public value: ValueReference<string>;
 
-  constructor({ namespace, name, value,  }: { namespace: InternedString, name: InternedString, value: InternedString }) {
+  constructor({ namespace, name, value }: StaticAttrOptions) {
     super();
     this.namespace = namespace;
     this.name = name;
@@ -395,12 +401,17 @@ function formatElement(element: Element): string {
   return JSON.stringify(`<${element.tagName.toLowerCase()} />`);
 }
 
+export interface DynamicAttrNSOptions {
+  name: InternedString;
+  namespace: InternedString;
+}
+
 export class DynamicAttrNSOpcode extends Opcode {
   public type = "dynamic-attr";
   public name: InternedString;
   public namespace: InternedString;
 
-  constructor({ name, namespace }: { name: InternedString, namespace: InternedString }) {
+  constructor({ name, namespace }: DynamicAttrNSOptions) {
     super();
     this.name = name;
     this.namespace = namespace;
@@ -428,11 +439,15 @@ export class DynamicAttrNSOpcode extends Opcode {
   }
 }
 
+export interface SimpleAttrOptions {
+  name: InternedString;
+}
+
 export class DynamicAttrOpcode extends Opcode {
   public type = "dynamic-attr";
   public name: InternedString;
 
-  constructor({ name }: { name: InternedString }) {
+  constructor({ name }: SimpleAttrOptions) {
     super();
     this.name = name;
   }
@@ -459,7 +474,7 @@ export class DynamicPropOpcode extends Opcode {
   public type = "dynamic-prop";
   public name: InternedString;
 
-  constructor({ name }: { name: InternedString }) {
+  constructor({ name }: SimpleAttrOptions) {
     super();
     this.name = name;
   }
@@ -505,6 +520,10 @@ export class PatchElementOpcode extends DOMUpdatingOpcode {
       details: operation.toJSON()
     };
   }
+}
+
+export interface CommentOptions {
+  comment: InternedString;
 }
 
 export class CommentOpcode extends Opcode {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -24,6 +24,10 @@ export class PushChildScopeOpcode extends Opcode {
   }
 }
 
+export interface PushRootScopeOptions {
+  size: number;
+}
+
 export class PushRootScopeOpcode extends Opcode {
   public type = "push-root-scope";
   public size: number;
@@ -92,12 +96,16 @@ export class PutValueOpcode extends Opcode {
   }
 }
 
+export interface PutArgsOptions {
+  args: CompiledArgs;
+}
+
 export class PutArgsOpcode extends Opcode {
   public type = "put-args";
 
   private args: CompiledArgs;
 
-  constructor({ args }: { args: CompiledArgs }) {
+  constructor({ args }: PutArgsOptions) {
     super();
     this.args = args;
   }
@@ -118,13 +126,17 @@ export class PutArgsOpcode extends Opcode {
   }
 }
 
+export interface BindPositionalArgsOptions {
+  block: InlineBlock
+}
+
 export class BindPositionalArgsOpcode extends Opcode {
   public type = "bind-positional-args";
 
   private names: string[];
   private positional: number[];
 
-  constructor({ block }: { block: InlineBlock }) {
+  constructor({ block }: BindPositionalArgsOptions) {
     super();
 
     this.names = block.locals;
@@ -146,6 +158,10 @@ export class BindPositionalArgsOpcode extends Opcode {
       args: [`[${this.names.map(name => JSON.stringify(name)).join(", ")}]`]
     };
   }
+}
+
+export interface BindNamedArgsOptions {
+  named: Dict<number>;
 }
 
 export class BindNamedArgsOpcode extends Opcode {
@@ -185,6 +201,10 @@ export class BindNamedArgsOpcode extends Opcode {
   }
 }
 
+export interface BindBlocksOptions {
+  blocks: Dict<number>;
+}
+
 export class BindBlocksOpcode extends Opcode {
   public type = "bind-blocks";
 
@@ -209,6 +229,8 @@ export class BindBlocksOpcode extends Opcode {
   }
 }
 
+export { BindDynamicScopeCallback };
+
 export class BindDynamicScopeOpcode extends Opcode {
   public type = "bind-dynamic-scope";
 
@@ -224,11 +246,16 @@ export class BindDynamicScopeOpcode extends Opcode {
   }
 }
 
+export interface EnterOptions {
+  begin: LabelOpcode;
+  end: LabelOpcode;
+}
+
 export class EnterOpcode extends Opcode {
   public type = "enter";
   private slice: Slice<Opcode>;
 
-  constructor({ begin, end }: { begin: LabelOpcode, end: LabelOpcode }) {
+  constructor({ begin, end }: EnterOptions) {
     super();
     this.slice = new ListSlice(begin, end);
   }
@@ -262,12 +289,16 @@ export class ExitOpcode extends Opcode {
   }
 }
 
+export interface LabelOptions {
+  label?: string;
+}
+
 export class LabelOpcode extends Opcode {
   public type = "label";
 
   public label: string = null;
 
-  constructor({ label }: { label?: string }) {
+  constructor({ label }: LabelOptions) {
     super();
     if (label) this.label = label;
   }
@@ -286,6 +317,11 @@ export class LabelOpcode extends Opcode {
       args: [JSON.stringify(this.inspect())]
     };
   }
+}
+
+export interface EvaluateOptions {
+  debug: string;
+  block: InlineBlock;
 }
 
 export class EvaluateOpcode extends Opcode {
@@ -326,6 +362,10 @@ export class TestOpcode extends Opcode {
       args: ["$OPERAND"]
     };
   }
+}
+
+export interface JumpOptions {
+  target: LabelOpcode;
 }
 
 export class JumpOpcode extends Opcode {

--- a/packages/glimmer-runtime/lib/syntax.ts
+++ b/packages/glimmer-runtime/lib/syntax.ts
@@ -6,6 +6,7 @@ import { Opcode, OpSeq } from './opcodes';
 import { InlineBlock } from './compiled/blocks';
 
 import OpcodeBuilder from './opcode-builder';
+import OpcodeBuilderDSL from './compiled/opcodes/builder';
 
 import {
   Statement as SerializedStatement,
@@ -65,7 +66,7 @@ export abstract class Statement implements LinkedListNode {
     return new (<new (any) => any>this.constructor)(this);
   }
 
-  abstract compile(opcodes: StatementCompilationBuffer, env: Environment);
+  abstract compile(opcodes: OpcodeBuilderDSL, env: Environment);
 
   scan(scanner: BlockScanner): Statement {
     return this;

--- a/packages/glimmer-runtime/lib/syntax/builtins/if.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/if.ts
@@ -17,6 +17,8 @@ import {
   ExitOpcode
 } from '../../compiled/opcodes/vm';
 
+import OpcodeBuilderDSL from '../../compiled/opcodes/builder'
+
 import Environment from '../../environment';
 
 export default class IfSyntax extends StatementSyntax {
@@ -36,7 +38,7 @@ export default class IfSyntax extends StatementSyntax {
     return `#if ${this.args.prettyPrint()}`;
   }
 
-  compile(compiler: CompileInto & SymbolLookup, env: Environment) {
+  compile(dsl: OpcodeBuilderDSL) {
     //        Enter(BEGIN, END)
     // BEGIN: Noop
     //        PutArgs
@@ -49,27 +51,29 @@ export default class IfSyntax extends StatementSyntax {
     // END:   Noop
     //        Exit
 
-    let BEGIN = new LabelOpcode({ label: "BEGIN" });
-    let ELSE = new LabelOpcode({ label: "ELSE" });
-    let END = new LabelOpcode({ label: "END" });
+    let { args } = this;
 
-    compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
-    compiler.append(BEGIN);
-    compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env) }));
-    compiler.append(new TestOpcode());
+    let BEGIN = dsl.label({ label: 'BEGIN' });
+    let ELSE = dsl.label({ label: 'ELSE' });
+    let END = dsl.label({ label: 'END' });
+
+    dsl.enter({ begin: BEGIN, end: END });
+    dsl.append(BEGIN);
+    dsl.putArgs({ args });
+    dsl.test();
 
     if (this.templates.inverse) {
-      compiler.append(new JumpUnlessOpcode({ target: ELSE }));
-      compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
-      compiler.append(new JumpOpcode({ target: END }));
-      compiler.append(ELSE);
-      compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
+      dsl.jumpUnless({ target: ELSE });
+      dsl.evaluate({ debug: "default", block: this.templates.default });
+      dsl.jump({ target: END });
+      dsl.append(ELSE);
+      dsl.evaluate({ debug: "inverse", block: this.templates.inverse })
     } else {
-      compiler.append(new JumpUnlessOpcode({ target: END }));
-      compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
+      dsl.jumpUnless({ target: END });
+      dsl.evaluate({ debug: "default", block: this.templates.default });
     }
 
-    compiler.append(END);
-    compiler.append(new ExitOpcode());
+    dsl.append(END);
+    dsl.exit();
   }
 }

--- a/packages/glimmer-runtime/lib/syntax/builtins/unless.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/unless.ts
@@ -17,6 +17,8 @@ import {
   ExitOpcode
 } from '../../compiled/opcodes/vm';
 
+import OpcodeBuilderDSL from '../../compiled/opcodes/builder';
+
 import Environment from '../../environment';
 
 export default class UnlessSyntax extends StatementSyntax {
@@ -36,7 +38,7 @@ export default class UnlessSyntax extends StatementSyntax {
     return `#unless ${this.args.prettyPrint()}`;
   }
 
-  compile(compiler: CompileInto & SymbolLookup, env: Environment) {
+  compile(dsl: OpcodeBuilderDSL, env: Environment) {
     //        Enter(BEGIN, END)
     // BEGIN: Noop
     //        PutArgs
@@ -49,27 +51,29 @@ export default class UnlessSyntax extends StatementSyntax {
     // END:   Noop
     //        Exit
 
-    let BEGIN = new LabelOpcode({ label: "BEGIN" });
-    let ELSE = new LabelOpcode({ label: "ELSE" });
-    let END = new LabelOpcode({ label: "END" });
+    let { args, templates } = this;
 
-    compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
-    compiler.append(BEGIN);
-    compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env) }));
-    compiler.append(new TestOpcode());
+    let BEGIN = dsl.label({ label: "BEGIN" });
+    let ELSE = dsl.label({ label: "ELSE" });
+    let END = dsl.label({ label: "END" });
 
-    if (this.templates.inverse) {
-      compiler.append(new JumpIfOpcode({ target: ELSE }));
-      compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
-      compiler.append(new JumpOpcode({ target: END }));
-      compiler.append(ELSE);
-      compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
+    dsl.enter({ begin: BEGIN, end: END });
+    dsl.append(BEGIN);
+    dsl.putArgs({ args });
+    dsl.test();
+
+    if (templates.inverse) {
+      dsl.jumpIf({ target: ELSE });
+      dsl.evaluate({ debug: "default", block: templates.default })
+      dsl.jump({ target: END });
+      dsl.append(ELSE);
+      dsl.evaluate({ debug: "inverse", block: templates.inverse });
     } else {
-      compiler.append(new JumpIfOpcode({ target: END }));
-      compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
+      dsl.jumpIf({ target: END });
+      dsl.evaluate({ debug: "default", block: templates.default });
     }
 
-    compiler.append(END);
-    compiler.append(new ExitOpcode());
+    dsl.append(END);
+    dsl.exit();
   }
 }


### PR DESCRIPTION
This is a simple re-org with tests still passing, but it should allow
more experimentation with the process of building opcodes, including
simplifying what an opcode is and allowing abstractions that build
several opcodes at once.
