### PR TITLE
More static runtime expectations

### DIFF
--- a/packages/@glimmer/runtime/lib/builder.ts
+++ b/packages/@glimmer/runtime/lib/builder.ts
@@ -8,6 +8,8 @@ import { Environment } from './environment';
 
 import { VM } from './vm';
 
+import { DEBUG } from '@glimmer/env-flags';
+
 import { VersionedReference } from '@glimmer/reference';
 
 import {
@@ -112,14 +114,6 @@ export class ElementStack implements Cursor {
     this.pushSimpleBlock();
     this.elementStack.push(this.element);
     this.nextSiblingStack.push(this.nextSibling);
-  }
-
-  expectConstructing(method: string): Simple.Element {
-    return expect(this.constructing, `${method} should only be called while constructing an element`);
-  }
-
-  expectOperations(method: string): ElementOperations {
-    return expect(this.operations, `${method} should only be called while constructing an element`);
   }
 
   block(): Tracker {
@@ -254,19 +248,36 @@ export class ElementStack implements Cursor {
   }
 
   setStaticAttribute(name: string, value: string) {
-    this.expectOperations('setStaticAttribute').addStaticAttribute(this.expectConstructing('setStaticAttribute'), name, value);
+    if (DEBUG) {
+      expect(this.operations, 'setStaticAttribute should only be called while constructing an element');
+      expect(this.constructing, 'setStaticAttribute should only be called while constructing an element');
+    }
+    this.operations!.addStaticAttribute(this.constructing!, name, value);
   }
 
   setStaticAttributeNS(namespace: string, name: string, value: string) {
-    this.expectOperations('setStaticAttributeNS').addStaticAttributeNS(this.expectConstructing('setStaticAttributeNS'), namespace, name, value);
+    if (DEBUG) {
+      expect(this.operations, 'setStaticAttributeNS should only be called while constructing an element');
+      expect(this.constructing, 'setStaticAttributeNS should only be called while constructing an element');
+    }
+    this.operations!.addStaticAttributeNS(this.constructing!, namespace, name, value);
   }
 
   setDynamicAttribute(name: string, reference: VersionedReference<string>, isTrusting: boolean) {
-    this.expectOperations('setDynamicAttribute').addDynamicAttribute(this.expectConstructing('setDynamicAttribute'), name, reference, isTrusting);
+    if (DEBUG) {
+      expect(this.operations, 'setDynamicAttribute should only be called while constructing an element');
+      expect(this.constructing, 'setDynamicAttribute should only be called while constructing an element');
+    }
+    this.operations!.addDynamicAttribute(this.constructing!, name, reference, isTrusting);
   }
 
   setDynamicAttributeNS(namespace: string, name: string, reference: VersionedReference<string>, isTrusting: boolean) {
-    this.expectOperations('setDynamicAttributeNS').addDynamicAttributeNS(this.expectConstructing('setDynamicAttributeNS'), namespace, name, reference, isTrusting);
+    if (DEBUG) {
+      expect(this.operations, 'setDynamicAttributeNS should only be called while constructing an element');
+      expect(this.constructing, 'setDynamicAttributeNS should only be called while constructing an element');
+    }
+
+    this.operations!.addDynamicAttributeNS(this.constructing!, namespace, name, reference, isTrusting);
   }
 
   closeElement() {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -15,6 +15,8 @@ import {
   combine,
   isConst
 } from '@glimmer/reference';
+import { DEBUG } from '@glimmer/env-flags';
+import { expect } from '@glimmer/util';
 
 APPEND_OPCODES.add(Op.PushComponentManager, (vm, { op1: _definition }) => {
   let definition = vm.constants.getOther<ComponentDefinition<Opaque>>(_definition);
@@ -130,8 +132,13 @@ APPEND_OPCODES.add(Op.PushComponentOperations, vm => {
 APPEND_OPCODES.add(Op.DidCreateElement, (vm, { op1: _state }) => {
   let { manager, component } = vm.fetchValue<ComponentState<Opaque>>(_state);
 
-  let action = 'DidCreateElementOpcode#evaluate';
-  manager.didCreateElement(component, vm.elements().expectConstructing(action), vm.elements().expectOperations(action));
+  if (DEBUG) {
+    let msg = 'DidCreateElementOpcode#evaluate should only be called while constructing an element';
+    expect(vm.elements().constructing, msg);
+    expect(vm.elements().operations, msg);
+  }
+
+  manager.didCreateElement(component, vm.elements().constructing!, vm.elements().operations!);
 });
 
 APPEND_OPCODES.add(Op.GetComponentSelf, (vm, { op1: _state }) => {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -23,6 +23,7 @@ import { AttributeManager } from '../../dom/attribute-managers';
 import { ElementOperations } from '../../builder';
 import { Assert } from './vm';
 import { APPEND_OPCODES, Op as Op } from '../../opcodes';
+import { DEBUG } from '@glimmer/env-flags';
 
 APPEND_OPCODES.add(Op.Text, (vm, { op1: text }) => {
   vm.elements().appendText(vm.constants.getString(text));
@@ -306,8 +307,12 @@ export class ComponentElementOperations implements ElementOperations {
 APPEND_OPCODES.add(Op.FlushElement, vm => {
   let stack = vm.elements();
 
-  let action = 'FlushElementOpcode#evaluate';
-  stack.expectOperations(action).flush(stack.expectConstructing(action), vm);
+  if (DEBUG) {
+    let msg = 'FlushElementOpcode#evaluate should only be called while constructing an element';
+    expect(stack.operations, msg);
+    expect(stack.constructing, msg);
+  }
+  stack.operations!.flush(stack.constructing!, vm);
   stack.flushElement();
 });
 


### PR DESCRIPTION
By being more verbose for dev mode we can more easily strip code for
production builds.