### PR TITLE
Implement memory compaction

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/blocks.ts
+++ b/packages/@glimmer/runtime/lib/compiled/blocks.ts
@@ -1,4 +1,5 @@
 import { SymbolTable, ProgramSymbolTable, BlockSymbolTable } from '@glimmer/interfaces';
+import { Handle } from '../environment';
 
 /**
  * The term "block" in the runtime refers to a section
@@ -35,17 +36,16 @@ import { SymbolTable, ProgramSymbolTable, BlockSymbolTable } from '@glimmer/inte
  */
 
 export interface OpSlice {
-  start: number;
-  end: number;
+  handle: Handle;
 }
 
 export class CompiledStaticTemplate implements OpSlice {
-  constructor(public start: number, public end: number) {
+  constructor(public handle: Handle) {
   }
 }
 
 export class CompiledDynamicTemplate<S extends SymbolTable> implements OpSlice {
-  constructor(public start: number, public end: number, public symbolTable: S) {
+  constructor(public handle: Handle, public symbolTable: S) {
   }
 }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/lists.ts
@@ -33,8 +33,8 @@ APPEND_OPCODES.add(Op.PutIterator, vm => {
   stack.push(new IterablePresenceReference(iterator.artifacts));
 });
 
-APPEND_OPCODES.add(Op.EnterList, (vm, { op1: start }) => {
-  vm.enterList(start);
+APPEND_OPCODES.add(Op.EnterList, (vm, { op1: relativeStart }) => {
+  vm.enterList(relativeStart);
 });
 
 APPEND_OPCODES.add(Op.ExitList, vm => vm.exitList());

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -95,7 +95,7 @@ APPEND_OPCODES.add(Op.CompileDynamicBlock, vm => {
 APPEND_OPCODES.add(Op.InvokeStatic, (vm, { op1: _block }) => {
   let block = vm.constants.getBlock(_block);
   let compiled = block.compileStatic(vm.env);
-  vm.call(compiled.start);
+  vm.call(compiled.handle);
 });
 
 export interface DynamicInvoker<S extends SymbolTable> {
@@ -147,6 +147,9 @@ APPEND_OPCODES.add(Op.JumpUnless, (vm, { op1: target }) => {
 });
 
 APPEND_OPCODES.add(Op.Return, vm => vm.return());
+APPEND_OPCODES.add(Op.ReturnTo, (vm, { op1: relative }) => {
+  vm.returnTo(relative);
+});
 
 export type TestFunction = (ref: Reference<Opaque>, env: Environment) => Reference<boolean>;
 

--- a/packages/@glimmer/runtime/lib/compiler.ts
+++ b/packages/@glimmer/runtime/lib/compiler.ts
@@ -25,6 +25,7 @@ import * as WireFormat from '@glimmer/wire-format';
 import { PublicVM } from './vm/append';
 import { IArguments } from './vm/arguments';
 import { FunctionExpression } from "./compiled/opcodes/expressions";
+import { DEBUG } from "@glimmer/local-debug-flags";
 
 export interface CompilableLayout {
   compile(builder: Component.ComponentLayoutBuilder): void;
@@ -172,9 +173,11 @@ class WrappedBuilder implements InnerLayoutBuilder {
     let start = b.start;
     let end = b.finalize();
 
-    debugSlice(env, start, end);
+    if (DEBUG) {
+      debugSlice(env, env.program.heap.getaddr(start), env.program.heap.getaddr(end));
+    }
 
-    return new CompiledDynamicTemplate(start, end, {
+    return new CompiledDynamicTemplate(start, {
       meta,
       hasEval: layout.hasEval,
       symbols: layout.symbols.concat([ATTRS_BLOCK])

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -1,4 +1,4 @@
-import { Scope, DynamicScope, Environment } from '../environment';
+import { Scope, DynamicScope, Environment, Handle } from '../environment';
 import { DestroyableBounds, clear, move as moveBounds } from '../bounds';
 import { ElementStack, Tracker, UpdatableTracker } from '../builder';
 import { Option, Opaque, Stack, LinkedList, Dict, dict, expect } from '@glimmer/util';
@@ -34,7 +34,7 @@ export default class UpdatingVM {
 
   constructor(env: Environment, { alwaysRevalidate = false }) {
     this.env = env;
-    this.constants = env.constants;
+    this.constants = env.program.constants;
     this.dom = env.getDOM();
     this.alwaysRevalidate = alwaysRevalidate;
   }
@@ -103,7 +103,7 @@ export abstract class BlockOpcode extends UpdatingOpcode implements DestroyableB
   protected stack: CapturedStack;
   protected bounds: DestroyableBounds;
 
-  constructor(public start: number, state: VMState, bounds: DestroyableBounds, children: LinkedList<UpdatingOpcode>) {
+  constructor(public start: Handle, state: VMState, bounds: DestroyableBounds, children: LinkedList<UpdatingOpcode>) {
     super();
     let { env, scope, dynamicScope, stack } = state;
     this.children = children;
@@ -161,7 +161,7 @@ export class TryOpcode extends BlockOpcode implements ExceptionHandler {
 
   protected bounds: UpdatableTracker;
 
-  constructor(start: number, state: VMState, bounds: UpdatableTracker, children: LinkedList<UpdatingOpcode>) {
+  constructor(start: Handle, state: VMState, bounds: UpdatableTracker, children: LinkedList<UpdatingOpcode>) {
     super(start, state, bounds, children);
     this.tag = this._tag = UpdatableTag.create(CONSTANT_TAG);
   }
@@ -296,7 +296,7 @@ export class ListBlockOpcode extends BlockOpcode {
   private lastIterated: Revision = INITIAL;
   private _tag: TagWrapper<UpdatableTag>;
 
-  constructor(start: number, state: VMState, bounds: Tracker, children: LinkedList<UpdatingOpcode>, artifacts: IterationArtifacts) {
+  constructor(start: Handle, state: VMState, bounds: Tracker, children: LinkedList<UpdatingOpcode>, artifacts: IterationArtifacts) {
     super(start, state, bounds, children);
     this.artifacts = artifacts;
     let _tag = this._tag = UpdatableTag.create(CONSTANT_TAG);

--- a/packages/@glimmer/util/lib/platform-utils.ts
+++ b/packages/@glimmer/util/lib/platform-utils.ts
@@ -15,3 +15,7 @@ export function expect<T>(val: Maybe<T>, message: string): T {
 export function unreachable(): Error {
   return new Error('unreachable');
 }
+
+export function typePos(lastOperand: number): number {
+  return lastOperand - 4;
+}


### PR DESCRIPTION
This PR does 2 things:

1. Moves `Constants` onto `Program`
2. Implements memory alloc/freeing by introducing `Heap`

When you `malloc` it passes back `handle`s which are simply pointers at a `table` on the `Heap` and not the actual memory address. Due to this indirection we have introduced a [mark and compact algorithm](https://en.wikipedia.org/wiki/Mark-compact_algorithm) for re-claiming parts of the `Heap`.

## Rules
- We never GC during execution
- Raw addresses are only valid during execution
- `getaddr` on `Heap` needs to be carefully used and nothing should hold on to it
  - Perhaps we should call this `dangerouslyGetAddr()` ?

