### PR TITLE
Restrict type for `StaticArg` from `Expression` to `Expressions.Value`.

### DIFF
--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -253,7 +253,7 @@ export default class JavaScriptCompiler<T extends TemplateMeta> {
   }
 
   staticArg(name: str) {
-    let value = this.popValue<Expression>();
+    let value = this.popValue<Expressions.Value>();
     this.push([Ops.StaticArg, name, value]);
   }
 

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -125,7 +125,7 @@ export namespace Statements {
   export type Yield         = [Opcodes.Yield, YieldTo, Option<Params>];
   export type Partial       = [Opcodes.Partial, Expression, Core.EvalInfo];
   export type DynamicArg    = [Opcodes.DynamicArg, str, Expression];
-  export type StaticArg     = [Opcodes.StaticArg, str, Expression];
+  export type StaticArg     = [Opcodes.StaticArg, str, Expressions.Value];
   export type TrustingAttr  = [Opcodes.TrustingAttr, str, Expression, str];
   export type Debugger      = [Opcodes.Debugger, Core.EvalInfo];
   export type ClientSide    = [Opcodes.ClientSideStatement, any];


### PR DESCRIPTION
@krisselden r?