### PR TITLE
Speed up tests by 73x by making logging opt-in

### DIFF
--- a/packages/@glimmer/local-debug-flags/index.ts
+++ b/packages/@glimmer/local-debug-flags/index.ts
@@ -1,5 +1,10 @@
+let location = typeof window !== undefined && window.location;
+let DEBUG = false;
+if (location && /[?&]glimmer_logging/.test(window.location.search) {
+  DEBUG = true;
+}
 
-export const DEBUG = true;
+export const DEBUG = DEBUG;
 
 // TODO this is hacky but requires unifying the build
 export const CI = !!window['Testem'];

--- a/test/index.html
+++ b/test/index.html
@@ -52,6 +52,12 @@
       label: "Disable TSLint",
       tooltip: "Do not include any TSLint tests"
     });
+    QUnit.config.urlConfig.push({
+      id: "glimmer_logging",
+      label: "Enable Glimmer Logging",
+      tooltip: "Enable Glimmer Logging"
+    });
+
 
     var testMatch;
     var notslint = QUnit.urlParams.notslint;


### PR DESCRIPTION
## Why?

Improve development sanity for glimmer contributors by reducing test suite runtime by ~73x

With logging: 139s (\w console open)
Without Logging: 1.9s (\w console open)

## How to re-enable logging?

Obviously, logging has value (but maybe not by default), to re-enable your can:

* toggle the Glimmer Logging checkbox in QUnit
* add the glimmer_logging query param