### PR TITLE
Consolidate DOM Compat

### DIFF
--- a/packages/@glimmer/runtime/lib/compat/inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/inner-html-fix.ts
@@ -1,14 +1,13 @@
 import { Bounds, ConcreteBounds } from '../bounds';
-import { moveNodesBefore, DOMChanges, DOMTreeConstruction } from '../dom/helper';
-import { Option } from '@glimmer/util';
+import { moveNodesBefore } from '../dom/helper';
 
-interface Wrapper {
+export interface Wrapper {
   depth: number;
   before: string;
   after: string;
 }
 
-let innerHTMLWrapper = {
+export const innerHTMLWrapper = {
   colgroup: { depth: 2, before: '<table><colgroup>', after: '</colgroup></table>' },
   table:    { depth: 1, before: '<table>', after: '</table>' },
   tbody:    { depth: 2, before: '<table><tbody>', after: '</tbody></table>' },
@@ -24,61 +23,7 @@ let innerHTMLWrapper = {
 // Fix:      Wrap the innerHTML we are about to set in its parents, apply the
 //           wrapped innerHTML on a div, then move the unwrapped nodes into the
 //           target position.
-export function domChanges(document: Option<Document>, DOMChangesClass: typeof DOMChanges): typeof DOMChanges {
-  if (!document) return DOMChangesClass;
-
-  if (!shouldApplyFix(document)) {
-    return DOMChangesClass;
-  }
-
-  let div = document.createElement('div');
-
-  return class DOMChangesWithInnerHTMLFix extends DOMChangesClass {
-    insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
-      if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, nextSibling, html);
-      }
-
-      let parentTag = parent.tagName.toLowerCase();
-      let wrapper = innerHTMLWrapper[parentTag];
-
-      if(wrapper === undefined) {
-        return super.insertHTMLBefore(parent, nextSibling, html);
-      }
-
-      return fixInnerHTML(parent, wrapper, div, html, nextSibling);
-    }
-  };
-}
-
-export function treeConstruction(document: Option<Document>, DOMTreeConstructionClass: typeof DOMTreeConstruction): typeof DOMTreeConstruction {
-  if (!document) return DOMTreeConstructionClass;
-
-  if (!shouldApplyFix(document)) {
-    return DOMTreeConstructionClass;
-  }
-
-  let div = document.createElement('div');
-
-  return class DOMTreeConstructionWithInnerHTMLFix extends DOMTreeConstructionClass {
-    insertHTMLBefore(parent: HTMLElement, referenceNode: Node, html: string): Bounds {
-      if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, referenceNode, html);
-      }
-
-      let parentTag = parent.tagName.toLowerCase();
-      let wrapper = innerHTMLWrapper[parentTag];
-
-      if(wrapper === undefined) {
-        return super.insertHTMLBefore(parent, referenceNode, html);
-      }
-
-      return fixInnerHTML(parent, wrapper, div, html, referenceNode);
-    }
-  };
-}
-
-function fixInnerHTML(parent: HTMLElement, wrapper: Wrapper, div: HTMLElement, html: string, reference: Node): Bounds {
+export function fixInnerHTML(parent: HTMLElement, wrapper: Wrapper, div: HTMLElement, html: string, reference: Node): Bounds {
   let wrappedHtml = wrapper.before + html + wrapper.after;
 
   div.innerHTML = wrappedHtml;
@@ -93,7 +38,7 @@ function fixInnerHTML(parent: HTMLElement, wrapper: Wrapper, div: HTMLElement, h
   return new ConcreteBounds(parent, first, last);
 }
 
-function shouldApplyFix(document: Document) {
+export function needsInnerHTMLFix(document: Document) {
   let table = document.createElement('table');
   try {
     table.innerHTML = '<tbody></tbody>';

--- a/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
@@ -1,6 +1,6 @@
 import { Bounds, ConcreteBounds } from '../bounds';
-import { moveNodesBefore, DOMChanges, DOMTreeConstruction } from '../dom/helper';
-import { Option, unwrap } from '@glimmer/util';
+import { moveNodesBefore } from '../dom/helper';
+import { unwrap } from '@glimmer/util';
 
 export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 export type SVG_NAMESPACE = typeof SVG_NAMESPACE;
@@ -16,55 +16,7 @@ export type SVG_NAMESPACE = typeof SVG_NAMESPACE;
 //           approach is used. A pre/post SVG tag is added to the string, then
 //           that whole string is added to a div. The created nodes are plucked
 //           out and applied to the target location on DOM.
-export function domChanges(document: Option<Document>, DOMChangesClass: typeof DOMChanges, svgNamespace: SVG_NAMESPACE): typeof DOMChanges {
-  if (!document) return DOMChangesClass;
-
-  if (!shouldApplyFix(document, svgNamespace)) {
-    return DOMChangesClass;
-  }
-
-  let div = document.createElement('div');
-
-  return class DOMChangesWithSVGInnerHTMLFix extends DOMChangesClass {
-    insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
-      if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, nextSibling, html);
-      }
-
-      if (parent.namespaceURI !== svgNamespace) {
-        return super.insertHTMLBefore(parent, nextSibling, html);
-      }
-
-      return fixSVG(parent, div, html, nextSibling);
-    }
-  };
-}
-
-export function treeConstruction(document: Option<Document>, TreeConstructionClass: typeof DOMTreeConstruction, svgNamespace: SVG_NAMESPACE): typeof DOMTreeConstruction {
-  if (!document) return TreeConstructionClass;
-
-  if (!shouldApplyFix(document, svgNamespace)) {
-    return TreeConstructionClass;
-  }
-
-  let div = document.createElement('div');
-
-  return class TreeConstructionWithSVGInnerHTMLFix extends TreeConstructionClass {
-    insertHTMLBefore(parent: HTMLElement, reference: Node, html: string): Bounds {
-      if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, reference, html);
-      }
-
-      if (parent.namespaceURI !== svgNamespace) {
-        return super.insertHTMLBefore(parent, reference, html);
-      }
-
-      return fixSVG(parent, div, html, reference);
-    }
-  };
-}
-
-function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Node): Bounds {
+export function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Node): Bounds {
   // IE, Edge: also do not correctly support using `innerHTML` on SVG
   // namespaced elements. So here a wrapper is used.
   let wrappedHtml = '<svg>' + html + '</svg>';
@@ -75,7 +27,7 @@ function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Node
   return new ConcreteBounds(parent, first, last);
 }
 
