### PR TITLE
Fix typing issue with compiler Syntax constraint.

### DIFF
--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -23,13 +23,12 @@ import { Block } from './interfaces';
 import RawInlineBlock from './raw-block';
 import Ops = WireFormat.Ops;
 
-export type SexpExpression = WireFormat.Expression;
-export type Syntax = WireFormat.Statement | WireFormat.Expression;
-export type CompilerFunction<T extends Syntax> = ((sexp: T, builder: OpcodeBuilder) => void);
+export type TupleSyntax = WireFormat.Statement | WireFormat.TupleExpression;
+export type CompilerFunction<T extends TupleSyntax> = ((sexp: T, builder: OpcodeBuilder) => void);
 
 export const ATTRS_BLOCK = '&attrs';
 
-class Compilers<T extends Syntax> {
+class Compilers<T extends TupleSyntax> {
   private names = dict<number>();
   private funcs: CompilerFunction<T>[] = [];
 
@@ -416,7 +415,7 @@ STATEMENTS.add(Ops.ClientSideStatement, (sexp: WireFormat.Statements.ClientSide,
   CLIENT_SIDE.compile(sexp as ClientSide.ClientSideStatement, builder);
 });
 
-const EXPRESSIONS = new Compilers<WireFormat.Expression>();
+const EXPRESSIONS = new Compilers<WireFormat.TupleExpression>();
 const CLIENT_SIDE_EXPRS = new Compilers<ClientSide.ClientSideExpression>(1);
 
 import E = WireFormat.Expressions;

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -50,14 +50,15 @@ export namespace Expressions {
    */
   export type MaybeLocal     = [Opcodes.MaybeLocal, Path];
 
-  export type Value          = str | number | boolean | null; // tslint:disable-line
+  export type Value          = str | number | boolean | null;
+
   export type HasBlock       = [Opcodes.HasBlock, YieldTo];
   export type HasBlockParams = [Opcodes.HasBlockParams, YieldTo];
   export type Undefined      = [Opcodes.Undefined];
   export type ClientSide     = [Opcodes.ClientSideExpression, any];
 
-  export type Expression =
-      Unknown
+  export type TupleExpression =
+    Unknown
     | Get
     | MaybeLocal
     | Concat
@@ -65,9 +66,10 @@ export namespace Expressions {
     | HasBlockParams
     | Helper
     | Undefined
-    | Value
     | ClientSide
     ;
+
+  export type Expression = TupleExpression | Value;
 
   export interface Concat extends Array<any> {
     [0]: Opcodes.Concat;
@@ -100,6 +102,8 @@ export namespace Expressions {
 }
 
 export type Expression = Expressions.Expression;
+
+export type TupleExpression = Expressions.TupleExpression;
 
 export namespace Statements {
   export type Expression = Expressions.Expression;


### PR DESCRIPTION
The compiler only expects tuple syntax, it is the function expr() that separates the 2.

supersedes #535 

```ts
export function expr(expression: WireFormat.Expression, builder: OpcodeBuilder): void {
  if (Array.isArray(expression)) { // Expressions.TupleExpression
    EXPRESSIONS.compile(expression, builder);
  } else { // Expressions.Value
    builder.primitive(expression);
  }
}
```