### PR TITLE
Remove forEach/map where we are creating context objects

### DIFF
--- a/packages/@glimmer/object-model/lib/reference.ts
+++ b/packages/@glimmer/object-model/lib/reference.ts
@@ -103,7 +103,10 @@ export class VersionedObjectReference implements VersionedPathReference<Opaque> 
     let tags: Tag[] = [meta(parentObject).tag(key)];
 
     if (computed) {
-      tags.push(...computed.dependentKeys.map(key => path(this, key).tag));
+      for (let i = 0; i < computed.dependentKeys.length; i++) {
+        let key = computed.dependentKeys[i];
+        tags.push(path(this, key).tag);
+      }
     }
 
     this.tag = combine(tags);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -502,7 +502,13 @@ export abstract class BasicOpcodeBuilder {
   }
 
   protected names(_names: string[]): ConstantArray {
-    let names = _names.map(n => this.constants.string(n));
+    let names: number[] = [];
+
+    for (let i = 0; i < _names.length; i++) {
+      let n = _names[i];
+      names[i]= this.constants.string(n);
+    }
+
     return this.constants.array(names);
   }
 
@@ -539,7 +545,9 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
     let positional = 0;
 
     if (params) {
-      params.forEach(p => expr(p, this));
+      for (let i = 0; i < params.length; i++) {
+        expr(params[i], this);
+      }
       positional = params.length;
     }
 
