### PR TITLE
Ensure positional arguments are accounted for in builder.

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -93,8 +93,8 @@ export abstract class BasicOpcodeBuilder {
 
   // args
 
-  pushArgs(positional: number, synthetic: boolean) {
-    this.push(Op.PushArgs, positional, synthetic === true ? 1 : 0);
+  pushArgs(synthetic: boolean) {
+    this.push(Op.PushArgs, synthetic === true ? 1 : 0);
   }
 
   // helpers
@@ -551,6 +551,8 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
       positional = params.length;
     }
 
+    this.pushImmediate(positional);
+
     let names = EMPTY_ARRAY;
 
     if (hash) {
@@ -562,7 +564,7 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
     }
 
     this.pushImmediate(names);
-    this.pushArgs(positional, synthetic);
+    this.pushArgs(synthetic);
   }
 
   compile<E>(expr: Represents<E>): E {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -60,9 +60,9 @@ APPEND_OPCODES.add(Op.InitializeComponentState, vm => {
   stack.push({ definition, manager, component: null });
 });
 
-APPEND_OPCODES.add(Op.PushArgs, (vm, { op1: positional, op2: synthetic }) => {
+APPEND_OPCODES.add(Op.PushArgs, (vm, { op1: synthetic }) => {
   let stack = vm.stack;
-  ARGS.setup(stack, positional, !!synthetic);
+  ARGS.setup(stack, !!synthetic);
   stack.push(ARGS);
 });
 
@@ -84,6 +84,8 @@ APPEND_OPCODES.add(Op.PrepareArgs, (vm, { op1: _state }) => {
       stack.push(positional[i]);
     }
 
+    stack.push(positionalCount);
+
     let names = Object.keys(named);
     let namedCount = names.length;
 
@@ -92,7 +94,7 @@ APPEND_OPCODES.add(Op.PrepareArgs, (vm, { op1: _state }) => {
     }
 
     stack.push(names);
-    args.setup(stack, positionalCount, true);
+    args.setup(stack, true);
   }
 
   stack.push(args);

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -732,11 +732,11 @@ export const enum Op {
    * Operation: Push a user representation of args onto the stack.
    *
    * Format:
-   *   (PushArgs positional:u32 synthetic:boolean)
+   *   (PushArgs synthetic:boolean)
    *
    * Operand Stack:
-   *   ..., [VersionedPathReference ...], #Array<string> →
-   *   ..., [VersionedPathReference ...], #Array<string>, Arguments
+   *   ..., [VersionedPathReference ...], number, [VersionedPathReference ...], #Array<string> →
+   *   ..., [VersionedPathReference ...], number, [VersionedPathReference ...], #Array<string>, Arguments
    *
    * Description:
    *   This arguments object is only necessary when calling into
@@ -1034,7 +1034,7 @@ function debug(c: Constants, op: Op, op1: number, op2: number, op3: number): [st
       case Op.PushComponentManager: return ['PushComponentManager', { definition: c.getOther(op1) }];
       case Op.PushDynamicComponentManager: return ['PushDynamicComponentManager', {}];
       case Op.InitializeComponentState: return ['InitializeComponentState', {}];
-      case Op.PushArgs: return ['PushArgs', { positional: op1, synthetic: !!op2 }];
+      case Op.PushArgs: return ['PushArgs', { synthetic: !!op1 }];
       case Op.PrepareArgs: return ['PrepareArgs', { state: Register[op1] }];
       case Op.CreateComponent: return ['CreateComponent', { flags: op1, state: Register[op2] }];
       case Op.RegisterComponentDestructor: return ['RegisterComponentDestructor', {}];

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -191,6 +191,13 @@ export class InvokeDynamicLayout implements DynamicInvoker<ProgramSymbolTable> {
       if (hasEval) lookup![callerNames[i]] = value;
     }
 
+    let numPositionalArgs = stack.pop<number>();
+
+    assert(typeof numPositionalArgs === 'number', '[BUG] Incorrect value of positional argument count found during invoke-dynamic-layout.');
+
+    // Currently we don't support accessing positional args in templates, so just throw them away
+    stack.pop(numPositionalArgs);
+
     let inverseSymbol = symbols.indexOf('&inverse');
     let inverse = stack.pop<Option<Block>>();
 
@@ -319,8 +326,9 @@ STATEMENTS.add(Ops.Partial, (sexp: S.Partial, builder: OpcodeBuilder) => {
   builder.returnTo('END');
 
   expr(name, builder);
+  builder.pushImmediate(1);
   builder.pushImmediate(EMPTY_ARRAY);
-  builder.pushArgs(1, true);
+  builder.pushArgs(true);
   builder.helper(helper);
 
   builder.dup();

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -9,6 +9,7 @@ import { PrimitiveReference, UNDEFINED_REFERENCE } from '../references';
   The calling convention is:
 
   * 0-N positional arguments at the bottom (left-to-right)
+  * number of positional args
   * 0-N named arguments next
   * an array of names on top
 */
@@ -72,16 +73,18 @@ export class Arguments implements IArguments {
   public named: INamedArguments = new NamedArguments();
 
   empty() {
-    this.setup(null as any as EvaluationStack, 0, true);
+    this.setup(null as any as EvaluationStack, true);
     return this;
   }
 
-  setup(stack: EvaluationStack, positionalCount: number, synthetic: boolean) {
+  setup(stack: EvaluationStack, synthetic: boolean) {
     this.stack = stack;
 
     let names = stack.fromTop<string[]>(0);
     let namedCount = names.length;
-    let start = positionalCount + namedCount + 1;
+
+    let positionalCount = stack.fromTop<number>(namedCount + 1);
+    let start = positionalCount + namedCount + 2;
 
     let positional = this.positional as PositionalArguments;
     positional.setup(stack, start, positionalCount);
@@ -117,11 +120,7 @@ export class Arguments implements IArguments {
 
   clear(): void {
     let { stack, length } = this;
-    let pops = length + 1;
-
-    while (--pops >= 0) {
-      stack.pop();
-    }
+    stack.pop(length + 2);
   }
 }
 


### PR DESCRIPTION
Prior to this commit, positional args are pushed onto the stack during `builder.component.dynamic` but we not properly `pop`'ed.

This resulted in issues when using positional param based API's (e.g. `{{render` or `{{mount` in Ember), because the stack ordering was off.

Tests exist for this in Ember itself (both `{{render` and `{{mount` tests that were failing, are passing now with this change), but adding tests here requires significant fleshing out of the testing infra.