-function shouldApplyFix(document: Document, svgNamespace: SVG_NAMESPACE) {
+export function needsSVGInnerHTMLFix(document: Document, svgNamespace: SVG_NAMESPACE) {
   let svg = document.createElementNS(svgNamespace, 'svg');
 
   try {

--- a/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
@@ -1,7 +1,3 @@
-import { Bounds } from '../bounds';
-import { DOMChanges, DOMTreeConstruction } from '../dom/helper';
-import { Option } from '@glimmer/util';
-
 // Patch:    Adjacent text node merging fix
 // Browsers: IE, Edge, Firefox w/o inspector open
 // Reason:   These browsers will merge adjacent text nodes. For exmaple given
@@ -14,85 +10,18 @@ import { Option } from '@glimmer/util';
 //           Note that this fix must only apply to the previous text node, as
 //           the base implementation of `insertHTMLBefore` already handles
 //           following text nodes correctly.
-export function domChanges(document: Option<Document>, DOMChangesClass: typeof DOMChanges): typeof DOMChanges {
-  if (!document) return DOMChangesClass;
-
-  if (!shouldApplyFix(document)) {
-    return DOMChangesClass;
+export function fixTextNodeMerging(parent: HTMLElement, reference: Node, uselessComment: Comment) {
+  let didSetUselessComment = false;
+  let nextPrevious = reference ? reference.previousSibling : parent.lastChild;
+  if (nextPrevious && nextPrevious instanceof Text) {
+    didSetUselessComment = true;
+    parent.insertBefore(uselessComment, reference);
   }
 
-  return class DOMChangesWithTextNodeMergingFix extends DOMChangesClass {
-    private uselessComment: Comment;
-
-    constructor(document: Document) {
-      super(document);
-      this.uselessComment = document.createComment('');
-    }
-
-    insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
-      if (html === null) {
-        return super.insertHTMLBefore(parent, nextSibling, html);
-      }
-
-      let didSetUselessComment = false;
-
-      let nextPrevious = nextSibling ? nextSibling.previousSibling : parent.lastChild;
-      if (nextPrevious && nextPrevious instanceof Text) {
-        didSetUselessComment = true;
-        parent.insertBefore(this.uselessComment, nextSibling);
-      }
-
-      let bounds = super.insertHTMLBefore(parent, nextSibling, html);
-
-      if (didSetUselessComment) {
-        parent.removeChild(this.uselessComment);
-      }
-
-      return bounds;
-    }
-  };
+  return didSetUselessComment;
 }
 
-export function treeConstruction(document: Option<Document>, TreeConstructionClass: typeof DOMTreeConstruction): typeof DOMTreeConstruction {
-  if (!document) return TreeConstructionClass;
-
-  if (!shouldApplyFix(document)) {
-    return TreeConstructionClass;
-  }
-
-  return class TreeConstructionWithTextNodeMergingFix extends TreeConstructionClass {
-    private uselessComment: Comment;
-
-    constructor(document: Document) {
-      super(document);
-      this.uselessComment = this.createComment('') as Comment;
-    }
-
-    insertHTMLBefore(parent: HTMLElement, reference: Node, html: string): Bounds {
-      if (html === null) {
-        return super.insertHTMLBefore(parent, reference, html);
-      }
-
-      let didSetUselessComment = false;
-
-      let nextPrevious = reference ? reference.previousSibling : parent.lastChild;
-      if (nextPrevious && nextPrevious instanceof Text) {
-        didSetUselessComment = true;
-        parent.insertBefore(this.uselessComment, reference);
-      }
-
-      let bounds = super.insertHTMLBefore(parent, reference, html);
-
-      if (didSetUselessComment) {
-        parent.removeChild(this.uselessComment);
-      }
-
-      return bounds;
-    }
-  };
-}
-
-function shouldApplyFix(document: Document) {
+export function needsTextNodeFix(document: Document) {
   let mergingTextDiv: HTMLDivElement = document.createElement('div');
 
   mergingTextDiv.innerHTML = 'first';

--- a/packages/@glimmer/runtime/lib/compat/utils.ts
+++ b/packages/@glimmer/runtime/lib/compat/utils.ts
@@ -1,0 +1,3 @@
+export function emptyHTML(html: string) {
+  return html === null || html === '';
+}


### PR DESCRIPTION
This is a subset of #530 that can land today without feature flags. Instead of doing 3 mixins and calling up the super chain, we can just branch in the one place and compose together the "fixer" functions. These only need to be applied when we are in the browser and that is why #530 has more guards around this.