### PR TITLE
Avoid errors in debug tooling when handling circular structures.

### DIFF
--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -944,7 +944,13 @@ function json(param: Opaque) {
     return '<function>';
   }
 
-  let string = JSON.stringify(param);
+  let string;
+  try {
+    string = JSON.stringify(param);
+  } catch(e) {
+    return '<cannot generate JSON>';
+  }
+
   if (string === undefined) {
     return 'undefined';
   }


### PR DESCRIPTION
When these debug tools are enabled while running Ember's test suite this `json` function ends up throwing the `Converting circular structure to JSON` error.

IMHO, the debug tooling should fail gracefully (instead of blowing up the whole program). This change just gaurds the `JSON.stringify` and returns a string that indicates it was not possible to stringify.