### PR TITLE
Add more tests for `-in-element`.

### DIFF
--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -328,8 +328,7 @@ class BasicComponentManager implements ComponentManager<BasicStateBucket> {
       return layout;
     }
 
-    layout = rawCompile(definition.layoutString, { env, meta: undefined as any as TemplateMeta }).asLayout(definition.name).compileDynamic(env);
-    return env.compiledLayouts[definition.name] = layout;
+    return env.compiledLayouts[definition.name] = compileLayout(new BasicComponentLayoutCompiler(definition.componentName, definition.layoutString), env);
   }
 
   getSelf({ component }: BasicStateBucket): PathReference<Opaque> {
@@ -1001,6 +1000,16 @@ abstract class GenericComponentLayoutCompiler implements CompilableLayout {
   }
 
   abstract compile(builder: ComponentLayoutBuilder): void;
+}
+
+class BasicComponentLayoutCompiler extends GenericComponentLayoutCompiler {
+  constructor(private componentName: string, layoutString: string) {
+    super(layoutString);
+  }
+
+  compile(builder: ComponentLayoutBuilder) {
+    builder.fromLayout(this.componentName, this.compileLayout(builder.env));
+  }
 }
 
 class StaticTaglessComponentLayoutCompiler extends GenericComponentLayoutCompiler {

--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -328,7 +328,7 @@ class BasicComponentManager implements ComponentManager<BasicStateBucket> {
       return layout;
     }
 
-    return env.compiledLayouts[definition.name] = compileLayout(new BasicComponentLayoutCompiler(definition.componentName, definition.layoutString), env);
+    return env.compiledLayouts[definition.name] = compileLayout(new BasicComponentLayoutCompiler(definition.name, definition.layoutString), env);
   }
 
   getSelf({ component }: BasicStateBucket): PathReference<Opaque> {


### PR DESCRIPTION
As I attempted to isolate a regression in glimmer apps I created this test to roughly emulate the [main template](https://github.com/glimmerjs/glimmer-application/blob/8443f24072f9311f8eef14a88b6e775596e793c1/src/templates/main.hbs) in `@glimmer/application`.  

Seems like a decent test to have around to me, so I figured I'd PR it even though the issue ended up not being something wrong in glimmer-vm...