### PR TITLE
Remove InitializeComponentState Opcode

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -122,10 +122,6 @@ export abstract class BasicOpcodeBuilder {
     this.push(Op.PushDynamicComponentManager);
   }
 
-  initializeComponentState() {
-    this.push(Op.InitializeComponentState);
-  }
-
   prepareArgs(state: Register) {
     this.push(Op.PrepareArgs, state);
   }
@@ -621,9 +617,7 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
     this.stopLabels();
   }
 
-  invokeComponent(attrs: Option<RawInlineBlock>, params: Option<WireFormat.Core.Params>, hash: Option<WireFormat.Core.Hash>, block: Option<Block> = null, inverse: Option<Block> = null) {
-    this.initializeComponentState();
-
+  invokeComponent(attrs: Option<RawInlineBlock>, params: Option<WireFormat.Core.Params>, hash: Option<WireFormat.Core.Hash>, block: Option<Block>, inverse: Option<Block> = null) {
     this.fetch(Register.s0);
     this.dup(Register.sp, 1);
     this.load(Register.s0);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -21,8 +21,7 @@ APPEND_OPCODES.add(Op.PushComponentManager, (vm, { op1: _definition }) => {
   let definition = vm.constants.getOther<ComponentDefinition<Opaque>>(_definition);
   let stack = vm.stack;
 
-  stack.push(definition);
-  stack.push(definition.manager);
+  stack.push({ definition, manager: definition.manager, component: null });
 });
 
 APPEND_OPCODES.add(Op.PushDynamicComponentManager, vm => {
@@ -31,8 +30,7 @@ APPEND_OPCODES.add(Op.PushDynamicComponentManager, vm => {
   let cache = isConst(reference) ? undefined : new ReferenceCache<ComponentDefinition<Opaque>>(reference);
   let definition = cache ? cache.peek() : reference.value();
 
-  stack.push(definition);
-  stack.push(definition.manager);
+  stack.push({ definition, manager: definition.manager, component: null });
 
   if (cache) {
     vm.updateWith(new Assert(cache));
@@ -50,15 +48,6 @@ export interface ComponentState<T> {
   manager: ComponentManager<T>;
   component: T;
 }
-
-APPEND_OPCODES.add(Op.InitializeComponentState, vm => {
-  let stack = vm.stack;
-
-  let manager = stack.pop();
-  let definition = stack.pop();
-
-  stack.push({ definition, manager, component: null });
-});
 
 APPEND_OPCODES.add(Op.PushArgs, (vm, { op1: synthetic }) => {
   let stack = vm.stack;

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -700,7 +700,7 @@ export const enum Op {
    *   (PushComponentManager #ComponentDefinition)
    * Operand Stack:
    *   ... →
-   *   ..., ComponentDefinition, ComponentManager
+   *   ..., { ComponentDefinition, ComponentManager }
    */
   PushComponentManager,
 
@@ -716,17 +716,6 @@ export const enum Op {
    *   ..., ComponentDefinition, ComponentManager
    */
   PushDynamicComponentManager,
-
-  /**
-   * Operation: push component metadata onto the stack.
-   *
-   * Format:
-   *   (InitializeComponentState)
-   * Operand Stack:
-   *   ..., ComponentDefinition<T>, ComponentManager<T> →
-   *   ..., ComponentState
-   */
-  InitializeComponentState,
 
   /**
    * Operation: Push a user representation of args onto the stack.
@@ -1039,8 +1028,7 @@ function debug(c: Constants, op: Op, op1: number, op2: number, op3: number): [st
       /// COMPONENTS
       case Op.PushComponentManager: return ['PushComponentManager', { definition: c.getOther(op1) }];
       case Op.PushDynamicComponentManager: return ['PushDynamicComponentManager', {}];
-      case Op.InitializeComponentState: return ['InitializeComponentState', {}];
-      case Op.PushArgs: return ['PushArgs', { synthetic: !!op1 }];
+      case Op.PushArgs: return ['PushArgs', { synthetic: !!op2 }];
       case Op.PrepareArgs: return ['PrepareArgs', { state: Register[op1] }];
       case Op.CreateComponent: return ['CreateComponent', { flags: op1, state: Register[op2] }];
       case Op.RegisterComponentDestructor: return ['RegisterComponentDestructor', {}];


### PR DESCRIPTION
All this Opcode did was provide indirection for gluing together a pojo. It appears we can just have the push of the component managers bottle these things up. In the long term I don't even now if this is even needed as we might be able to transition to some more generic infrastructure for keeping this state together.