@@ -547,7 +555,10 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
 
     if (hash) {
       names = hash[0];
-      hash[1].forEach(v => expr(v, this));
+      let val = hash[1];
+      for (let i = 0; i < val.length; i++) {
+        expr(val[i], this);
+      }
     }
 
     this.pushImmediate(names);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -34,11 +34,12 @@ class ScopeInspector {
   private locals = dict<VersionedPathReference<Opaque>>();
 
   constructor(private scope: Scope, symbols: string[], evalInfo: number[]) {
-    evalInfo.forEach(slot => {
+    for (let i = 0; i < evalInfo.length; i++) {
+      let slot = evalInfo[i];
       let name = symbols[slot - 1];
       let ref  = scope.getSymbol(slot);
       this.locals[name] = ref;
-    });
+    }
   }
 
   get(path: string): VersionedPathReference<Opaque> {

--- a/packages/@glimmer/runtime/lib/environment/constants.ts
+++ b/packages/@glimmer/runtime/lib/environment/constants.ts
@@ -62,7 +62,15 @@ export class Constants {
   }
 
   getNames(value: ConstantArray): string[] {
-    return this.getArray(value).map(n => this.getString(n));
+    let _names: string[] = [];
+    let names = this.getArray(value);
+
+    for (let i = 0; i < names.length; i++) {
+      let n = names[i];
+      _names[i] = this.getString(n);
+    }
+
+    return _names;
   }
 
   array(values: number[]): ConstantArray {

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -232,9 +232,18 @@ STATEMENTS.add(Ops.Component, (sexp: S.Component, builder: OpcodeBuilder) => {
     throw new Error(`Compile Error: Cannot find component ${tag}`);
   } else {
     builder.openPrimitiveElement(tag);
-    attrs.forEach(attr => STATEMENTS.compile(attr, builder));
+
+    for (let i = 0; i < attrs.length; i++) {
+      STATEMENTS.compile(attrs[i], builder);
+    }
+
     builder.flushElement();
-    if (block) block.statements.forEach(s => STATEMENTS.compile(s, builder));
+    if (block) {
+      let stmts = block.statements;
+      for (let i = 0; i <  stmts.length; i++) {
+        STATEMENTS.compile(stmts[i], builder);
+      }
+    }
     builder.closeElement();
   }
 });
@@ -255,19 +264,22 @@ export class PartialInvoker implements DynamicInvoker<ProgramSymbolTable> {
 
     let locals = dict<VersionedPathReference<Opaque>>();
 
-    evalInfo.forEach(slot => {
+    for (let i = 0; i < evalInfo.length; i++) {
+      let slot = evalInfo[i];
       let name = outerSymbols[slot - 1];
       let ref  = outerScope.getSymbol(slot);
       locals[name] = ref;
-    });
+    }
 
     let evalScope = outerScope.getEvalScope()!;
-    partialSymbols.forEach((name, i) => {
+
+    for (let i = 0; i < partialSymbols.length; i++) {
+      let name = partialSymbols[i];
       let symbol = i + 1;
       let value = evalScope[name];
 
       if (value !== undefined) partialScope.bind(symbol, value);
-    });
+    }
 
     partialScope.bindPartialMap(locals);
 
@@ -427,7 +439,9 @@ EXPRESSIONS.add(Ops.Unknown, (sexp: E.Unknown, builder: OpcodeBuilder) => {
 
 EXPRESSIONS.add(Ops.Concat, ((sexp: E.Concat, builder: OpcodeBuilder) => {
   let parts = sexp[1];
-  parts.forEach(p => expr(p, builder));
+  for (let i = 0; i < parts.length; i++) {
+    expr(parts[i], builder);
+  }
   builder.concat(parts.length);
 }) as any);
 
@@ -450,7 +464,9 @@ EXPRESSIONS.add(Ops.Helper, (sexp: E.Helper, builder: OpcodeBuilder) => {
 EXPRESSIONS.add(Ops.Get, (sexp: E.Get, builder: OpcodeBuilder) => {
   let [, head, path] = sexp;
   builder.getVariable(head);
-  path.forEach(p => builder.getProperty(p));
+  for (let i = 0; i < path.length; i++) {
+    builder.getProperty(path[i]);
+  }
 });
 
 EXPRESSIONS.add(Ops.MaybeLocal, (sexp: E.MaybeLocal, builder: OpcodeBuilder) => {
@@ -465,7 +481,9 @@ EXPRESSIONS.add(Ops.MaybeLocal, (sexp: E.MaybeLocal, builder: OpcodeBuilder) => 
     builder.getVariable(0);
   }
 
-  path.forEach(p => builder.getProperty(p));
+  for(let i = 0; i < path.length; i++) {
+    builder.getProperty(path[i]);
+  }
 });
 
 EXPRESSIONS.add(Ops.Undefined, (_sexp, builder) => {
@@ -486,7 +504,11 @@ EXPRESSIONS.add(Ops.ClientSideExpression, (sexp: E.ClientSide, builder: OpcodeBu
 
 export function compileList(params: Option<WireFormat.Expression[]>, builder: OpcodeBuilder): number {
   if (!params) return 0;
-  params.forEach(p => expr(p, builder));
+
+  for (let i = 0; i < params.length; i++) {
+    expr(params[i], builder);
+  }
+
   return params.length;
 }
 

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -333,7 +333,12 @@ class CapturedNamedArguments implements ICapturedNamedArguments {
     if (!map) {
       let { names, references } = this;
       map = this._map = dict<VersionedPathReference<Opaque>>();
-      names.forEach((name, i) => map![name] = references[i]);
+
+      for (let i = 0; i < names.length; i++) {
+        let name = names[i];
+        map![name] = references[i];
+      }
+
     }
 
     return map;
@@ -358,7 +363,10 @@ class CapturedNamedArguments implements ICapturedNamedArguments {
     let { names, references } = this;
     let out = dict<Opaque>();
 
-    names.forEach((name, i) => out[name] = references[i].value());
+    for (let i = 0; i < names.length; i++) {
+      let name = names[i];
+      out[name] = references[i].value();
+    }
 
     return out;
   }

--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -192,11 +192,25 @@ class Iterable implements AbstractIterable<Opaque, Opaque, IterationItem<Opaque,
       return EMPTY_ITERATOR;
     } else if (iterable.forEach !== undefined) {
       let array: Opaque[] = [];
-      iterable.forEach((item: Opaque) => array.push(item));
+      for (let i = 0; i < iterable.length; i++) {
+        array.push(iterable[i]);
+      }
       return array.length > 0 ? new ArrayIterator(array, keyFor) : EMPTY_ITERATOR;
     } else if (typeof iterable === 'object') {
       let keys = Object.keys(iterable);
-      return keys.length > 0 ? new ObjectKeysIterator(keys, keys.map(key => iterable[key]), keyFor) : EMPTY_ITERATOR;
+
+      if (keys.length > 0) {
+        let values: Opaque[] = [];
+
+        for (let i = 0; i < keys.length; i++) {
+          let key = keys[i];
+          values[i] = iterable[key];
+        }
+
+        return new ObjectKeysIterator(keys, values, keyFor);
+      } else {
+        return EMPTY_ITERATOR;
+      }
     } else {
       throw new Error(`Don't know how to {{#each ${iterable}}}`);
     }
@@ -496,7 +510,10 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
     let dyn: Option<string[]> = definition.ComponentClass ? definition.ComponentClass['fromDynamicScope'] : null;
 
     if (dyn) {
-      dyn.forEach(name => component.set(name, dynamicScope.get(name).value()));
+      for (let i = 0; i < dyn.length; i++) {
+        let name = dyn[i];
+        component.set(name, dynamicScope.get(name).value());
+      }
     }
 
     component.didInitAttrs({ attrs });

--- a/packages/@glimmer/util/lib/collections.ts
+++ b/packages/@glimmer/util/lib/collections.ts
@@ -54,7 +54,10 @@ export class DictSet<T extends SetMember> implements Set<T> {
 
   forEach(callback: (item: T) => void) {
     let { dict } = this;
-    Object.keys(dict).forEach(key => callback(dict[key]));
+    let dictKeys = Object.keys(dict);
+    for (let i = 0; dictKeys.length; i++) {
+      callback(dict[dictKeys[i]]);
+    }
   }
 
   toArray(): string[] {


### PR DESCRIPTION
As always this is likely to be controversial, but these are creating a context object.