### PR TITLE
Unify dom

### DIFF
--- a/packages/@glimmer/runtime/lib/compat/inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/inner-html-fix.ts
@@ -61,19 +61,19 @@ export function treeConstruction(document: Option<Document>, DOMTreeConstruction
   let div = document.createElement('div');
 
   return class DOMTreeConstructionWithInnerHTMLFix extends DOMTreeConstructionClass {
-    insertHTMLBefore(parent: HTMLElement, html: string, reference: Node): Bounds {
+    insertHTMLBefore(parent: HTMLElement, referenceNode: Node, html: string): Bounds {
       if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, html, reference);
+        return super.insertHTMLBefore(parent, referenceNode, html);
       }
 
       let parentTag = parent.tagName.toLowerCase();
       let wrapper = innerHTMLWrapper[parentTag];
 
       if(wrapper === undefined) {
-        return super.insertHTMLBefore(parent, html, reference);
+        return super.insertHTMLBefore(parent, referenceNode, html);
       }
 
-      return fixInnerHTML(parent, wrapper, div, html, reference);
+      return fixInnerHTML(parent, wrapper, div, html, referenceNode);
     }
   };
 }

--- a/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
@@ -50,13 +50,13 @@ export function treeConstruction(document: Option<Document>, TreeConstructionCla
   let div = document.createElement('div');
 
   return class TreeConstructionWithSVGInnerHTMLFix extends TreeConstructionClass {
-    insertHTMLBefore(parent: HTMLElement, html: string,  reference: Node,): Bounds {
+    insertHTMLBefore(parent: HTMLElement, reference: Node, html: string): Bounds {
       if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, html, reference);
+        return super.insertHTMLBefore(parent, reference, html);
       }
 
       if (parent.namespaceURI !== svgNamespace) {
-        return super.insertHTMLBefore(parent, html, reference);
+        return super.insertHTMLBefore(parent, reference, html);
       }
 
       return fixSVG(parent, div, html, reference);

--- a/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
@@ -68,9 +68,9 @@ export function treeConstruction(document: Option<Document>, TreeConstructionCla
       this.uselessComment = this.createComment('') as Comment;
     }
 
-    insertHTMLBefore(parent: HTMLElement, html: string, reference: Node): Bounds {
+    insertHTMLBefore(parent: HTMLElement, reference: Node, html: string): Bounds {
       if (html === null) {
-        return super.insertHTMLBefore(parent, html, reference);
+        return super.insertHTMLBefore(parent, reference, html);
       }
 
       let didSetUselessComment = false;
@@ -81,7 +81,7 @@ export function treeConstruction(document: Option<Document>, TreeConstructionCla
         parent.insertBefore(this.uselessComment, reference);
       }
 
-      let bounds = super.insertHTMLBefore(parent, html, reference);
+      let bounds = super.insertHTMLBefore(parent, reference, html);
 
       if (didSetUselessComment) {
         parent.removeChild(this.uselessComment);

--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -46,7 +46,7 @@ export function isWhitespace(string: string) {
 
 export function moveNodesBefore(source: Simple.Node, target: Simple.Element, nextSibling: Simple.Node) {
   let first = source.firstChild;
-  let last: Option<Simple.Node> = null;
+  let last: Simple.Node | null = null;
   let current = first;
   while (current) {
     last = current;
@@ -63,8 +63,8 @@ export class DOMOperations {
     this.uselessElement = this.document.createElement('div');
   }
 
-  createElement(tag: string, context?: Element): Element {
-    let isElementInSVGNamespace, isHTMLIntegrationPoint;
+  createElement(tag: string, context?: Simple.Element): Simple.Element {
+    let isElementInSVGNamespace: boolean, isHTMLIntegrationPoint: boolean;
 
     if (context) {
       isElementInSVGNamespace = context.namespaceURI === SVG_NAMESPACE || tag === 'svg';
@@ -82,7 +82,7 @@ export class DOMOperations {
         throw new Error(`Cannot create a ${tag} inside an SVG context`);
       }
 
-      return this.document.createElementNS(SVG_NAMESPACE as Namespace, tag);
+      return this.document.createElementNS(SVG_NAMESPACE, tag);
     } else {
       return this.document.createElement(tag);
     }
@@ -90,6 +90,10 @@ export class DOMOperations {
 
   insertBefore(parent: Element, node: Node, reference: Option<Node>) {
     parent.insertBefore(node, reference);
+  }
+
+  insertHTMLBefore(_parent: Element, nextSibling: Node, html: string): Bounds {
+    return insertHTMLBefore(this.uselessElement, _parent, nextSibling, html);
   }
 
   createTextNode(text: string): Text {
@@ -121,10 +125,6 @@ export namespace DOM {
       } else {
         element.setAttribute(name, value);
       }
-    }
-
-    insertHTMLBefore(parent: Element, html: string, reference: Option<Node>): Bounds {
-      return insertHTMLBefore(this.uselessElement, parent, reference, html);
     }
   }
 
@@ -159,10 +159,6 @@ export class DOMChanges extends DOMOperations {
 
   removeAttributeNS(element: Simple.Element, namespace: string, name: string) {
     element.removeAttributeNS(namespace, name);
-  }
-
-  insertHTMLBefore(_parent: Element, nextSibling: Node, html: string): Bounds {
-    return insertHTMLBefore(this.uselessElement, _parent, nextSibling, html);
   }
 
   insertNodeBefore(parent: Simple.Element, node: Simple.Node, reference: Simple.Node): Bounds {
@@ -201,7 +197,7 @@ export function insertHTMLBefore(this: void, _useless: Simple.HTMLElement, _pare
   let nextSibling = _nextSibling as Node;
 
   let prev = nextSibling ? nextSibling.previousSibling : parent.lastChild;
-  let last: Node | null;
+  let last: Node;
 
   if (html === null || html === '') {
     return new ConcreteBounds(parent, null, null);

--- a/packages/@glimmer/runtime/lib/upsert.ts
+++ b/packages/@glimmer/runtime/lib/upsert.ts
@@ -61,7 +61,7 @@ export function trustingInsert(dom: DOMTreeConstruction, cursor: Cursor, value: 
 class TextUpsert extends Upsert {
   static insert(dom: DOMTreeConstruction, cursor: Cursor, value: string): Upsert {
     let textNode = dom.createTextNode(value);
-    dom.insertBefore(cursor.element, textNode, cursor.nextSibling);
+    dom.insertBefore(cursor.element as Element, textNode, cursor.nextSibling as Node);
     let bounds = new SingleNodeBounds(cursor.element, textNode);
     return new TextUpsert(bounds, textNode);
   }
@@ -86,7 +86,7 @@ class TextUpsert extends Upsert {
 
 class HTMLUpsert extends Upsert {
   static insert(dom: DOMTreeConstruction, cursor: Cursor, value: string): Upsert {
-    let bounds = dom.insertHTMLBefore(cursor.element, value, cursor.nextSibling);
+    let bounds = dom.insertHTMLBefore(cursor.element as Element, cursor.nextSibling as Node, value);
     return new HTMLUpsert(bounds);
   }
 
@@ -109,7 +109,7 @@ class HTMLUpsert extends Upsert {
 class SafeStringUpsert extends Upsert {
   static insert(dom: DOMTreeConstruction, cursor: Cursor, value: SafeString): Upsert {
     let stringValue = value.toHTML();
-    let bounds = dom.insertHTMLBefore(cursor.element, stringValue, cursor.nextSibling);
+    let bounds = dom.insertHTMLBefore(cursor.element as Element, cursor.nextSibling as Node, stringValue);
     return new SafeStringUpsert(bounds, stringValue);
   }
 
@@ -140,7 +140,7 @@ class SafeStringUpsert extends Upsert {
 
 class NodeUpsert extends Upsert {
   static insert(dom: DOMTreeConstruction, cursor: Cursor, node: Simple.Node): Upsert {
-    dom.insertBefore(cursor.element, node, cursor.nextSibling);
+    dom.insertBefore(cursor.element as Element, node as Node, cursor.nextSibling as Node);
     return new NodeUpsert(single(cursor.element, node));
   }
 


### PR DESCRIPTION
Closes #471. This drys up majority of the duplication in the DOM construction and updating. This leaves us with 2 classes specifically for the constructing and updating but share a `DOMOperations` super class.