### PR TITLE
Use correct casing for `Element.prototype.insertAdjacentHTML` position.

### DIFF
--- a/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
@@ -79,7 +79,7 @@ function shouldApplyFix(document: Document, svgNamespace: SVG_NAMESPACE) {
   let svg = document.createElementNS(svgNamespace, 'svg');
 
   try {
-    svg['insertAdjacentHTML']('beforeEnd', '<circle></circle>');
+    svg['insertAdjacentHTML']('beforeend', '<circle></circle>');
   } catch (e) {
     // IE, Edge: Will throw, insertAdjacentHTML is unsupported on SVG
     // Safari: Will throw, insertAdjacentHTML is not present on SVG

--- a/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
@@ -96,7 +96,7 @@ function shouldApplyFix(document: Document) {
   let mergingTextDiv: HTMLDivElement = document.createElement('div');
 
   mergingTextDiv.innerHTML = 'first';
-  mergingTextDiv.insertAdjacentHTML('beforeEnd', 'second');
+  mergingTextDiv.insertAdjacentHTML('beforeend', 'second');
 
   if (mergingTextDiv.childNodes.length === 2) {
     // It worked as expected, no fix required

--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -210,10 +210,10 @@ export function insertHTMLBefore(this: void, _useless: Simple.Element, _parent: 
   }
 
   if (nextSibling === null) {
-    parent.insertAdjacentHTML('beforeEnd', html);
+    parent.insertAdjacentHTML('beforeend', html);
     last = parent.lastChild;
   } else if (nextSibling instanceof HTMLElement) {
-    nextSibling.insertAdjacentHTML('beforeBegin', html);
+    nextSibling.insertAdjacentHTML('beforebegin', html);
     last = nextSibling.previousSibling;
   } else {
     // Non-element nodes do not support insertAdjacentHTML, so add an
@@ -222,7 +222,7 @@ export function insertHTMLBefore(this: void, _useless: Simple.Element, _parent: 
     // This also protects Edge, IE and Firefox w/o the inspector open
     // from merging adjacent text nodes. See ./compat/text-node-merging-fix.ts
     parent.insertBefore(useless, nextSibling);
-    useless.insertAdjacentHTML('beforeBegin', html);
+    useless.insertAdjacentHTML('beforebegin', html);
     last = useless.previousSibling;
     parent.removeChild(useless);
   }


### PR DESCRIPTION
Per https://w3c.github.io/DOM-Parsing/#widl-Element-insertAdjacentHTML-void-DOMString-position-DOMString-text the valid values 
are:

* `beforebegin`
* `afterbegin`
* `beforeend`
* `afterend`