### PR TITLE
Ensure custom element fallback properly specializes statements. 

### DIFF
--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -196,29 +196,6 @@ STATEMENTS.add(Ops.ScannedBlock, (sexp: BaselineSyntax.ScannedBlock, builder) =>
   blocks.compile([Ops.NestedBlock, path, params, hash, templateBlock, inverseBlock], builder);
 });
 
-// this fixes an issue with Ember versions using glimmer-vm@0.22 when attempting
-// to use nested web components.  This is obviously not correct for angle bracket components
-// but since no consumers are currently using them with glimmer@0.22.x we are hard coding
-// support to just use the fallback case.
-STATEMENTS.add(Ops.Component, (sexp: WireFormat.Statements.Component, builder) => {
-  let [, tag, component ] = sexp;
-  let { attrs, statements } = component;
-
-  builder.openPrimitiveElement(tag);
-
-  for (let i = 0; i < attrs.length; i++) {
-    STATEMENTS.compile(attrs[i], builder);
-  }
-
-  builder.flushElement();
-
-  for (let i = 0; i < statements.length; i++) {
-    STATEMENTS.compile(statements[i], builder);
-  }
-
-  builder.closeElement();
-});
-
 STATEMENTS.add(Ops.ScannedComponent, (sexp: BaselineSyntax.ScannedComponent, builder) => {
   let [, tag, attrs, rawArgs, rawBlock] = sexp;
   let block = rawBlock && rawBlock.scan();

--- a/packages/@glimmer/runtime/tests/rendering/content-test.ts
+++ b/packages/@glimmer/runtime/tests/rendering/content-test.ts
@@ -42,6 +42,27 @@ class StaticContentTests extends RenderingTest {
     this.assertStableRerender();
   }
 
+  @template(`<fake-thing><other-fake-thing data-src="extra-{{someDynamicBits}}-here" /></fake-thing>`)
+  ['renders custom elements with dynamic attributes']() {
+    this.render({ someDynamicBits: 'things' });
+    this.assertContent(`<fake-thing><other-fake-thing data-src="extra-things-here"></other-fake-thing></fake-thing>`);
+    this.assertStableRerender();
+  }
+
+  @template(`<x-foo><x-bar>{{derp}}</x-bar></x-foo>`)
+  ['renders dynamic content within nested custom elements']() {
+    this.render({ derp: 'stuff' });
+    this.assertContent(`<x-foo><x-bar>stuff</x-bar></x-foo>`);
+    this.assertStableRerender();
+  }
+
+  @template(`<x-foo>{{#if derp}}Content Here{{/if}}</x-foo>`)
+  ['renders dynamic content within single custom element']() {
+    this.render({ derp: 'stuff' });
+    this.assertContent(`<x-foo>Content Here</x-foo>`);
+    this.assertStableRerender();
+  }
+
   @template(strip`
     <div class="world">
       <h1>Hello World!</h1>


### PR DESCRIPTION
The root cause of the various `implementation missing for: x` errors is that the custom element fallback was using unspecialized opcodes that are not used/tested through the rest of the system (since we generally use the specialized versions if at all possible).

This fixes the issue by specializing inside the fallback branch.

A joint @krisselden / @rwjblue production.

Fixes #511 
Fixes #494 
Fixes #493 
Replaces #488