### PR TITLE
Preserve original comment style when available

### DIFF
--- a/packages/@glimmer/syntax/tests/generation/print-test.ts
+++ b/packages/@glimmer/syntax/tests/generation/print-test.ts
@@ -1,7 +1,7 @@
 import { preprocess as parse, print, builders as b } from "@glimmer/syntax";
 
 function printTransform(template) {
-  return print(parse(template));
+  return print(parse(template), template);
 }
 
 function printEqual(template) {
@@ -98,7 +98,8 @@ test('HTML comment', function() {
 });
 
 test('Handlebars comment', function() {
-  equal(printTransform('{{! foo }}'), '{{!-- foo --}}');
+  printEqual('{{! foo }}');
+  printEqual('{{!-- foo --}}');
 });
 
 test('Handlebars comment: in ElementNode', function() {


### PR DESCRIPTION
Addresses @rwjblue's [comment](https://github.com/tildeio/glimmer/pull/382#discussion_r95986330) in #382.

This PR is a bit gnarly because I had to string the `source` through each function. We should rewrite these functions as a methods on a class [like these guys](https://github.com/tildeio/glimmer/blob/master/packages/@glimmer/syntax/lib/parser.ts#L62-L101).