### PR TITLE
Fix prod builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
 script:
   - yarn run problems
   - yarn run test:ci
+  - yarn run build
 after_script:
   - sleep 10
   - yarn run sauce:disconnect

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "inlineSources": true,
+    "inlineSourceMap": true,
+    "declaration": true,
+    "newLine": "LF",
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
* Brings back `build/tsconfig.json` (still needed)
* Add prod build to CI, to ensure we know if a PR breaks the production build.