### PR TITLE
[WIP] Replace inlined strings in WireFormat with index into strings array.

### DIFF
--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -59,12 +59,14 @@ const defaultOptions: PrecompileOptions<TemplateMeta> = {
 export function precompile<T extends TemplateMeta>(string: string, options?: PrecompileOptions<T>): TemplateJavascript;
 export function precompile(string: string, options: PrecompileOptions<TemplateMeta> = defaultOptions): TemplateJavascript {
   let ast = preprocess(string, options);
-  let { block, meta } = TemplateCompiler.compile(options, ast);
+  let { block, meta, strings } = TemplateCompiler.compile(options, ast);
   let idFn = options.id || defaultId;
   let blockJSON = JSON.stringify(block.toJSON());
+  let stringsJSON = JSON.stringify(strings);
   let templateJSONObject: SerializedTemplateWithLazyBlock<TemplateMeta> = {
     id: idFn(JSON.stringify(meta) + blockJSON),
     block: blockJSON,
+    strings: stringsJSON,
     meta
   };
 

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -259,23 +259,23 @@ export default class TemplateCompiler<T extends TemplateMeta> {
   }
 
   StringLiteral(action: AST.StringLiteral) {
-    this.opcode('literal', null, action.value);
+    this.opcode('literal', action, action.value);
   }
 
   BooleanLiteral(action: AST.BooleanLiteral) {
-    this.opcode('literal', null, action.value);
+    this.opcode('literal', action, action.value);
   }
 
   NumberLiteral(action: AST.NumberLiteral) {
-    this.opcode('literal', null, action.value);
+    this.opcode('literal', action, action.value);
   }
 
   NullLiteral(action: AST.NullLiteral) {
-    this.opcode('literal', null, action.value);
+    this.opcode('literal', action, action.value);
   }
 
   UndefinedLiteral(action: AST.UndefinedLiteral) {
-    this.opcode('literal', null, action.value);
+    this.opcode('literal', action, action.value);
   }
 
   /// Utilities
@@ -330,7 +330,7 @@ export default class TemplateCompiler<T extends TemplateMeta> {
       this.opcode('literal', null, key);
     }
 
-    this.opcode('prepareObject', null, pairs.length);
+    this.opcode('prepareObject', hash, pairs.length);
   }
 
   prepareAttributeValue(value: AST.AttrNode['value']) {
@@ -357,11 +357,11 @@ export default class TemplateCompiler<T extends TemplateMeta> {
       if (part.type === 'MustacheStatement') {
         this.attributeMustache([part]);
       } else if (part.type === 'TextNode') {
-        this.opcode('literal', null, part.chars);
+        this.opcode('literal', part, part.chars);
       }
     }
 
-    this.opcode('prepareArray', null, parts.length);
+    this.opcode('prepareArray', parts, parts.length);
   }
 
   attributeMustache([action]: [AST.MustacheStatement]) {

--- a/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
+++ b/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
@@ -6,6 +6,7 @@ export interface Symbols {
 
 export interface CompilationMeta {
   symbols: string[];
+  strings: string[];
   templateMeta: TemplateMeta;
   asPartial: boolean;
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -80,6 +80,10 @@ export abstract class BasicOpcodeBuilder {
     return this.heap.size();
   }
 
+  getString(index: number) {
+    return this.meta.strings[index];
+  }
+
   upvars<T extends [Opaque]>(count: number): T {
     return fillNulls(count) as T;
   }
@@ -561,10 +565,14 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
     let names = EMPTY_ARRAY;
 
     if (hash) {
-      names = hash[0];
-      let val = hash[1];
-      for (let i = 0; i < val.length; i++) {
-        expr(val[i], this);
+      let [nameIndexes, values] = hash;
+      names = new Array(nameIndexes.length);
+      for (let i = 0; i < nameIndexes.length; i++) {
+        names[i] = this.getString(nameIndexes[i]);
+      }
+
+      for (let i = 0; i < values.length; i++) {
+        expr(values[i], this);
       }
     }
 

--- a/packages/@glimmer/runtime/lib/scanner.ts
+++ b/packages/@glimmer/runtime/lib/scanner.ts
@@ -43,10 +43,11 @@ export default class Scanner {
     for (let i = 0; i < statements.length; i++) {
       let statement = statements[i];
       if (WireFormat.Statements.isComponent(statement)) {
-        let tagName = statement[1];
+        let tagNameIndex = statement[1];
+        let tagName = meta.strings[tagNameIndex];
         if (!this.env.hasComponentDefinition(tagName, meta.templateMeta)) {
           if (toplevel !== undefined) {
-            newStatements.push([Ops.OpenElement, tagName]);
+            newStatements.push([Ops.OpenElement, tagNameIndex]);
           } else {
             toplevel = tagName;
             decorateTopLevelElement(tagName, symbols, attrs, newStatements);
@@ -63,7 +64,8 @@ export default class Scanner {
         }
       } else {
         if (toplevel === undefined && WireFormat.Statements.isOpenElement(statement)) {
-          toplevel = statement[1];
+          let [,tagNameIndex] = statement;
+          toplevel = meta.strings[tagNameIndex];
           inTopLevel = true;
           decorateTopLevelElement(toplevel, symbols, attrs, newStatements);
         } else {

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -29,9 +29,9 @@ export function is<T>(variant: number): (value: any) => value is T {
 export namespace Core {
   export type Expression = Expressions.Expression;
 
-  export type Path          = str[];
+  export type Path          = number[];
   export type Params        = Expression[];
-  export type Hash          = Option<[str[], Expression[]]>;
+  export type Hash          = Option<[number[], Expression[]]>;
   export type Args          = [Params, Hash];
   export type EvalInfo      = number[];
 }
@@ -41,7 +41,7 @@ export namespace Expressions {
   export type Params = Core.Params;
   export type Hash = Core.Hash;
 
-  export type Unknown        = [Opcodes.Unknown, str];
+  export type Unknown        = [Opcodes.Unknown, number];
   export type Get            = [Opcodes.Get, number, Path];
 
   /**
@@ -78,7 +78,7 @@ export namespace Expressions {
 
   export interface Helper extends Array<any> {
     [0]: Opcodes.Helper;
-    [1]: str;
+    [1]: number;
     [2]: Params;
     [3]: Hash;
   }
@@ -111,22 +111,22 @@ export namespace Statements {
   export type Hash = Core.Hash;
   export type Path = Core.Path;
 
-  export type Text          = [Opcodes.Text, str];
+  export type Text          = [Opcodes.Text, number];
   export type Append        = [Opcodes.Append, Expression, boolean];
-  export type Comment       = [Opcodes.Comment, str];
-  export type Modifier      = [Opcodes.Modifier, str, Params, Hash];
-  export type Block         = [Opcodes.Block, str, Params, Hash, Option<SerializedInlineBlock>, Option<SerializedInlineBlock>];
-  export type Component     = [Opcodes.Component, str, Attribute[], Hash, Option<SerializedInlineBlock>];
-  export type OpenElement   = [Opcodes.OpenElement, str];
+  export type Comment       = [Opcodes.Comment, number];
+  export type Modifier      = [Opcodes.Modifier, number, Params, Hash];
+  export type Block         = [Opcodes.Block, number, Params, Hash, Option<SerializedInlineBlock>, Option<SerializedInlineBlock>];
+  export type Component     = [Opcodes.Component, number, Attribute[], Hash, Option<SerializedInlineBlock>];
+  export type OpenElement   = [Opcodes.OpenElement, number];
   export type FlushElement  = [Opcodes.FlushElement];
   export type CloseElement  = [Opcodes.CloseElement];
-  export type StaticAttr    = [Opcodes.StaticAttr, str, Expression, Option<str>];
-  export type DynamicAttr   = [Opcodes.DynamicAttr, str, Expression, Option<str>];
+  export type StaticAttr    = [Opcodes.StaticAttr, number, Expression, Option<str>];
+  export type DynamicAttr   = [Opcodes.DynamicAttr, number, Expression, Option<str>];
   export type Yield         = [Opcodes.Yield, YieldTo, Option<Params>];
   export type Partial       = [Opcodes.Partial, Expression, Core.EvalInfo];
-  export type DynamicArg    = [Opcodes.DynamicArg, str, Expression];
-  export type StaticArg     = [Opcodes.StaticArg, str, Expression];
-  export type TrustingAttr  = [Opcodes.TrustingAttr, str, Expression, str];
+  export type DynamicArg    = [Opcodes.DynamicArg, number, Expression];
+  export type StaticArg     = [Opcodes.StaticArg, number, Expression];
+  export type TrustingAttr  = [Opcodes.TrustingAttr, number, Expression, str];
   export type Debugger      = [Opcodes.Debugger, Core.EvalInfo];
   export type ClientSide    = [Opcodes.ClientSideStatement, any];
 
@@ -194,7 +194,7 @@ export namespace Statements {
     return isAttribute(val) || isArgument(val);
   }
 
-  export function getParameterName(s: Parameter): string {
+  export function getParameterName(s: Parameter): number {
     return s[1];
   }
 }
@@ -232,6 +232,7 @@ export interface SerializedTemplateBlock extends SerializedBlock {
  */
 export interface SerializedTemplate<T extends TemplateMeta> {
   block: SerializedTemplateBlock;
+  strings: string[];
   meta: T;
 }
 
@@ -240,12 +241,15 @@ export interface SerializedTemplate<T extends TemplateMeta> {
  */
 export type SerializedTemplateBlockJSON = string;
 
+export type SerializedStringsJSON = string;
+
 /**
  * A JSON object containing the SerializedTemplateBlock as JSON and TemplateMeta.
  */
 export interface SerializedTemplateWithLazyBlock<T extends TemplateMeta> {
   id?: Option<string>;
   block: SerializedTemplateBlockJSON;
+  strings: SerializedStringsJSON;
   meta: T;
 }
 


### PR DESCRIPTION
Input:

```hbs
<div class="derp">foo{{bar}}</div><div class="huzzah">derp{{ha.ha.ha}}</div><div></div><div></div>'
```

Before Precompile Output:

```js
{
  "id":null,
  "block":"{\"symbols\":[],\"statements\":[[6,\"div\"],[9,\"class\",\"derp\"],[7],[0,\"foo\"],[1,[18,\"bar\"],false],[8],[6,\"div\"],[9,\"class\",\"huzzah\"],[7],[0,\"derp\"],[1,[20,[\"ha\",\"ha\",\"ha\"]],false],[8],[6,\"div\"],[7],[8],[6,\"div\"],[7],[8]],\"hasEval\":false}",
  "meta":{}
}
```

After Precompile Output:

```js
{
  "id":null,
  "block":"{\"symbols\":[],\"statements\":[[6,0],[9,1,\"derp\"],[7],[0,2],[1,[18,3],false],[8],[6,0],[9,1,\"huzzah\"],[7],[0,4],[1,[20,[5,5,5]],false],[8],[6,0],[7],[8],[6,0],[7],[8]],\"hasEval\":false}",
  "strings":"[\"div\",\"class\",\"foo\",\"bar\",\"derp\",\"ha\"]",
  "meta":{}
}
```

---

- [ ] Confirm actual file savings against real world apps.
- [ ] Confirm that this does not regress resulting gzip sizes.
- [ ] Sanity check