### PR TITLE
Restore building demos

### DIFF
--- a/build/broccoli/build-tests.js
+++ b/build/broccoli/build-tests.js
@@ -22,8 +22,11 @@ module.exports = function(packages) {
   let testTree = merge([
     includeGlimmerAMD(amdTree),
     includeTestFiles(amdTree),
+    includeDemoFiles(amdTree),
+    includeBenchmarkFiles(amdTree),
     includeVendorDependencies(),
-    includeTestHarness()
+    includeTestHarness(),
+    includeDemoHtmls(),
   ]);
 
   return funnel(testTree, {
@@ -117,6 +120,30 @@ function includeTestFiles(amd) {
   });
 }
 
+function includeDemoFiles(amd) {
+  let demoAMD = funnel(amd, {
+    include: [
+      'glimmer-demos/**/*.js'
+    ]
+  });
+
+  return concat(demoAMD, {
+    outputFile: 'assets/demos.js'
+  });
+}
+
+function includeBenchmarkFiles(amd) {
+  let benchmarkAMD = funnel(amd, {
+    include: [
+      'glimmer-benchmarks/**/*.js'
+    ]
+  });
+
+  return concat(benchmarkAMD, {
+    outputFile: 'assets/benchmarks.js'
+  });
+}
+
 function includeVendorDependencies() {
   let simpleHTMLTokenizer = funnel('node_modules/simple-html-tokenizer/dist/es6', {
     include: ['*.js'],
@@ -156,4 +183,13 @@ function includeTestHarness() {
   ];
 
   return merge(harnessTrees);
+}
+
+function includeDemoHtmls() {
+  let htmls = funnel('demos', {
+    include: ['*.html'],
+    destDir: 'demos/',
+  });
+
+  return htmls;
 }

--- a/demos/benchmark.html
+++ b/demos/benchmark.html
@@ -1,13 +1,10 @@
 <html>
   <head>
     <title>Glimmer Benchmark</title>
-    <script src='./benchmark.js'></script>
     <script src="../assets/loader.js"></script>
-    <script>loader.noConflict({ define: 'enifed' });</script>
-    <script src="../amd/glimmer-common.amd.js"></script>
-    <script src="../amd/glimmer-compiler.amd.js"></script>
-    <script src="../amd/glimmer-runtime.amd.js"></script>
-    <script src="../amd/glimmer-benchmarks.amd.js"></script>
+    <script src="../assets/vendor.js"></script>
+    <script src="../assets/glimmer.js"></script>
+    <script src="../assets/benchmarks.js"></script>
 
     <style>
       * {

--- a/demos/conways.html
+++ b/demos/conways.html
@@ -27,12 +27,11 @@
         background: white;
       }
     </style>
+    <script src="../assets/loader.js"></script>
     <script src="http://static.iamstef.net/conways.js"></script>
-    <script>loader.noConflict({ define: 'enifed' });</script>
-    <script src="../amd/glimmer-common.amd.js"></script>
-    <script src="../amd/glimmer-compiler.amd.js"></script>
-    <script src="../amd/glimmer-runtime.amd.js"></script>
-    <script src="../amd/glimmer-demos.amd.js"></script>
+    <script src="../assets/vendor.js"></script>
+    <script src="../assets/glimmer.js"></script>
+    <script src="../assets/demos.js"></script>
   </head>
   <body>
     <script type="application/javascript">

--- a/demos/dbmon.html
+++ b/demos/dbmon.html
@@ -36,11 +36,9 @@
     <div id="output"></div>
 
     <script src="../assets/loader.js"></script>
-    <script>loader.noConflict({ define: 'enifed' });</script>
-    <script src="../amd/glimmer-common.amd.js"></script>
-    <script src="../amd/glimmer-compiler.amd.js"></script>
-    <script src="../amd/glimmer-runtime.amd.js"></script>
-    <script src="../amd/glimmer-demos.amd.js"></script>
+    <script src="../assets/vendor.js"></script>
+    <script src="../assets/glimmer.js"></script>
+    <script src="../assets/demos.js"></script>
     <script>
       var Dbmon = require("glimmer-demos").Dbmon;
       Dbmon.init();

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,5 +1,5 @@
 <h1>Glimmer Demos</h1>
-<div><a href="/bench/benchmark.html">Benchmarks</a></div>
+<div><a href="./benchmark.html">Benchmarks</a></div>
 <div><a href="./ripples.html">Ripples</a></div>
 <div><a href="./dbmon.html">DB Monster</a></div>
 <div><a href="./uptime-boxes.html">Uptime Boxes</a></div>

--- a/demos/ripples.html
+++ b/demos/ripples.html
@@ -25,11 +25,9 @@
     <div id="output"></div>
 
     <script src="../assets/loader.js"></script>
-    <script>loader.noConflict({ define: 'enifed' });</script>
-    <script src="../amd/glimmer-common.amd.js"></script>
-    <script src="../amd/glimmer-compiler.amd.js"></script>
-    <script src="../amd/glimmer-runtime.amd.js"></script>
-    <script src="../amd/glimmer-demos.amd.js"></script>
+    <script src="../assets/vendor.js"></script>
+    <script src="../assets/glimmer.js"></script>
+    <script src="../assets/demos.js"></script>
 
     <script>
       require("glimmer-demos").RipplesDemo.start();

--- a/demos/uptime-boxes.html
+++ b/demos/uptime-boxes.html
@@ -71,11 +71,9 @@
     <div id="output"></div>
 
     <script src="../assets/loader.js"></script>
-    <script>loader.noConflict({ define: 'enifed' });</script>
-    <script src="../amd/glimmer-common.amd.js"></script>
-    <script src="../amd/glimmer-compiler.amd.js"></script>
-    <script src="../amd/glimmer-runtime.amd.js"></script>
-    <script src="../amd/glimmer-demos.amd.js"></script>
+    <script src="../assets/vendor.js"></script>
+    <script src="../assets/glimmer.js"></script>
+    <script src="../assets/demos.js"></script>
     <script>
       var UptimeDemo = require("glimmer-demos").UptimeDemo;
       UptimeDemo.init();

--- a/demos/visualizer.html
+++ b/demos/visualizer.html
@@ -183,11 +183,9 @@
       }
     </style>
     <script src="../assets/loader.js"></script>
-    <script>loader.noConflict({ define: 'enifed' });</script>
-    <script src="../amd/glimmer-common.amd.js"></script>
-    <script src="../amd/glimmer-compiler.amd.js"></script>
-    <script src="../amd/glimmer-runtime.amd.js"></script>
-    <script src="../amd/glimmer-demos.amd.js"></script>
+    <script src="../assets/vendor.js"></script>
+    <script src="../assets/glimmer.js"></script>
+    <script src="../assets/demos.js"></script>
   </head>
   <body>
     <script type="application/javascript">

--- a/guides/05-validators.md
+++ b/guides/05-validators.md
@@ -74,7 +74,7 @@ let titleReference: Reference<string> = {
   }
 };
 
-let seperatorReference: Reference<string> = {
+let separatorReference: Reference<string> = {
   value() {
     return ': ';
   }
@@ -90,7 +90,7 @@ let result: Reference<string> = (
   new UppercaseReference(
     new ConcatReference(
       titleReference,
-      seperatorReference,
+      separatorReference,
       subtitleReference
     )
   )

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -72,11 +72,6 @@ export class Arguments implements IArguments {
   public positional: IPositionalArguments = new PositionalArguments();
   public named: INamedArguments = new NamedArguments();
 
-  empty() {
-    this.setup(null as any as EvaluationStack, true);
-    return this;
-  }
-
   setup(stack: EvaluationStack, synthetic: boolean) {
     this.stack = stack;
 

--- a/packages/glimmer-demos/lib/conways.ts
+++ b/packages/glimmer-demos/lib/conways.ts
@@ -5,7 +5,7 @@ import { UpdatableReference } from '@glimmer/object-reference';
 // const app = `{{#each world.cells key="key" as |cell|}}<organism-cell class="{{if cell.isAlive "alive" ""}}" style="top: {{cell.y}}0px; left: {{cell.x}}0px"/>{{/each}}`;
 
 // Component version
-const app = `<div class="world">{{#each world.cells key="key" as |cell|}}<organism-cell-component cell={{cell}} />{{/each}}</div>`;
+const app = `<div class="world">{{#each world.cells key="key" as |cell|}}<organism-cell-component @cell={{cell}} />{{/each}}</div>`;
 
 let env = new TestEnvironment();
 
@@ -24,7 +24,13 @@ export function startGlimmer() {
   let world = getWorld();
   env.begin();
   self = new UpdatableReference({ world });
-  res = env.compile(app).render(self, document.body, new TestDynamicScope());
+  let templateIterator = env.compile(app).render(self, document.body, new TestDynamicScope());
+
+  do {
+    res = templateIterator.next();
+  } while (!res.done);
+  res = res.value;
+
   env.commit();
 
   requestAnimationFrame(rerenderGlimmer);

--- a/packages/glimmer-demos/lib/dbmon.ts
+++ b/packages/glimmer-demos/lib/dbmon.ts
@@ -121,7 +121,13 @@ export function init() {
   env.begin();
 
   serversRef = new UpdatableReference({ model });
-  result = app.render(serversRef, output, new TestDynamicScope());
+  let templateIterator = app.render(serversRef, output, new TestDynamicScope());
+
+  do {
+    result = templateIterator.next();
+  } while (!result.done);
+
+  result = result.value;
 
   env.commit();
   console.timeEnd('initial render');
@@ -144,8 +150,6 @@ export function toggle() {
 function start() {
   playing = true;
 
-  env.begin();
-
   let lastFrame = null;
   let fpsMeter = new ExponentialMovingAverage(2/121);
 
@@ -158,7 +162,10 @@ function start() {
       fps = Math.round(fpsMeter.push(1000 / (thisFrame - lastFrame)));
     }
 
+    env.begin();
     result.rerender();
+    env.commit();
+
     clear = requestAnimationFrame(callback);
     lastFrame = thisFrame;
   };

--- a/packages/glimmer-demos/lib/uptime.ts
+++ b/packages/glimmer-demos/lib/uptime.ts
@@ -111,7 +111,13 @@ export function init({ app, env } = compile()) {
   env.begin();
 
   serversRef = new UpdatableReference({ servers: generateServers(), fps: null });
-  result = app.render(serversRef, output, new TestDynamicScope());
+  let templateIterator = app.render(serversRef, output, new TestDynamicScope());
+
+  do {
+    result = templateIterator.next();
+  } while (!result.done);
+
+  result = result.value;
 
   env.commit();
   console.timeEnd('initial render');


### PR DESCRIPTION
This PR restores the demo building that was lost after #424, and also fixes some of those demos (conway’s, dbmon, uptime, and visualizer).

Ripples and benchmark are still broken. Ripples has an issue with rerendering changes made inside a RingBuffer, and benchmark gets its utf8 methods (e.g. Σ, Π) mangled in the build process.

TBH I just wanted to run visualizer to help myself learning the glimmer compilation process… 😉 

Any feedback is greatly appreciated! 😊 