### PR TITLE
Fix some of the content deopt cases

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -563,7 +563,6 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
   }
 
   guardedAppend(expression: WireFormat.Expression, trusting: boolean) {
-
     this.startLabels();
 
     this.pushFrame();

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -14,18 +14,15 @@ import { isComponentDefinition } from '../../component/interfaces';
 import { DOMTreeConstruction } from '../../dom/helper';
 import { OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
-import { TryOpcode } from '../../vm/update';
-import { Reference, VersionedPathReference, ReferenceCache, UpdatableTag, TagWrapper, isModified, isConst, map } from '@glimmer/reference';
-import { Option, Opaque } from '@glimmer/util';
+import { Reference, VersionedPathReference, ReferenceCache, isModified, isConst, map } from '@glimmer/reference';
+import { Opaque } from '@glimmer/util';
 import { Cursor, clear } from '../../bounds';
 import { Fragment } from '../../builder';
 import { ConditionalReference } from '../../references';
-import { Environment } from '../../environment';
 import { APPEND_OPCODES, Op } from '../../opcodes';
 
 APPEND_OPCODES.add(Op.DynamicContent, (vm, { op1: append }) => {
   let opcode = vm.constants.getOther(append) as AppendDynamicOpcode<Insertion>;
-  debugger;
   opcode.evaluate(vm);
 });
 
@@ -79,111 +76,30 @@ export abstract class AppendDynamicOpcode<T extends Insertion> {
   evaluate(vm: VM) {
     let reference = vm.stack.pop<VersionedPathReference<Opaque>>();
 
-    if (isComponentDefinition(reference.value())) {
+    let normalized = this.normalize(reference);
 
+    let value: T, cache: ReferenceCache<T> | undefined;
+
+    if (isConst(reference)) {
+      value = normalized.value();
     } else {
-      let normalized = this.normalize(reference);
+      cache = new ReferenceCache(normalized);
+      value = cache.peek();
+    }
 
-      let value, cache;
+    let stack = vm.elements();
+    let upsert = this.insert(vm.env.getAppendOperations(), stack, value);
+    let bounds = new Fragment(upsert.bounds);
 
-      if (isConst(reference)) {
-        value = normalized.value();
-      } else {
-        cache = new ReferenceCache(normalized);
-        value = cache.peek();
-      }
+    stack.newBounds(bounds);
 
-      let stack = vm.elements();
-      let upsert = this.insert(vm.env.getAppendOperations(), stack, value);
-      let bounds = new Fragment(upsert.bounds);
-
-      stack.newBounds(bounds);
-
-      if (cache /* i.e. !isConst(reference) */) {
-        vm.updateWith(this.updateWith(vm, reference, cache, bounds, upsert));
-      }
+    if (cache /* i.e. !isConst(reference) */) {
+      vm.updateWith(this.updateWith(vm, reference, cache, bounds, upsert));
     }
   }
 }
 
-export abstract class GuardedAppendOpcode<T extends Insertion> extends AppendDynamicOpcode<T> {
-  protected abstract AppendOpcode: typeof OptimizedCautiousAppendOpcode | typeof OptimizedTrustingAppendOpcode;
-  private start = -1;
-
-  constructor() {
-    super();
-  }
-
-  get deopted(): boolean {
-    return this.start === -1;
-  }
-
-  evaluate(vm: VM) {
-    if (this.deopted) {
-      vm.goto(this.start);
-    } else {
-      let value = vm.stack.pop();
-
-      if(isComponentDefinition(value)) {
-        this.deopt(vm.env);
-        vm.goto(this.start);
-      } else {
-        vm.stack.push(value);
-        super.evaluate(vm);
-      }
-    }
-  }
-
-  public deopt(_env: Environment): number { // Public because it's used in the lazy deopt
-    // At compile time, we determined that this append callsite might refer
-    // to a local variable/property lookup that resolves to a component
-    // definition at runtime.
-    //
-    // We could have eagerly compiled this callsite into something like this:
-    //
-    //   {{#if (is-component-definition foo)}}
-    //     {{component foo}}
-    //   {{else}}
-    //     {{foo}}
-    //   {{/if}}
-    //
-    // However, in practice, there might be a large amout of these callsites
-    // and most of them would resolve to a simple value lookup. Therefore, we
-    // tried to be optimistic and assumed that the callsite will resolve to
-    // appending a simple value.
-    //
-    // However, we have reached here because at runtime, the guard conditional
-    // have detected that this callsite is indeed referring to a component
-    // definition object. Since this is likely going to be true for other
-    // instances of the same callsite, it is now appropiate to deopt into the
-    // expanded version that handles both cases. The compilation would look
-    // like this:
-    //
-    //               PutValue(expression)
-    //               Test(is-component-definition)
-    //               Enter(BEGIN, END)
-    //   BEGIN:      Noop
-    //               JumpUnless(VALUE)
-    //               PutDynamicComponentDefinitionOpcode
-    //               OpenComponent
-    //               CloseComponent
-    //               Jump(END)
-    //   VALUE:      Noop
-    //               OptimizedAppend
-    //   END:        Noop
-    //               Exit
-    //
-    // Keep in mind that even if we *don't* reach here at initial render time,
-    // it is still possible (although quite rare) that the simple value we
-    // encounter during initial render could later change into a component
-    // definition object at update time. That is handled by the "lazy deopt"
-    // code on the update side (scroll down for the next big block of comment).
-
-    return null as any;
-  }
-}
-
-class IsComponentDefinitionReference extends ConditionalReference {
+export class IsComponentDefinitionReference extends ConditionalReference {
   static create(inner: Reference<Opaque>): IsComponentDefinitionReference {
     return new IsComponentDefinitionReference(inner);
   }
@@ -232,82 +148,6 @@ abstract class UpdateOpcode<T extends Insertion> extends UpdatingOpcode {
   }
 }
 
-abstract class GuardedUpdateOpcode<T extends Insertion> extends UpdateOpcode<T> {
-  private _tag: TagWrapper<UpdatableTag>;
-  private deopted: Option<TryOpcode> = null;
-
-  constructor(
-    private reference: Reference<Opaque>,
-    cache: ReferenceCache<T>,
-    bounds: Fragment,
-    upsert: Upsert
-  ) {
-    super(cache, bounds, upsert);
-    this.tag = this._tag = UpdatableTag.create(this.tag);
-  }
-
-  evaluate(vm: UpdatingVM) {
-    if (this.deopted) {
-      vm.evaluateOpcode(this.deopted);
-    } else {
-      if (isComponentDefinition(this.reference.value())) {
-        this.lazyDeopt(vm);
-      } else {
-        super.evaluate(vm);
-      }
-    }
-  }
-
-  private lazyDeopt(_vm: UpdatingVM) {
-    // Durign initial render, we know that the reference does not contain a
-    // component definition, so we optimistically assumed that this append
-    // is just a normal append. However, at update time, we discovered that
-    // the reference has switched into containing a component definition, so
-    // we need to do a "lazy deopt", simulating what would have happened if
-    // we had decided to perform the deopt in the first place during initial
-    // render.
-    //
-    // More concretely, we would have expanded the curly into a if/else, and
-    // based on whether the value is a component definition or not, we would
-    // have entered either the dynamic component branch or the simple value
-    // branch.
-    //
-    // Since we rendered a simple value during initial render (and all the
-    // updates up until this point), we need to pretend that the result is
-    // produced by the "VALUE" branch of the deopted append opcode:
-    //
-    //   Try(BEGIN, END)
-    //     Assert(IsComponentDefinition, expected=false)
-    //     OptimizedUpdate
-    //
-    // In this case, because the reference has switched from being a simple
-    // value into a component definition, what would have happened is that
-    // the assert would throw, causing the Try opcode to teardown the bounds
-    // and rerun the original append opcode.
-    //
-    // Since the Try opcode would have nuked the updating opcodes anyway, we
-    // wouldn't have to worry about simulating those. All we have to do is to
-    // execute the Try opcode and immediately throw.
-
-    return null as any;
-  }
-
-  toJSON(): OpcodeJSON {
-    let { _guid: guid, type, deopted } = this;
-
-    if (deopted) {
-      return {
-        guid,
-        type,
-        deopted: true,
-        children: [deopted.toJSON()]
-      };
-    } else {
-      return super.toJSON();
-    }
-  }
-}
-
 export class OptimizedCautiousAppendOpcode extends AppendDynamicOpcode<CautiousInsertion> {
   type = 'optimized-cautious-append';
 
@@ -332,32 +172,6 @@ class OptimizedCautiousUpdateOpcode extends UpdateOpcode<CautiousInsertion> {
   }
 }
 
-export class GuardedCautiousAppendOpcode extends GuardedAppendOpcode<CautiousInsertion> {
-  type = 'guarded-cautious-append';
-
-  protected AppendOpcode = OptimizedCautiousAppendOpcode;
-
-  protected normalize(reference: Reference<Opaque>): Reference<CautiousInsertion> {
-    return map(reference, normalizeValue);
-  }
-
-  protected insert(dom: DOMTreeConstruction, cursor: Cursor, value: CautiousInsertion): Upsert {
-    return cautiousInsert(dom, cursor, value);
-  }
-
-  protected updateWith(_vm: VM, reference: Reference<Opaque>, cache: ReferenceCache<CautiousInsertion>, bounds: Fragment, upsert: Upsert): UpdatingOpcode {
-    return new GuardedCautiousUpdateOpcode(reference, cache, bounds, upsert);
-  }
-}
-
-class GuardedCautiousUpdateOpcode extends GuardedUpdateOpcode<CautiousInsertion> {
-  type = 'guarded-cautious-update';
-
-  protected insert(dom: DOMTreeConstruction, cursor: Cursor, value: CautiousInsertion): Upsert {
-    return cautiousInsert(dom, cursor, value);
-  }
-}
-
 export class OptimizedTrustingAppendOpcode extends AppendDynamicOpcode<TrustingInsertion> {
   type = 'optimized-trusting-append';
 
@@ -376,32 +190,6 @@ export class OptimizedTrustingAppendOpcode extends AppendDynamicOpcode<TrustingI
 
 class OptimizedTrustingUpdateOpcode extends UpdateOpcode<TrustingInsertion> {
   type = 'optimized-trusting-update';
-
-  protected insert(dom: DOMTreeConstruction, cursor: Cursor, value: TrustingInsertion): Upsert {
-    return trustingInsert(dom, cursor, value);
-  }
-}
-
-export class GuardedTrustingAppendOpcode extends GuardedAppendOpcode<TrustingInsertion> {
-  type = 'guarded-trusting-append';
-
-  protected AppendOpcode = OptimizedTrustingAppendOpcode;
-
-  protected normalize(reference: Reference<Opaque>): Reference<TrustingInsertion> {
-    return map(reference, normalizeTrustedValue);
-  }
-
-  protected insert(dom: DOMTreeConstruction, cursor: Cursor, value: TrustingInsertion): Upsert {
-    return trustingInsert(dom, cursor, value);
-  }
-
-  protected updateWith(_vm: VM, reference: Reference<Opaque>, cache: ReferenceCache<TrustingInsertion>, bounds: Fragment, upsert: Upsert): UpdatingOpcode {
-    return new GuardedTrustingUpdateOpcode(reference, cache, bounds, upsert);
-  }
-}
-
-class GuardedTrustingUpdateOpcode extends GuardedUpdateOpcode<TrustingInsertion> {
-  type = 'trusting-update';
 
   protected insert(dom: DOMTreeConstruction, cursor: Cursor, value: TrustingInsertion): Upsert {
     return trustingInsert(dom, cursor, value);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -25,6 +25,7 @@ import { APPEND_OPCODES, Op } from '../../opcodes';
 
 APPEND_OPCODES.add(Op.DynamicContent, (vm, { op1: append }) => {
   let opcode = vm.constants.getOther(append) as AppendDynamicOpcode<Insertion>;
+  debugger;
   opcode.evaluate(vm);
 });
 
@@ -77,25 +78,30 @@ export abstract class AppendDynamicOpcode<T extends Insertion> {
 
   evaluate(vm: VM) {
     let reference = vm.stack.pop<VersionedPathReference<Opaque>>();
-    let normalized = this.normalize(reference);
 
-    let value, cache;
+    if (isComponentDefinition(reference.value())) {
 
-    if (isConst(reference)) {
-      value = normalized.value();
     } else {
-      cache = new ReferenceCache(normalized);
-      value = cache.peek();
-    }
+      let normalized = this.normalize(reference);
 
-    let stack = vm.elements();
-    let upsert = this.insert(vm.env.getAppendOperations(), stack, value);
-    let bounds = new Fragment(upsert.bounds);
+      let value, cache;
 
-    stack.newBounds(bounds);
+      if (isConst(reference)) {
+        value = normalized.value();
+      } else {
+        cache = new ReferenceCache(normalized);
+        value = cache.peek();
+      }
 
-    if (cache /* i.e. !isConst(reference) */) {
-      vm.updateWith(this.updateWith(vm, reference, cache, bounds, upsert));
+      let stack = vm.elements();
+      let upsert = this.insert(vm.env.getAppendOperations(), stack, value);
+      let bounds = new Fragment(upsert.bounds);
+
+      stack.newBounds(bounds);
+
+      if (cache /* i.e. !isConst(reference) */) {
+        vm.updateWith(this.updateWith(vm, reference, cache, bounds, upsert));
+      }
     }
   }
 }

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -108,8 +108,8 @@ export interface ComponentAttrsBuilder {
 
 const COMPONENT_DEFINITION_BRAND = 'COMPONENT DEFINITION [id=e59c754e-61eb-4392-8c4a-2c0ac72bfcd4]';
 
-export function isComponentDefinition(obj: any): obj is ComponentDefinition<Opaque> {
-  return typeof obj === 'object' && obj && obj[COMPONENT_DEFINITION_BRAND];
+export function isComponentDefinition(obj: Opaque): obj is ComponentDefinition<Opaque> {
+  return typeof obj === 'object' && obj !== null && obj[COMPONENT_DEFINITION_BRAND];
 }
 
 export abstract class ComponentDefinition<T> {

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -136,17 +136,13 @@ STATEMENTS.add(Ops.Append, (sexp: S.Append, builder: OpcodeBuilder) => {
 
   if (returned === true) return;
 
-  let hasGet = E.isGet(value as E.Get);
+  let isGet = E.isGet(value);
+  let isMaybeLocal = E.isMaybeLocal(value);
 
   if (trusting) {
-    if (hasGet) {
-      builder.guardedAppend(value, true);
-    } else {
-      expr(value, builder);
-      builder.trustingAppend();
-    }
+    builder.guardedAppend(value, true);
   } else {
-    if (hasGet) {
+    if (isGet || isMaybeLocal) {
       builder.guardedAppend(value, false);
     } else {
       expr(value, builder);

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -7,6 +7,7 @@ import { DynamicInvoker } from '../compiled/opcodes/vm';
 import { VM, PublicVM } from '../vm';
 import { IArguments } from '../vm/arguments';
 import { Register } from '../opcodes';
+import { IsComponentDefinitionReference } from '../compiled/opcodes/content';
 import { ATTRS_BLOCK, Block, ClientSide, RawInlineBlock } from '../scanner';
 
 import {
@@ -139,14 +140,14 @@ STATEMENTS.add(Ops.Append, (sexp: S.Append, builder: OpcodeBuilder) => {
 
   if (trusting) {
     if (hasGet) {
-      builder.guardedTrustingAppend(value)
+      builder.guardedAppend(value, true);
     } else {
       expr(value, builder);
       builder.trustingAppend();
     }
   } else {
     if (hasGet) {
-      builder.guardedCautiousAppend(value);
+      builder.guardedAppend(value, false);
     } else {
       expr(value, builder);
       builder.cautiousAppend();

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -135,12 +135,22 @@ STATEMENTS.add(Ops.Append, (sexp: S.Append, builder: OpcodeBuilder) => {
 
   if (returned === true) return;
 
-  expr(value, builder);
+  let hasGet = E.isGet(value as E.Get);
 
   if (trusting) {
-    builder.trustingAppend();
+    if (hasGet) {
+      builder.guardedTrustingAppend(value)
+    } else {
+      expr(value, builder);
+      builder.trustingAppend();
+    }
   } else {
-    builder.cautiousAppend();
+    if (hasGet) {
+      builder.guardedCautiousAppend(value);
+    } else {
+      expr(value, builder);
+      builder.cautiousAppend();
+    }
   }
 });
 

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -3400,7 +3400,7 @@ QUnit.test('it does not work on optimized appends', function(assert) {
   assertAppended('[object Object]');
 });
 
-QUnit.todo('it works on unoptimized appends (dot paths)', function(assert) {
+QUnit.test('it works on unoptimized appends (dot paths)', function(assert) {
   class FooBar extends EmberishCurlyComponent {}
 
   env.registerEmberishCurlyComponent('foo-bar', FooBar, 'foo bar');
@@ -3464,7 +3464,7 @@ QUnit.test('it works on unoptimized appends (this paths)', function(assert) {
   assertEmberishElement('div', {}, 'foo bar');
 });
 
-QUnit.todo('it works on unoptimized appends when initially not a component (dot paths)', function(assert) {
+QUnit.test('it works on unoptimized appends when initially not a component (dot paths)', function(assert) {
   class FooBar extends EmberishCurlyComponent {}
 
   env.registerEmberishCurlyComponent('foo-bar', FooBar, 'foo bar');

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -1946,7 +1946,7 @@ QUnit.test('component helper can handle higher order block components without ar
   assertText('Hello World! Test');
 });
 
-QUnit.todo('component deopt can handle aliased inline components without args', assert => {
+QUnit.test('component deopt can handle aliased inline components without args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello');
 
   appendViewFor(

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -1960,7 +1960,7 @@ QUnit.test('component deopt can handle aliased inline components without args', 
   assertText('Hello World!');
 });
 
-QUnit.todo('component deopt can handle higher order inline components without args', assert => {
+QUnit.test('component deopt can handle higher order inline components without args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
   env.registerEmberishCurlyComponent('baz-bar', null, 'Hello');
 
@@ -3432,7 +3432,7 @@ QUnit.todo('it works on unoptimized appends (dot paths)', function(assert) {
   assertEmberishElement('div', {}, 'foo bar');
 });
 
-QUnit.todo('it works on unoptimized appends (this paths)', function(assert) {
+QUnit.test('it works on unoptimized appends (this paths)', function(assert) {
   class FooBar extends EmberishCurlyComponent {}
 
   env.registerEmberishCurlyComponent('foo-bar', FooBar, 'foo bar');
@@ -3492,7 +3492,7 @@ QUnit.todo('it works on unoptimized appends when initially not a component (dot 
   assertAppended('lol');
 });
 
-QUnit.todo('it works on unoptimized appends when initially not a component (this paths)', function(assert) {
+QUnit.test('it works on unoptimized appends when initially not a component (this paths)', function(assert) {
   class FooBar extends EmberishCurlyComponent {}
 
   env.registerEmberishCurlyComponent('foo-bar', FooBar, 'foo bar');

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -153,6 +153,7 @@ module("[glimmer-runtime] Updating", hooks => {
     assert.strictEqual(root.firstChild.lastChild.firstChild, valueNode2, "The text node was not blown away");
 
     object.v1 = 'hello';
+
     rerender();
 
     equalTokens(root, '<div><p>hello</p><p></p></div>', "After updating and dirtying");

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -20,9 +20,9 @@ export type str = string;
 export type TemplateReference = Option<SerializedBlock>;
 export type YieldTo = number;
 
-export function is<T extends any[]>(variant: number): (value: any[]) => value is T {
-  return function(value: any[]): value is T {
-    return value[0] === variant;
+export function is<T>(variant: number): (value: any) => value is T {
+  return function(value: any): value is T {
+    return Array.isArray(value) && value[0] === variant;
   };
 }
 
@@ -89,6 +89,7 @@ export namespace Expressions {
   export const isHasBlockParams = is<HasBlockParams>(Opcodes.HasBlockParams);
   export const isUndefined      = is<Undefined>(Opcodes.Undefined);
   export const isClientSide     = is<ClientSide>(Opcodes.ClientSideExpression);
+  export const isMaybeLocal     = is<MaybeLocal>(Opcodes.MaybeLocal);
 
   export function isPrimitiveValue(value: any): value is Value {
     if (value === null) {


### PR DESCRIPTION
This fixes some of the content deopt cases by emitting the operations to effectively do the following:

```
{{if isComponentReferent (component foo.bar) foo.bar}}
```

This also fixes an issue where the deopt instructions were not being reused, meaning we were compiling new instructions for the deopt effectively creating a slow memory leak.