### PR TITLE
Fix @glimmer/syntax type errors

### DIFF
--- a/packages/@glimmer/syntax/lib/parser.ts
+++ b/packages/@glimmer/syntax/lib/parser.ts
@@ -5,6 +5,7 @@ import {
 } from "simple-html-tokenizer";
 import { Program } from "./types/nodes";
 import * as AST from "./types/nodes";
+import * as HandlebarsAST from './types/handlebars-ast';
 import { Option } from '@glimmer/interfaces';
 import { assert, expect } from '@glimmer/util';
 
@@ -80,9 +81,9 @@ export class Parser {
 
   }
 
-  acceptNode(node: hbs.AST.Program): Program;
-  acceptNode<U extends AST.Node>(node: hbs.AST.Node): U;
-  acceptNode(node: hbs.AST.Node): any {
+  acceptNode(node: HandlebarsAST.Program): Program;
+  acceptNode<U extends AST.Node>(node: HandlebarsAST.Node): U;
+  acceptNode(node: HandlebarsAST.Node): any {
     return this[node.type](node);
   }
 
@@ -90,7 +91,7 @@ export class Parser {
     return this.elementStack[this.elementStack.length - 1];
   }
 
-  sourceForNode(node: hbs.AST.Node, endNode?: { loc: hbs.AST.SourceLocation }): string {
+  sourceForNode(node: HandlebarsAST.Node, endNode?: { loc: HandlebarsAST.SourceLocation }): string {
     let firstLine = node.loc.start.line - 1;
     let currentLine = firstLine - 1;
     let firstColumn = node.loc.start.column;

--- a/packages/@glimmer/syntax/lib/types/handlebars-ast.ts
+++ b/packages/@glimmer/syntax/lib/types/handlebars-ast.ts
@@ -1,0 +1,130 @@
+/**
+ * @module
+ *
+ * This file contains types for the raw AST returned from the Handlebars parser.
+ * These types were originally imported from
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/handlebars/index.d.ts.
+ */
+
+export interface Node {
+  type: string;
+  loc: SourceLocation;
+}
+
+export interface SourceLocation {
+  source: string;
+  start: Position;
+  end: Position;
+}
+
+export interface Position {
+  line: number;
+  column: number;
+}
+
+export interface Program extends Node {
+  body: Statement[];
+  blockParams: string[];
+}
+
+export interface Statement extends Node { }
+
+export interface MustacheStatement extends Statement {
+  path: PathExpression | Literal;
+  params: Expression[];
+  hash: Hash;
+  escaped: boolean;
+  strip: StripFlags;
+}
+
+export interface Decorator extends MustacheStatement { }
+
+export interface BlockStatement extends Statement {
+  path: PathExpression;
+  params: Expression[];
+  hash: Hash;
+  program: Program;
+  inverse: Program;
+  openStrip: StripFlags;
+  inverseStrip: StripFlags;
+  closeStrip: StripFlags;
+}
+
+export interface DecoratorBlock extends BlockStatement { }
+
+export interface PartialStatement extends Statement {
+  name: PathExpression | SubExpression;
+  params: Expression[];
+  hash: Hash;
+  indent: string;
+  strip: StripFlags;
+}
+
+export interface PartialBlockStatement extends Statement {
+  name: PathExpression | SubExpression;
+  params: Expression[];
+  hash: Hash;
+  program: Program;
+  openStrip: StripFlags;
+  closeStrip: StripFlags;
+}
+
+export interface ContentStatement extends Statement {
+  value: string;
+  original: StripFlags;
+}
+
+export interface CommentStatement extends Statement {
+  value: string;
+  strip: StripFlags;
+}
+
+export interface Expression extends Node { }
+
+export interface SubExpression extends Expression {
+  path: PathExpression;
+  params: Expression[];
+  hash: Hash;
+}
+
+export interface PathExpression extends Expression {
+  data: boolean;
+  depth: number;
+  parts: string[];
+  original: string;
+}
+
+export interface Literal extends Expression { }
+
+export interface StringLiteral extends Literal {
+  value: string;
+  original: string;
+}
+
+export interface BooleanLiteral extends Literal {
+  value: boolean;
+  original: boolean;
+}
+
+export interface NumberLiteral extends Literal {
+  value: number;
+  original: number;
+}
+
+export interface UndefinedLiteral extends Literal { }
+
+export interface NullLiteral extends Literal { }
+
+export interface Hash extends Node {
+  pairs: HashPair[];
+}
+
+export interface HashPair extends Node {
+  key: string;
+  value: Expression;
+}
+
+export interface StripFlags {
+  open: boolean;
+  close: boolean;
+}


### PR DESCRIPTION
Currently, downstream consumers of `@glimmer/compiler` will get an error due to a missing `.d.ts` file in `@glimmer/syntax`, which was not being generated due to type errors at compilation time.

This PR fixes two issues that were preventing the `.d.ts` files from being generated correctly:

1. The global `hbs` namespace (which at one time was provided by `@types/handlebars` but went missing at some point) has been replaced with vendored types for Handlebars AST nodes.
2. TS wasn't able to infer the types of the exported `syntax` object, so I've made them more explicit.