### PR TITLE
[glimmer-syntax] add a `chained` argument to program builder since we expect …

### DIFF
--- a/packages/glimmer-syntax/lib/builders.ts
+++ b/packages/glimmer-syntax/lib/builders.ts
@@ -191,11 +191,12 @@ function buildPair(key, value) {
   };
 }
 
-function buildProgram(body?, blockParams?, loc?) {
+function buildProgram(body?, blockParams?, chained?, loc?) {
   return {
     type: "Program",
     body: body || [],
     blockParams: blockParams || [],
+    chained: chained || false,
     loc: buildLoc(loc)
   };
 }

--- a/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
@@ -5,7 +5,7 @@ export default {
 
   Program: function(program) {
     let body = [];
-    let node = b.program(body, program.blockParams, program.loc);
+    let node = b.program(body, program.blockParams, program.chained, program.loc);
     let i, l = program.body.length;
 
     this.elementStack.push(node);


### PR DESCRIPTION
…it in the actual handlebars AST. Change only required altering args list in a single invocation since the builder is currently almost always invoked with only the first argument by tests.