### PR TITLE
Update DOMOperations to allow creation of the useless element to be customized.

### DIFF
--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -60,6 +60,12 @@ export class DOMOperations {
   protected uselessElement: HTMLElement;
 
   constructor(protected document: Document) {
+    this.setupUselessElement();
+  }
+
+  // split into seperate method so that NodeDOMTreeConstruction
+  // can override it.
+  protected setupUselessElement() {
     this.uselessElement = this.document.createElement('div');
   }
 


### PR DESCRIPTION
`NodeDOMTreeConstruction` inherits from `DOMOperations` and intentionally overrides `setupUselessElement` (to be a noop). This is required in Ember (currently) because we create an instance of `NodeDOMTreeConstruction` even when we don't have a `document` (e.g. `App.visit('/', { shouldRender: false {})`). That is obviously not ideal ( `document` should never be `null` here), and that issue will be fixed upstream.

This commit can be reverted once `shouldRender: false` no longer instantiates the Glimmer environment.

https://github.com/emberjs/ember.js/issues/15273 tracks untangling this gnarly web.