### PR TITLE
Revert "Remove unused WF opcode (it's now MaybeLocal)"

### DIFF
--- a/packages/@glimmer/wire-format/lib/opcodes.ts
+++ b/packages/@glimmer/wire-format/lib/opcodes.ts
@@ -25,6 +25,7 @@ export enum Opcodes {
   Unknown,
   Get,
   MaybeLocal,
+  FixThisBeforeWeMerge,
   HasBlock,
   HasBlockParams,
   Undefined,


### PR DESCRIPTION
This reverts commit 2d561e9ba741feb93402dce62398c4f91e28d248.

Prior to this a standard "hello glimmer" app would fail with the following error:

```
Uncaught TypeError: parts.forEach is not a function
```

@chadhietala bisected the failure down to this commit, and we suspect that the issue is caused by the hard coding of some of the opcode id's (and removing an opcode shifted the numbers by 1).  We will investigate further, but getting master into a "less broken" state is the higher priority.