### PR TITLE
Ensure `hasDefault` and `hasInverse` function properly.

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -621,7 +621,7 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
     this.stopLabels();
   }
 
-  invokeComponent(attrs: Option<RawInlineBlock>, params: Option<WireFormat.Core.Params>, hash: Option<WireFormat.Core.Hash>, block: Option<Block>, inverse: Option<Block> = null) {
+  invokeComponent(attrs: Option<RawInlineBlock>, params: Option<WireFormat.Core.Params>, hash: Option<WireFormat.Core.Hash>, block: Option<Block> = null, inverse: Option<Block> = null) {
     this.initializeComponentState();
 
     this.fetch(Register.s0);
@@ -636,7 +636,7 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
 
     this.beginComponentTransaction();
     this.pushDynamicScope();
-    this.createComponent(Register.s0, true, inverse === null);
+    this.createComponent(Register.s0, block !== null, inverse !== null);
     this.registerComponentDestructor(Register.s0);
 
     this.getComponentSelf(Register.s0);

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -807,6 +807,32 @@ testComponent('parameterized has-block (concatted attr, default) when block not 
   expected: '<button data-has-block="is-false"></button>'
 });
 
+module('Manager#create - hasBlock');
+
+QUnit.test('when no block present', assert => {
+  class FooBar extends EmberishCurlyComponent {
+    tagName = 'div';
+  }
+
+  env.registerEmberishCurlyComponent('foo-bar', FooBar, `{{HAS_BLOCK}}`);
+
+  appendViewFor(`{{foo-bar}}`);
+
+  assertEmberishElement('div', {}, `false`);
+});
+
+QUnit.test('when block present', assert => {
+  class FooBar extends EmberishCurlyComponent {
+    tagName = 'div';
+  }
+
+  env.registerEmberishCurlyComponent('foo-bar', FooBar, `{{HAS_BLOCK}}`);
+
+  appendViewFor(`{{#foo-bar}}{{/foo-bar}}`);
+
+  assertEmberishElement('div', {}, `true`);
+});
+
 module('Dynamically-scoped variable accessors');
 
 testComponent('Can get and set dynamic variable', {

--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -499,12 +499,12 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
     }
   }
 
-  create(_environment: Environment, definition: EmberishCurlyComponentDefinition, _args: Arguments, dynamicScope: DynamicScope, callerSelf: PathReference<Opaque>): EmberishCurlyComponent {
+  create(_environment: Environment, definition: EmberishCurlyComponentDefinition, _args: Arguments, dynamicScope: DynamicScope, callerSelf: PathReference<Opaque>, hasDefaultBlock: boolean): EmberishCurlyComponent {
     let klass = definition.ComponentClass || BaseEmberishCurlyComponent;
     let self = callerSelf.value();
     let args = _args.named.capture();
     let attrs = args.value();
-    let merged = assign({}, attrs, { attrs }, { args }, { targetObject: self });
+    let merged = assign({}, attrs, { attrs }, { args }, { targetObject: self }, { HAS_BLOCK: hasDefaultBlock });
     let component = klass.create(merged);
 
     let dyn: Option<string[]> = definition.ComponentClass ? definition.ComponentClass['fromDynamicScope'] : null;


### PR DESCRIPTION
Prior to this change, the `hasDefault` and `hasInverse` flags were not properly set when using `builder.component.static` (which is used by Ember's `inlines.addMissing` in order to support extending from `{{link-to}}` and having non-block functionality working).

Fixes [this `{{link-to}}` test](https://github.com/emberjs/ember.js/blob/d7a163b5b8ea290f44b5a96ade6d2eb28d94f8c0/packages/ember-glimmer/tests/integration/components/link-to-test.js#L131-L141) for https://github.com/emberjs/ember.js/pull/15245.