### PR TITLE
[FEAT] render-portal, replaces in-element for wormhole support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "qunit": "^0.7.2",
     "simple-dom": "^0.3.0",
     "simple-html-tokenizer": "^0.2.5",
-    "typescript": "next"
+    "typescript": "2.0.0"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -106,8 +106,8 @@ export {
 } from './lib/syntax/builtins/with-dynamic-vars';
 
 export {
-  default as InElementSyntax
-} from './lib/syntax/builtins/in-element';
+  default as RenderPortalSyntax
+} from './lib/syntax/builtins/render-portal';
 
 export { PublicVM as VM, UpdatingVM, RenderResult } from './lib/vm';
 

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -395,7 +395,7 @@ export class RemoteBlockTracker extends SimpleBlockTracker {
     let firstNode = this._firstNode();
     let lastNode = this._lastNode();
 
-    let lastElement = newParent ? newTarget.lastNode : this.comment.nextSibling;
+    let lastElement = newParent ? newTarget.lastChild : this.comment.nextSibling;
     let nextNode;
 
     while (firstNode) {

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -143,12 +143,15 @@ export class ElementStack implements Cursor {
     return tracker;
   }
 
-  private pushBlockTracker(tracker: Tracker) {
+  private pushBlockTracker(tracker: Tracker, isRemote = false) {
     let current = this.blockStack.current;
 
     if (current !== null) {
       current.newDestroyable(tracker);
-      current.newBounds(tracker);
+
+      if (!isRemote) {
+        current.newBounds(tracker);
+      }
     }
 
     this.blockStack.push(tracker);
@@ -197,10 +200,15 @@ export class ElementStack implements Cursor {
   }
 
   pushRemoteElement(element: Simple.Element) {
-    this.pushElement(element);
+    let tracker;
 
-    let tracker = new RemoteBlockTracker(element);
-    this.pushBlockTracker(tracker);
+    if (!element) {
+      this.pushUpdatableBlock();
+    } else {
+      tracker = new RemoteBlockTracker(element);
+      this.pushElement(element);
+      this.pushBlockTracker(tracker, true);
+    }
   }
 
   popRemoteElement() {

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -395,7 +395,7 @@ export class RemoteBlockTracker extends SimpleBlockTracker {
     let firstNode = this._firstNode();
     let lastNode = this._lastNode();
 
-    let lastElement = newParent ? newTarget.lastChild : this.comment.nextSibling;
+    let lastElement = newParent ? null : this.comment.nextSibling;
     let nextNode;
 
     while (firstNode) {

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -143,15 +143,12 @@ export class ElementStack implements Cursor {
     return tracker;
   }
 
-  private pushBlockTracker(tracker: Tracker, isRemote = false) {
+  private pushBlockTracker(tracker: Tracker) {
     let current = this.blockStack.current;
 
     if (current !== null) {
       current.newDestroyable(tracker);
-
-      if (!isRemote) {
-        current.newBounds(tracker);
-      }
+      current.newBounds(tracker);
     }
 
     this.blockStack.push(tracker);
@@ -200,15 +197,16 @@ export class ElementStack implements Cursor {
   }
 
   pushRemoteElement(element: Simple.Element) {
-    let tracker;
+    let comment = this.appendComment('portal');
+    let tracker = new RemoteBlockTracker(this.element, element, comment);
 
-    if (!element) {
-      this.pushUpdatableBlock();
-    } else {
-      tracker = new RemoteBlockTracker(element);
+    this.pushBlockTracker(tracker);
+
+    if (element) {
       this.pushElement(element);
-      this.pushBlockTracker(tracker, true);
     }
+
+    return tracker;
   }
 
   popRemoteElement() {
@@ -350,14 +348,6 @@ export class SimpleBlockTracker implements Tracker {
   }
 }
 
-class RemoteBlockTracker extends SimpleBlockTracker {
-  destroy() {
-    super.destroy();
-
-    clear(this);
-  }
-}
-
 export interface UpdatableTracker extends Tracker {
   reset(env: Environment);
 }
@@ -379,6 +369,89 @@ export class UpdatableBlockTracker extends SimpleBlockTracker implements Updatab
     this.last = null;
 
     return nextSibling;
+  }
+}
+
+export class RemoteBlockTracker extends SimpleBlockTracker {
+  private remoteParent: Simple.Element;
+  private comment: Simple.Comment;
+
+  constructor(private parent: Simple.Element, remoteParent: Simple.Element, comment: Simple.Comment) {
+    super(parent);
+
+    this.remoteParent = remoteParent;
+    this.comment = comment;
+  }
+
+  update(newParent) {
+    if (newParent === this.remoteParent) {
+      return;
+    }
+
+    // update actual bounds
+    this.remoteParent = newParent;
+    let newTarget = newParent || this.parent;
+
+    let firstNode = this._firstNode();
+    let lastNode = this._lastNode();
+
+    let lastElement = newParent ? newTarget.lastNode : this.comment.nextSibling;
+    let nextNode;
+
+    while (firstNode) {
+      nextNode = firstNode.nextSibling;
+      newTarget.insertBefore(firstNode, lastElement);
+      firstNode = firstNode !== lastNode ? nextNode : null;
+    }
+  }
+
+  parentElement() {
+    return this.parent;
+  }
+
+  firstNode() {
+    if (this.isRemote()) {
+      return this.comment;
+    }
+    return this._firstNode();
+  }
+
+  _firstNode() {
+    return this.first && this.first.firstNode();
+  }
+
+  lastNode() {
+    if (this.isRemote()) {
+      return this.comment;
+    }
+    return this._lastNode();
+  }
+
+  _lastNode() {
+    return this.last && this.last.lastNode();
+  }
+
+  isRemote() {
+    return !!this.remoteParent;
+  }
+
+  clearRemote() {
+    if (this.isRemote()) {
+      let firstNode = this._firstNode();
+      let lastNode = this._lastNode().nextSibling;
+      let parent = firstNode.parentNode;
+
+      while (firstNode && firstNode !== lastNode) {
+        let next = firstNode.nextSibling;
+        parent.removeChild(firstNode);
+        firstNode = next;
+      }
+    }
+  }
+
+  destroy() {
+    super.destroy();
+    this.clearRemote();
   }
 }
 

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -143,15 +143,12 @@ export class ElementStack implements Cursor {
     return tracker;
   }
 
-  private pushBlockTracker(tracker: Tracker, isRemote = false) {
+  private pushBlockTracker(tracker: Tracker) {
     let current = this.blockStack.current;
 
     if (current !== null) {
       current.newDestroyable(tracker);
-
-      if (!isRemote) {
-        current.newBounds(tracker);
-      }
+      current.newBounds(tracker);
     }
 
     this.blockStack.push(tracker);
@@ -203,7 +200,7 @@ export class ElementStack implements Cursor {
     this.pushElement(element);
 
     let tracker = new RemoteBlockTracker(element);
-    this.pushBlockTracker(tracker, true);
+    this.pushBlockTracker(tracker);
   }
 
   popRemoteElement() {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -70,6 +70,7 @@ export class PushRemoteElementOpcode extends Opcode {
     let reference = vm.frame.getOperand<Simple.Element>();
     let cache = isConstReference(reference) ? undefined : new ReferenceCache(reference);
     let element = cache ? cache.peek() : reference.value();
+    // debugger;
 
     vm.stack().pushRemoteElement(element);
 
@@ -87,7 +88,7 @@ export class PushRemoteElementOpcode extends Opcode {
   }
 }
 
-export class PopRemoteElementOpcode extends Opcode {
+export class PopRemoteElementOpcode extends UpdatingOpcode {
   public type = "pop-remote-element";
 
   evaluate(vm: VM) {

--- a/packages/glimmer-runtime/lib/syntax/builtins/render-portal.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/render-portal.ts
@@ -6,8 +6,8 @@ import OpcodeBuilderDSL from '../../compiled/opcodes/builder';
 import * as Syntax from '../core';
 import Environment from '../../environment';
 
-export default class InElementSyntax extends StatementSyntax {
-  type = "in-element-statement";
+export default class RenderPortalSyntax extends StatementSyntax {
+  type = "render-portal-statement";
 
   public args: Syntax.Args;
   public templates: Syntax.Templates;

--- a/packages/glimmer-runtime/lib/syntax/builtins/render-portal.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/render-portal.ts
@@ -24,8 +24,6 @@ export default class RenderPortalSyntax extends StatementSyntax {
 
     dsl.block({ templates, args }, (dsl, BEGIN, END) => {
       dsl.putArgs(args);
-      dsl.test('simple');
-      dsl.jumpUnless(END);
       dsl.pushRemoteElement();
       dsl.evaluate('default');
       dsl.popRemoteElement();

--- a/packages/glimmer-runtime/tests/render-portal-test.ts
+++ b/packages/glimmer-runtime/tests/render-portal-test.ts
@@ -70,90 +70,99 @@ QUnit.test('changing to falsey', function(assert) {
     stripTight`
       |{{foo}}|
       {{#-render-portal first}}[{{foo}}]{{/-render-portal}}
-      {{#-render-portal second}}[{{foo}}]{{/-render-portal}}
+      {{#-render-portal second}}[{{bar}}]{{/-render-portal}}
     `,
-    { first, second: null, foo: 'Yippie!' }
+    { first, second: null, foo: 'Yippie 1!', bar: 'Bar 1!' }
   );
 
-  equalsElement(first, 'div', {}, `[Yippie!]`);
+  equalsElement(first, 'div', {}, `[Yippie 1!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Yippie!|<!---->[Yippie!]');
+  assertAppended('|Yippie 1!|<!---->[Bar 1!]');
 
-  set(view, 'foo', 'Double Yips!');
+  set(view, 'foo', 'Double Yips 1!');
+  set(view, 'bar', 'Bar 2!');
   rerender();
 
-  equalsElement(first, 'div', {}, `[Double Yips!]`);
+  equalsElement(first, 'div', {}, `[Double Yips 1!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Double Yips!|<!---->[Double Yips!]');
+  assertAppended('|Double Yips 1!|<!---->[Bar 2!]');
 
+  set(view, 'foo', 'Double Yips 2!');
+  set(view, 'bar', 'Bar 3!');
   set(view, 'first', null);
   rerender();
 
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Double Yips!|[Double Yips!][Double Yips!]');
+  assertAppended('|Double Yips 2!|[Double Yips 2!][Bar 3!]');
 
+  set(view, 'foo', 'Double Yips 3!');
+  set(view, 'bar', 'Bar 4!');
   set(view, 'second', second);
   rerender();
 
   equalsElement(first, 'div', {}, ``);
-  equalsElement(second, 'div', {}, `[Double Yips!]`);
-  assertAppended('|Double Yips!|[Double Yips!]<!---->');
+  equalsElement(second, 'div', {}, `[Bar 4!]`);
+  assertAppended('|Double Yips 3!|[Double Yips 3!]<!---->');
 
-  set(view, 'foo', 'Yippie!');
+  set(view, 'foo', 'Yippie 2!');
+  set(view, 'bar', 'Bar 5!');
   rerender();
 
   equalsElement(first, 'div', {}, ``);
-  equalsElement(second, 'div', {}, `[Yippie!]`);
-  assertAppended('|Yippie!|[Yippie!]<!---->');
+  equalsElement(second, 'div', {}, `[Bar 5!]`);
+  assertAppended('|Yippie 2!|[Yippie 2!]<!---->');
 
+  set(view, 'foo', 'Yippie 3!');
+  set(view, 'bar', 'Bar 6!');
   set(view, 'first', first);
   set(view, 'second', null);
   rerender();
 
-  equalsElement(first, 'div', {}, `[Yippie!]`);
+  equalsElement(first, 'div', {}, `[Yippie 3!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Yippie!|<!---->[Yippie!]');
+  assertAppended('|Yippie 3!|<!---->[Bar 6!]');
 });
-/*
+
 QUnit.test('with pre-existing content', function(assert) {
   let externalElement = document.createElement('div');
   let initialContent = externalElement.innerHTML = '<p>Hello there!</p>';
 
   appendViewFor(
     stripTight`{{#-render-portal externalElement}}[{{foo}}]{{/-render-portal}}`,
-    { externalElement, foo: 'Yippie!' }
+    { externalElement, foo: 'Yippie 1!' }
   );
 
   assertAppended('<!---->');
-  equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie!]`);
+  equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie 1!]`);
 
-  set(view, 'foo', 'Double Yips!');
+  set(view, 'foo', 'Double Yips 1!');
   rerender();
 
   assertAppended('<!---->');
-  equalsElement(externalElement, 'div', {}, `${initialContent}[Double Yips!]`);
+  equalsElement(externalElement, 'div', {}, `${initialContent}[Double Yips 1!]`);
 
-  set(view, 'foo', 'Yippie!');
+  set(view, 'foo', 'Yippie 2!');
   rerender();
 
   assertAppended('<!---->');
-  equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie!]`);
+  equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie 2!]`);
 
+  set(view, 'foo', 'Yippie 3!');
   set(view, 'externalElement', null);
   rerender();
 
-  assertAppended('<!---->');
+  assertAppended('[Yippie 3!]');
   equalsElement(externalElement, 'div', {}, `${initialContent}`);
 
+  set(view, 'foo', 'Yippie 4!');
   set(view, 'externalElement', externalElement);
   rerender();
 
   assertAppended('<!---->');
-  equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie!]`);
+  equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie 4!]`);
 });
-*/
-/*
+
 QUnit.test('updating remote element', function(assert) {
   let first = document.createElement('div');
   let second = document.createElement('div');
@@ -199,8 +208,61 @@ QUnit.test('updating remote element', function(assert) {
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, `[Yippie!]`);
 });
-*/
-/*
+
+QUnit.test('changing targets maintains referential integrity', function(assert) {
+  let first = document.createElement('div');
+  first.setAttribute('id', 'first');
+  let second = document.createElement('div');
+  second.setAttribute('id', 'second');
+  let element;
+  let cachedElement;
+
+  function getViewElementById(id) {
+    if (view.element) {
+      let viewElement = view.element.matches('#stable-div') ? view.element
+        : view.element.querySelector(`${id}`);
+
+      if (viewElement) {
+        return viewElement;
+      }
+    }
+
+    return null;
+  }
+
+  appendViewFor(
+    stripTight`
+      {{#-render-portal element}}<div id="stable-div">{{foo}}</div>{{/-render-portal}}
+    `,
+    {
+      element: null,
+      foo: 'Yippie!'
+    }
+  );
+
+  assertAppended('<div id="stable-div">Yippie!</div>');
+  equalsElement(first, 'div', { id: 'first' }, ``);
+  equalsElement(second, 'div', { id: 'second' }, ``);
+  cachedElement = getViewElementById('stable-div');
+
+  set(view, 'element', first);
+  rerender();
+
+  assertAppended('<!---->');
+  equalsElement(first, 'div', { id: 'first' }, `<div id="stable-div">Yippie!</div>`);
+  equalsElement(second, 'div', { id: 'second' }, ``);
+  element = first.querySelector(`#stable-div`);
+  assert.ok(element === cachedElement, 'Moving from in-place maintained integrity');
+
+  set(view, 'element', second);
+  rerender();
+
+  equalsElement(first, 'div', { id: 'first' }, ``);
+  equalsElement(second, 'div', { id: 'second' }, `<div id="stable-div">Yippie!</div>`);
+  element = second.querySelector(`#stable-div`);
+  assert.ok(element === cachedElement, 'Moving to new destination maintained integrity');
+});
+
 QUnit.test('inside an `{{if}}', function(assert) {
   let first = document.createElement('div');
   let second = document.createElement('div');
@@ -262,8 +324,7 @@ QUnit.test('inside an `{{if}}', function(assert) {
   equalsElement(first, 'div', {}, stripTight`[Yippie!]`);
   equalsElement(second, 'div', {}, stripTight``);
 });
-*/
-/*
+
 QUnit.test('multiple', function(assert) {
   let firstElement = document.createElement('div');
   let secondElement = document.createElement('div');
@@ -312,8 +373,7 @@ QUnit.test('multiple', function(assert) {
   equalsElement(firstElement, 'div', {}, stripTight`[Hello!]`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 });
-*/
-/*
+
 QUnit.test('nesting', function(assert) {
   let firstElement = document.createElement('div');
   let secondElement = document.createElement('div');
@@ -362,8 +422,7 @@ QUnit.test('nesting', function(assert) {
   equalsElement(firstElement, 'div', {}, stripTight`[Hello!]<!---->`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 });
-*/
-/*
+
 QUnit.test('components are destroyed', function(assert) {
   let destroyed = 0;
   let DestroyMeComponent = EmberishCurlyComponent.extend({
@@ -404,4 +463,3 @@ QUnit.test('components are destroyed', function(assert) {
   equalsElement(externalElement, 'div', {}, stripTight``);
   assert.equal(destroyed, 1, 'component was destroyed');
 });
-*/

--- a/packages/glimmer-runtime/tests/render-portal-test.ts
+++ b/packages/glimmer-runtime/tests/render-portal-test.ts
@@ -45,7 +45,7 @@ QUnit.test('basic', function(assert) {
   let externalElement = document.createElement('div');
 
   appendViewFor(
-    stripTight`{{#-in-element externalElement}}[{{foo}}]{{/-in-element}}`,
+    stripTight`{{#-render-portal externalElement}}[{{foo}}]{{/-render-portal}}`,
     { externalElement, foo: 'Yippie!' }
   );
 
@@ -69,43 +69,43 @@ QUnit.test('changing to falsey', function(assert) {
   appendViewFor(
     stripTight`
       |{{foo}}|
-      {{#-in-element first}}[{{foo}}]{{/-in-element}}
-      {{#-in-element second}}[{{foo}}]{{/-in-element}}
+      {{#-render-portal first}}[{{foo}}]{{/-render-portal}}
+      {{#-render-portal second}}[{{foo}}]{{/-render-portal}}
     `,
     { first, second: null, foo: 'Yippie!' }
   );
 
   equalsElement(first, 'div', {}, `[Yippie!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Yippie!|<!----><!---->');
+  assertAppended('|Yippie!|<!---->[Yippie!]');
 
   set(view, 'foo', 'Double Yips!');
   rerender();
 
   equalsElement(first, 'div', {}, `[Double Yips!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Double Yips!|<!----><!---->');
+  assertAppended('|Double Yips!|<!---->[Double Yips!]');
 
   set(view, 'first', null);
   rerender();
 
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Double Yips!|<!----><!---->');
+  assertAppended('|Double Yips!|[Double Yips!][Double Yips!]');
 
   set(view, 'second', second);
   rerender();
 
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, `[Double Yips!]`);
-  assertAppended('|Double Yips!|<!----><!---->');
+  assertAppended('|Double Yips!|[Double Yips!]<!---->');
 
   set(view, 'foo', 'Yippie!');
   rerender();
 
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, `[Yippie!]`);
-  assertAppended('|Yippie!|<!----><!---->');
+  assertAppended('|Yippie!|[Yippie!]<!---->');
 
   set(view, 'first', first);
   set(view, 'second', null);
@@ -113,15 +113,15 @@ QUnit.test('changing to falsey', function(assert) {
 
   equalsElement(first, 'div', {}, `[Yippie!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Yippie!|<!----><!---->');
+  assertAppended('|Yippie!|<!---->[Yippie!]');
 });
-
+/*
 QUnit.test('with pre-existing content', function(assert) {
   let externalElement = document.createElement('div');
   let initialContent = externalElement.innerHTML = '<p>Hello there!</p>';
 
   appendViewFor(
-    stripTight`{{#-in-element externalElement}}[{{foo}}]{{/-in-element}}`,
+    stripTight`{{#-render-portal externalElement}}[{{foo}}]{{/-render-portal}}`,
     { externalElement, foo: 'Yippie!' }
   );
 
@@ -152,13 +152,14 @@ QUnit.test('with pre-existing content', function(assert) {
   assertAppended('<!---->');
   equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie!]`);
 });
-
+*/
+/*
 QUnit.test('updating remote element', function(assert) {
   let first = document.createElement('div');
   let second = document.createElement('div');
 
   appendViewFor(
-    stripTight`{{#-in-element targetElement}}[{{foo}}]{{/-in-element}}`,
+    stripTight`{{#-render-portal targetElement}}[{{foo}}]{{/-render-portal}}`,
     {
       targetElement: first,
       foo: 'Yippie!'
@@ -198,7 +199,8 @@ QUnit.test('updating remote element', function(assert) {
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, `[Yippie!]`);
 });
-
+*/
+/*
 QUnit.test('inside an `{{if}}', function(assert) {
   let first = document.createElement('div');
   let second = document.createElement('div');
@@ -206,10 +208,10 @@ QUnit.test('inside an `{{if}}', function(assert) {
   appendViewFor(
     stripTight`
       {{#if showFirst}}
-        {{#-in-element first}}[{{foo}}]{{/-in-element}}
+        {{#-render-portal first}}[{{foo}}]{{/-render-portal}}
       {{/if}}
       {{#if showSecond}}
-        {{#-in-element second}}[{{foo}}]{{/-in-element}}
+        {{#-render-portal second}}[{{foo}}]{{/-render-portal}}
       {{/if}}
     `,
     {
@@ -260,19 +262,20 @@ QUnit.test('inside an `{{if}}', function(assert) {
   equalsElement(first, 'div', {}, stripTight`[Yippie!]`);
   equalsElement(second, 'div', {}, stripTight``);
 });
-
+*/
+/*
 QUnit.test('multiple', function(assert) {
   let firstElement = document.createElement('div');
   let secondElement = document.createElement('div');
 
   appendViewFor(
     stripTight`
-      {{#-in-element firstElement}}
+      {{#-render-portal firstElement}}
         [{{foo}}]
-      {{/-in-element}}
-      {{#-in-element secondElement}}
+      {{/-render-portal}}
+      {{#-render-portal secondElement}}
         [{{bar}}]
-      {{/-in-element}}
+      {{/-render-portal}}
       `,
     {
       firstElement,
@@ -309,19 +312,20 @@ QUnit.test('multiple', function(assert) {
   equalsElement(firstElement, 'div', {}, stripTight`[Hello!]`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 });
-
+*/
+/*
 QUnit.test('nesting', function(assert) {
   let firstElement = document.createElement('div');
   let secondElement = document.createElement('div');
 
   appendViewFor(
     stripTight`
-      {{#-in-element firstElement}}
+      {{#-render-portal firstElement}}
         [{{foo}}]
-        {{#-in-element secondElement}}
+        {{#-render-portal secondElement}}
           [{{bar}}]
-        {{/-in-element}}
-      {{/-in-element}}
+        {{/-render-portal}}
+      {{/-render-portal}}
       `,
     {
       firstElement,
@@ -358,7 +362,8 @@ QUnit.test('nesting', function(assert) {
   equalsElement(firstElement, 'div', {}, stripTight`[Hello!]<!---->`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 });
-
+*/
+/*
 QUnit.test('components are destroyed', function(assert) {
   let destroyed = 0;
   let DestroyMeComponent = EmberishCurlyComponent.extend({
@@ -375,7 +380,7 @@ QUnit.test('components are destroyed', function(assert) {
   appendViewFor(
     stripTight`
       {{#if showExternal}}
-        {{#-in-element externalElement}}[{{destroy-me}}]{{/-in-element}}
+        {{#-render-portal externalElement}}[{{destroy-me}}]{{/-render-portal}}
       {{/if}}
     `,
     {
@@ -399,3 +404,4 @@ QUnit.test('components are destroyed', function(assert) {
   equalsElement(externalElement, 'div', {}, stripTight``);
   assert.equal(destroyed, 1, 'component was destroyed');
 });
+*/

--- a/packages/glimmer-runtime/tests/render-portal-test.ts
+++ b/packages/glimmer-runtime/tests/render-portal-test.ts
@@ -232,7 +232,7 @@ QUnit.test('changing targets maintains referential integrity', function(assert) 
 
   function getViewElementById(id) {
     if (view.element) {
-      let viewElement = view.element.matches('#stable-div') ? view.element
+      let viewElement = view.element.id === 'stable-div' ? view.element
         : view.element.querySelector(`${id}`);
 
       if (viewElement) {

--- a/packages/glimmer-runtime/tests/render-portal-test.ts
+++ b/packages/glimmer-runtime/tests/render-portal-test.ts
@@ -35,7 +35,7 @@ function appendViewFor(template: string, context: Object = {}) {
   return view;
 }
 
-QUnit.module('Targeting a remote element', {
+QUnit.module('Render Portal', {
   setup() {
     env = new TestEnvironment();
   }
@@ -50,16 +50,29 @@ QUnit.test('basic', function(assert) {
   );
 
   equalsElement(externalElement, 'div', {}, stripTight`[Yippie!]`);
+  assertAppended('<!--portal-->');
 
   set(view, 'foo', 'Double Yips!');
   rerender();
 
   equalsElement(externalElement, 'div', {}, stripTight`[Double Yips!]`);
+  assertAppended('<!--portal-->');
 
   set(view, 'foo', 'Yippie!');
   rerender();
 
   equalsElement(externalElement, 'div', {}, stripTight`[Yippie!]`);
+  assertAppended('<!--portal-->');
+});
+
+QUnit.test('initialized falsey', function(assert) {
+
+  appendViewFor(
+    stripTight`{{#-render-portal externalElement}}[{{foo}}]{{/-render-portal}}`,
+    { externalElement: null, foo: 'Yippie!' }
+  );
+
+  assertAppended('<!--portal-->[Yippie!]');
 });
 
 QUnit.test('changing to falsey', function(assert) {
@@ -77,7 +90,7 @@ QUnit.test('changing to falsey', function(assert) {
 
   equalsElement(first, 'div', {}, `[Yippie 1!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Yippie 1!|<!---->[Bar 1!]');
+  assertAppended('|Yippie 1!|<!--portal--><!--portal-->[Bar 1!]');
 
   set(view, 'foo', 'Double Yips 1!');
   set(view, 'bar', 'Bar 2!');
@@ -85,7 +98,7 @@ QUnit.test('changing to falsey', function(assert) {
 
   equalsElement(first, 'div', {}, `[Double Yips 1!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Double Yips 1!|<!---->[Bar 2!]');
+  assertAppended('|Double Yips 1!|<!--portal--><!--portal-->[Bar 2!]');
 
   set(view, 'foo', 'Double Yips 2!');
   set(view, 'bar', 'Bar 3!');
@@ -94,7 +107,7 @@ QUnit.test('changing to falsey', function(assert) {
 
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Double Yips 2!|[Double Yips 2!][Bar 3!]');
+  assertAppended('|Double Yips 2!|<!--portal-->[Double Yips 2!]<!--portal-->[Bar 3!]');
 
   set(view, 'foo', 'Double Yips 3!');
   set(view, 'bar', 'Bar 4!');
@@ -103,7 +116,7 @@ QUnit.test('changing to falsey', function(assert) {
 
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, `[Bar 4!]`);
-  assertAppended('|Double Yips 3!|[Double Yips 3!]<!---->');
+  assertAppended('|Double Yips 3!|<!--portal-->[Double Yips 3!]<!--portal-->');
 
   set(view, 'foo', 'Yippie 2!');
   set(view, 'bar', 'Bar 5!');
@@ -111,7 +124,7 @@ QUnit.test('changing to falsey', function(assert) {
 
   equalsElement(first, 'div', {}, ``);
   equalsElement(second, 'div', {}, `[Bar 5!]`);
-  assertAppended('|Yippie 2!|[Yippie 2!]<!---->');
+  assertAppended('|Yippie 2!|<!--portal-->[Yippie 2!]<!--portal-->');
 
   set(view, 'foo', 'Yippie 3!');
   set(view, 'bar', 'Bar 6!');
@@ -121,7 +134,7 @@ QUnit.test('changing to falsey', function(assert) {
 
   equalsElement(first, 'div', {}, `[Yippie 3!]`);
   equalsElement(second, 'div', {}, ``);
-  assertAppended('|Yippie 3!|<!---->[Bar 6!]');
+  assertAppended('|Yippie 3!|<!--portal--><!--portal-->[Bar 6!]');
 });
 
 QUnit.test('with pre-existing content', function(assert) {
@@ -133,33 +146,33 @@ QUnit.test('with pre-existing content', function(assert) {
     { externalElement, foo: 'Yippie 1!' }
   );
 
-  assertAppended('<!---->');
+  assertAppended('<!--portal-->');
   equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie 1!]`);
 
   set(view, 'foo', 'Double Yips 1!');
   rerender();
 
-  assertAppended('<!---->');
+  assertAppended('<!--portal-->');
   equalsElement(externalElement, 'div', {}, `${initialContent}[Double Yips 1!]`);
 
   set(view, 'foo', 'Yippie 2!');
   rerender();
 
-  assertAppended('<!---->');
+  assertAppended('<!--portal-->');
   equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie 2!]`);
 
   set(view, 'foo', 'Yippie 3!');
   set(view, 'externalElement', null);
   rerender();
 
-  assertAppended('[Yippie 3!]');
+  assertAppended('<!--portal-->[Yippie 3!]');
   equalsElement(externalElement, 'div', {}, `${initialContent}`);
 
   set(view, 'foo', 'Yippie 4!');
   set(view, 'externalElement', externalElement);
   rerender();
 
-  assertAppended('<!---->');
+  assertAppended('<!--portal-->');
   equalsElement(externalElement, 'div', {}, `${initialContent}[Yippie 4!]`);
 });
 
@@ -240,7 +253,7 @@ QUnit.test('changing targets maintains referential integrity', function(assert) 
     }
   );
 
-  assertAppended('<div id="stable-div">Yippie!</div>');
+  assertAppended('<!--portal--><div id="stable-div">Yippie!</div>');
   equalsElement(first, 'div', { id: 'first' }, ``);
   equalsElement(second, 'div', { id: 'second' }, ``);
   cachedElement = getViewElementById('stable-div');
@@ -248,7 +261,7 @@ QUnit.test('changing targets maintains referential integrity', function(assert) 
   set(view, 'element', first);
   rerender();
 
-  assertAppended('<!---->');
+  assertAppended('<!--portal-->');
   equalsElement(first, 'div', { id: 'first' }, `<div id="stable-div">Yippie!</div>`);
   equalsElement(second, 'div', { id: 'second' }, ``);
   element = first.querySelector(`#stable-div`);
@@ -260,7 +273,7 @@ QUnit.test('changing targets maintains referential integrity', function(assert) 
   equalsElement(first, 'div', { id: 'first' }, ``);
   equalsElement(second, 'div', { id: 'second' }, `<div id="stable-div">Yippie!</div>`);
   element = second.querySelector(`#stable-div`);
-  assert.ok(element === cachedElement, 'Moving to new destination maintained integrity');
+  assert.equal(element, cachedElement, 'Moving to new destination maintained integrity');
 });
 
 QUnit.test('inside an `{{if}}', function(assert) {
@@ -395,31 +408,31 @@ QUnit.test('nesting', function(assert) {
     }
   );
 
-  equalsElement(firstElement, 'div', {}, stripTight`[Hello!]<!---->`);
+  equalsElement(firstElement, 'div', {}, stripTight`[Hello!]<!--portal-->`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 
   set(view, 'foo', 'GoodBye!');
   rerender();
 
-  equalsElement(firstElement, 'div', {}, stripTight`[GoodBye!]<!---->`);
+  equalsElement(firstElement, 'div', {}, stripTight`[GoodBye!]<!--portal-->`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 
   set(view, 'bar', 'Folks!');
   rerender();
 
-  equalsElement(firstElement, 'div', {}, stripTight`[GoodBye!]<!---->`);
+  equalsElement(firstElement, 'div', {}, stripTight`[GoodBye!]<!--portal-->`);
   equalsElement(secondElement, 'div', {}, stripTight`[Folks!]`);
 
   set(view, 'bar', 'World!');
   rerender();
 
-  equalsElement(firstElement, 'div', {}, stripTight`[GoodBye!]<!---->`);
+  equalsElement(firstElement, 'div', {}, stripTight`[GoodBye!]<!--portal-->`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 
   set(view, 'foo', 'Hello!');
   rerender();
 
-  equalsElement(firstElement, 'div', {}, stripTight`[Hello!]<!---->`);
+  equalsElement(firstElement, 'div', {}, stripTight`[Hello!]<!--portal-->`);
   equalsElement(secondElement, 'div', {}, stripTight`[World!]`);
 });
 

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -42,7 +42,7 @@ import {
   ArgsSyntax,
   OptimizedAppend,
   WithDynamicVarsSyntax,
-  InElementSyntax,
+  RenderPortalSyntax,
 
   // References
   ValueReference,
@@ -797,6 +797,8 @@ export class TestEnvironment extends Environment {
           return new WithDynamicVarsSyntax({ args, templates });
         case '-in-element':
           return new InElementSyntax({ args, templates });
+        case '-render-portal':
+          return new RenderPortalSyntax({ args, templates });
       }
     }
 

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,6 @@
     "no-consecutive-blank-lines": true,
     "no-construct": true,
     "no-debugger": true,
-    "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-inferrable-types": true,
     "no-trailing-whitespace": true,


### PR DESCRIPTION
The `in-element` API provided by @rwjblue in #331 was insufficient to support ember-wormhole and flexi.  I have not yet done work to see if this PR will fix flexi, but it does fix wormhole and I'm reasonably confident it at least gets us closer to supporting that library.

**in-element deficiencies**
- no support for renderInPlace
- no ability to move the DOM from one remote target to another remote target or from a remote target to in-place.

**naming**

The wormhole concept has often been referred to as a "portal" or "portal-ing" in other frameworks and in talks.  I'm also particularly partial to the game Portal.
