### PR TITLE
Adds `SyntaxError`

### DIFF
--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -7,6 +7,9 @@ export { default as traverse, NodeHandler, NodeVisitor, NodeHandlerFunction, Ent
 export { default as Walker } from './lib/traversal/walker';
 export { default as print } from './lib/generation/print';
 
+// errors
+export { default as SyntaxError } from './lib/errors/syntax-error';
+
 // AST
 import * as AST from './lib/types/nodes';
 export { AST };

--- a/packages/@glimmer/syntax/lib/errors/syntax-error.ts
+++ b/packages/@glimmer/syntax/lib/errors/syntax-error.ts
@@ -1,0 +1,23 @@
+import * as AST from '../types/nodes';
+
+/*
+ * Subclass of `Error` with additional information
+ * about location of incorrect markup.
+ */
+class SyntaxError {
+  message: string;
+  stack: string;
+  location: AST.SourceLocation;
+
+  constructor(message: string, location: AST.SourceLocation) {
+    let error = Error.call(this, message);
+
+    this.message = message;
+    this.stack = error.stack;
+    this.location = location;
+  }
+}
+
+SyntaxError.prototype = Object.create(Error.prototype);
+
+export default SyntaxError;

--- a/packages/@glimmer/syntax/lib/utils.ts
+++ b/packages/@glimmer/syntax/lib/utils.ts
@@ -1,5 +1,6 @@
 import * as AST from './types/nodes';
 import { Option } from "@glimmer/interfaces";
+import SyntaxError from './errors/syntax-error';
 
 // Regex to validate the identifier for block parameters.
 // Based on the ID validation regex in Handlebars.
@@ -29,7 +30,7 @@ function parseBlockParams(element: AST.ElementNode): Option<string[]> {
     // Some basic validation, since we're doing the parsing ourselves
     let paramsString = attrNames.slice(asIndex).join(' ');
     if (paramsString.charAt(paramsString.length - 1) !== '|' || paramsString.match(/\|/g)!.length !== 2) {
-      throw new Error('Invalid block parameters syntax: \'' + paramsString + '\'');
+      throw new SyntaxError('Invalid block parameters syntax: \'' + paramsString + '\'', element.loc);
     }
 
     let params = [];
@@ -37,14 +38,14 @@ function parseBlockParams(element: AST.ElementNode): Option<string[]> {
       let param = attrNames[i].replace(/\|/g, '');
       if (param !== '') {
         if (ID_INVERSE_PATTERN.test(param)) {
-          throw new Error('Invalid identifier for block parameters: \'' + param + '\' in \'' + paramsString + '\'');
+          throw new SyntaxError('Invalid identifier for block parameters: \'' + param + '\' in \'' + paramsString + '\'', element.loc);
         }
         params.push(param);
       }
     }
 
     if (params.length === 0) {
-      throw new Error('Cannot use zero block parameters: \'' + paramsString + '\'');
+      throw new SyntaxError('Cannot use zero block parameters: \'' + paramsString + '\'', element.loc);
     }
 
     element.attributes = element.attributes.slice(0, asIndex);


### PR DESCRIPTION
Adds a subclass of `Error` with additional `location` property. This helps to deliver error information to `broccoli-builder` and improve error reporting as described [here](https://github.com/ember-cli/ember-cli/issues/6441).

I believe this closes https://github.com/glimmerjs/glimmer-vm/issues/348