### PR TITLE
[BUGFIX beta] Fix range element reporting wrong initial value

### DIFF
--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -71,8 +71,18 @@ export default class TemplateCompiler<T extends TemplateMeta> {
 
   openElement([action]) {
     this.opcode('openElement', action, action.tag, action.blockParams);
+    let typeAttr = null;
     for (let i = 0; i < action.attributes.length; i++) {
-      this.attribute([action.attributes[i]]);
+      let attr = action.attributes[i];
+      if (attr.name.toLowerCase() === 'type') {
+        typeAttr = attr;
+        continue;
+      }
+      this.attribute([attr]);
+    }
+
+    if (typeAttr) {
+      this.attribute([typeAttr]);
     }
 
     for (let i = 0; i < action.modifiers.length; i++) {

--- a/packages/@glimmer/runtime/tests/attributes-test.ts
+++ b/packages/@glimmer/runtime/tests/attributes-test.ts
@@ -121,6 +121,26 @@ test("disable updates properly", () => {
   equalTokens(root, '<input disabled />');
 });
 
+[
+  ['<input type="range" max="10" />', '5'],
+  ['<input max="10" type="range" />', '5'],
+  ['<input min="90" type="range" />', '95'],
+  ['<input type="range" min="90" />', '95'],
+  ['<input min="30" max="50" type="range" />', '40'],
+  ['<input type="range" min="30" max="50" />', '40'],
+  ['<input max="50" min="30" type="range" />', '40'],
+  ['<input type="range" max="50" min="30" />', '40'],
+  ['<input type="range" max="50" min="30" value="43" />', '43'],
+].forEach(([input, expectedValue]) => {
+  test(`input ${input} works`, () => {
+    let template = compile(input);
+
+    render(template);
+
+    strictEqual(root.children[0].value, expectedValue);
+  });
+});
+
 test("quoted disable is always disabled", () => {
   let template = compile('<input disabled="{{enabled}}" />');
 


### PR DESCRIPTION
If a template had an `input` `range` whose type was set before a max or a min
attribute was added, the initial value would be wrong.

In plain HTML, the initial value for `<input max="10" type="range" />` would be
`5` (`(min + max) / 2 = (0 + 10) / 2 = 5`).

In Glimmer, this would be 10 because the code would be equivalent to:

```js
let input = document.createElement('input');
input.type = "range";
input.max = "10";
```

Setting `type` to `range` would make the value sanitization algorihtm to kick
in, setting the value to 50. When setting the `max` to `10`, the algorithm
would sanitize the value (50 by now) to the maximum (10).

More info in whatwg/html#2427
Fixes emberjs/ember.js#14958