### PR TITLE
More type fixes

### DIFF
--- a/packages/@glimmer/compiler/lib/template-visitor.ts
+++ b/packages/@glimmer/compiler/lib/template-visitor.ts
@@ -223,7 +223,7 @@ export default class TemplateVisitor {
       program['symbols'] = parentFrame.symbols!.child(program.blockParams);
     }
 
-    let startType, endType;
+    let startType: string, endType: string;
 
     if (this.programDepth === 0) {
       startType = 'startProgram';

--- a/packages/@glimmer/object/lib/computed.ts
+++ b/packages/@glimmer/object/lib/computed.ts
@@ -96,7 +96,7 @@ function wrapAccessor(home: Object, accessorName: string, _desc: ComputedDescrip
   let set = _desc.set;
 
   if (set && set.length > 1) {
-    originalSet = function(this: any, value) {
+    originalSet = function(this: any, value: any) {
       return (set as any).call(this, accessorName, value);
     };
   } else {

--- a/packages/@glimmer/object/lib/object.ts
+++ b/packages/@glimmer/object/lib/object.ts
@@ -138,8 +138,8 @@ export class ClassMeta {
   }
 
   static applyAllMixins(Subclass: GlimmerObjectFactory<any>, Parent: GlimmerObjectFactory<any>) {
-    Subclass[CLASS_META].getMixins().forEach(m => m.extendPrototypeOnto(Subclass, Parent));
-    Subclass[CLASS_META].getStaticMixins().forEach(m => m.extendStatic(Subclass));
+    Subclass[CLASS_META].getMixins().forEach((m: Mixin) => m.extendPrototypeOnto(Subclass, Parent));
+    Subclass[CLASS_META].getStaticMixins().forEach((m: Mixin) => m.extendStatic(Subclass));
     Subclass[CLASS_META].seal();
   }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -98,7 +98,7 @@ APPEND_OPCODES.add(Op.PrepareArgs, (vm, { op1: _state }) => {
 });
 
 APPEND_OPCODES.add(Op.CreateComponent, (vm, { op1: flags, op2: _state }) => {
-  let definition, manager;
+  let definition: ComponentDefinition<Opaque>, manager: ComponentManager<Opaque>;
   let args = vm.stack.pop<IArguments>();
   let dynamicScope = vm.dynamicScope();
   let state = { definition, manager } = vm.fetchValue<InitialComponentState<Opaque>>(_state);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -188,7 +188,7 @@ export class Assert extends UpdatingOpcode {
   toJSON(): OpcodeJSON {
     let { type, _guid, cache } = this;
 
-    let expected;
+    let expected: string;
 
     try {
       expected = JSON.stringify(cache.peek());

--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -46,7 +46,7 @@ export function isWhitespace(string: string) {
 
 export function moveNodesBefore(source: Simple.Node, target: Simple.Element, nextSibling: Simple.Node) {
   let first = source.firstChild;
-  let last = null;
+  let last: Option<Simple.Node> = null;
   let current = first;
   while (current) {
     last = current;
@@ -76,7 +76,7 @@ export namespace DOM {
     }
 
     createElement(tag: string, context?: Element): Element {
-      let isElementInSVGNamespace, isHTMLIntegrationPoint;
+      let isElementInSVGNamespace: boolean, isHTMLIntegrationPoint: boolean;
 
       if (context) {
         isElementInSVGNamespace = context.namespaceURI === SVG_NAMESPACE || tag === 'svg';
@@ -172,7 +172,7 @@ export class DOMChanges {
   }
 
   createElement(tag: string, context?: Simple.Element): Simple.Element {
-    let isElementInSVGNamespace, isHTMLIntegrationPoint;
+    let isElementInSVGNamespace: boolean, isHTMLIntegrationPoint: boolean;
 
     if (context) {
       isElementInSVGNamespace = context.namespaceURI === SVG_NAMESPACE || tag === 'svg';
@@ -236,7 +236,7 @@ export function insertHTMLBefore(this: void, _useless: Simple.HTMLElement, _pare
   let nextSibling = _nextSibling as Node;
 
   let prev = nextSibling ? nextSibling.previousSibling : parent.lastChild;
-  let last;
+  let last: Node;
 
   if (html === null || html === '') {
     return new ConcreteBounds(parent, null, null);

--- a/packages/@glimmer/runtime/lib/scanner.ts
+++ b/packages/@glimmer/runtime/lib/scanner.ts
@@ -105,7 +105,7 @@ export default class Scanner {
   scanEntryPoint(meta: CompilationMeta): Program {
     let { block, env } = this;
 
-    let statements;
+    let statements: WireFormat.Statement[];
     if (block.prelude && block.head) {
       statements = block.prelude.concat(block.head).concat(block.statements);
     } else {
@@ -118,7 +118,7 @@ export default class Scanner {
   scanBlock(meta: CompilationMeta): Block {
     let { block, env } = this;
 
-    let statements;
+    let statements: WireFormat.Statement[];
     if (block.prelude && block.head) {
       statements = block.prelude.concat(block.head).concat(block.statements);
     } else {
@@ -189,7 +189,7 @@ export namespace ClientSide {
   export type FunctionExpressionCallback<T> = (VM: PublicVM, symbolTable: SymbolTable) => VersionedPathReference<T>;
 
   export type ClientSideStatement =
-    | OpenComponentElement
+    OpenComponentElement
     | DidCreateElement
     | DidRenderLayout
     | OptimizedAppend
@@ -198,9 +198,7 @@ export namespace ClientSide {
     | DynamicPartial
     ;
 
-  export type ClientSideExpression =
-    | FunctionExpression
-    ;
+  export type ClientSideExpression = FunctionExpression;
 }
 
 const { Ops } = WireFormat;

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -18,7 +18,6 @@ import {
   dict,
   assert,
   unwrap,
-  unreachable,
 } from '@glimmer/util';
 
 import {
@@ -65,12 +64,12 @@ STATEMENTS.add(Ops.Comment, (sexp: S.Comment, builder: OpcodeBuilder) => {
   builder.comment(sexp[1]);
 });
 
-STATEMENTS.add(Ops.CloseElement, (_sexp, builder: OpcodeBuilder) => {
+STATEMENTS.add(Ops.CloseElement, (_sexp: S.CloseElement, builder: OpcodeBuilder) => {
   LOGGER.trace('close-element statement');
   builder.closeElement();
 });
 
-STATEMENTS.add(Ops.FlushElement, (_sexp, builder: OpcodeBuilder) => {
+STATEMENTS.add(Ops.FlushElement, (_sexp: S.FlushElement, builder: OpcodeBuilder) => {
   builder.flushElement();
 });
 
@@ -91,11 +90,11 @@ STATEMENTS.add(Ops.StaticAttr, (sexp: S.StaticAttr, builder: OpcodeBuilder) => {
   builder.staticAttr(name, namespace, value as string);
 });
 
-STATEMENTS.add(Ops.DynamicAttr, (sexp: S.DynamicAttr, builder) => {
+STATEMENTS.add(Ops.DynamicAttr, (sexp: S.DynamicAttr, builder: OpcodeBuilder) => {
   dynamicAttr(sexp, false, builder);
 });
 
-STATEMENTS.add(Ops.TrustingAttr, (sexp: S.DynamicAttr, builder) => {
+STATEMENTS.add(Ops.TrustingAttr, (sexp: S.DynamicAttr, builder: OpcodeBuilder) => {
   dynamicAttr(sexp, true, builder);
 });
 
@@ -115,16 +114,16 @@ STATEMENTS.add(Ops.OpenElement, (sexp: S.OpenElement, builder: OpcodeBuilder) =>
   builder.openPrimitiveElement(sexp[1]);
 });
 
-CLIENT_SIDE.add(ClientSide.Ops.OpenComponentElement, (sexp: ClientSide.OpenComponentElement, builder) => {
+CLIENT_SIDE.add(ClientSide.Ops.OpenComponentElement, (sexp: ClientSide.OpenComponentElement, builder: OpcodeBuilder) => {
   builder.pushComponentOperations();
   builder.openElementWithOperations(sexp[2]);
 });
 
-CLIENT_SIDE.add(ClientSide.Ops.DidCreateElement, (_sexp: ClientSide.DidCreateElement, builder) => {
+CLIENT_SIDE.add(ClientSide.Ops.DidCreateElement, (_sexp: ClientSide.DidCreateElement, builder: OpcodeBuilder) => {
   builder.didCreateElement(Register.s0);
 });
 
-CLIENT_SIDE.add(ClientSide.Ops.DidRenderLayout, (_sexp: ClientSide.DidRenderLayout, builder) => {
+CLIENT_SIDE.add(ClientSide.Ops.DidRenderLayout, (_sexp: ClientSide.DidRenderLayout, builder: OpcodeBuilder) => {
   builder.didRenderLayout(Register.s0);
 });
 
@@ -160,7 +159,7 @@ STATEMENTS.add(Ops.Append, (sexp: S.Append, builder: OpcodeBuilder) => {
 //   }
 // });
 
-STATEMENTS.add(Ops.Block, (sexp: S.Block, builder) => {
+STATEMENTS.add(Ops.Block, (sexp: S.Block, builder: OpcodeBuilder) => {
   let [, name, params, hash, _template, _inverse] = sexp;
   let template = builder.template(_template);
   let inverse = builder.template(_inverse);
@@ -230,7 +229,7 @@ export class InvokeDynamicLayout implements DynamicInvoker<ProgramSymbolTable> {
   }
 }
 
-STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
+STATEMENTS.add(Ops.Component, (sexp: S.Component, builder: OpcodeBuilder) => {
   let [, tag, attrs, args, block] = sexp;
 
   if (builder.env.hasComponentDefinition(tag, builder.meta.templateMeta)) {
@@ -287,7 +286,7 @@ export class PartialInvoker implements DynamicInvoker<ProgramSymbolTable> {
   }
 }
 
-STATEMENTS.add(Ops.Partial, (sexp: S.Partial, builder) => {
+STATEMENTS.add(Ops.Partial, (sexp: S.Partial, builder: OpcodeBuilder) => {
   let [, name, evalInfo] = sexp;
 
   let { templateMeta, symbols } = builder.meta;
@@ -383,7 +382,7 @@ class InvokeDynamicYield implements DynamicInvoker<BlockSymbolTable> {
   }
 }
 
-STATEMENTS.add(Ops.Yield, (sexp: WireFormat.Statements.Yield, builder) => {
+STATEMENTS.add(Ops.Yield, (sexp: WireFormat.Statements.Yield, builder: OpcodeBuilder) => {
   let [, to, params] = sexp;
 
   let count = compileList(params, builder);
@@ -405,7 +404,7 @@ STATEMENTS.add(Ops.Debugger, (sexp: WireFormat.Statements.Debugger, builder: Opc
   builder.debugger(builder.meta.symbols, evalInfo);
 });
 
-STATEMENTS.add(Ops.ClientSideStatement, (sexp: WireFormat.Statements.ClientSide, builder) => {
+STATEMENTS.add(Ops.ClientSideStatement, (sexp: WireFormat.Statements.ClientSide, builder: OpcodeBuilder) => {
   CLIENT_SIDE.compile(sexp as ClientSide.ClientSideStatement, builder);
 });
 
@@ -458,13 +457,13 @@ EXPRESSIONS.add(Ops.Helper, (sexp: E.Helper, builder: OpcodeBuilder) => {
   }
 });
 
-EXPRESSIONS.add(Ops.Get, (sexp: E.Get, builder) => {
+EXPRESSIONS.add(Ops.Get, (sexp: E.Get, builder: OpcodeBuilder) => {
   let [, head, path] = sexp;
   builder.getVariable(head);
   path.forEach(p => builder.getProperty(p));
 });
 
-EXPRESSIONS.add(Ops.MaybeLocal, (sexp: E.MaybeLocal, builder) => {
+EXPRESSIONS.add(Ops.MaybeLocal, (sexp: E.MaybeLocal, builder: OpcodeBuilder) => {
   let [, path] = sexp;
 
   if (builder.meta.asPartial) {
@@ -483,15 +482,15 @@ EXPRESSIONS.add(Ops.Undefined, (_sexp, builder) => {
   return builder.primitive(undefined);
 });
 
-EXPRESSIONS.add(Ops.HasBlock, (sexp: E.HasBlock, builder) => {
+EXPRESSIONS.add(Ops.HasBlock, (sexp: E.HasBlock, builder: OpcodeBuilder) => {
   builder.hasBlock(sexp[1]);
 });
 
-EXPRESSIONS.add(Ops.HasBlockParams, (sexp: E.HasBlockParams, builder) => {
+EXPRESSIONS.add(Ops.HasBlockParams, (sexp: E.HasBlockParams, builder: OpcodeBuilder) => {
   builder.hasBlockParams(sexp[1]);
 });
 
-EXPRESSIONS.add(Ops.ClientSideExpression, (sexp: E.ClientSide, builder) => {
+EXPRESSIONS.add(Ops.ClientSideExpression, (sexp: E.ClientSide, builder: OpcodeBuilder) => {
   CLIENT_SIDE_EXPRS.compile(sexp as ClientSide.ClientSideExpression, builder);
 });
 

--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -82,7 +82,7 @@ export default function build(ast: HBS.Node): string {
       output.push(ast.value ? 'true' : 'false');
     break;
     case 'BlockStatement': {
-      const lines = [];
+      const lines: string[] = [];
 
       if(ast['chained']){
         lines.push(['{{else ', pathParams(ast), '}}'].join(''));


### PR DESCRIPTION
This cleans up some of the places where we were using implicit `any` types. There are still a great deal of type errors through the pre-compilation stack, and reference to types that don't even exist, for [example](https://github.com/glimmerjs/glimmer-vm/blob/master/packages/@glimmer/syntax/lib/parser.ts#L83-L85) what is a `hbs.AST` type.  