### PR TITLE
Types for AST transform plugins

### DIFF
--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -2,6 +2,7 @@ import { preprocess } from "@glimmer/syntax";
 import TemplateCompiler, { CompileOptions } from "./template-compiler";
 import { SerializedTemplateWithLazyBlock, TemplateJavascript, TemplateMeta } from "@glimmer/wire-format";
 import { Option } from "@glimmer/interfaces";
+import { TransformASTPluginFactory } from "@glimmer/syntax";
 
 export interface TemplateIdFn {
   (src: string): Option<string>;
@@ -9,6 +10,9 @@ export interface TemplateIdFn {
 
 export interface PrecompileOptions<T extends TemplateMeta> extends CompileOptions<T> {
   id?: TemplateIdFn;
+  plugins?: {
+    ast?: TransformASTPluginFactory[]
+  };
 }
 
 declare function require(id: string): any;

--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -1,5 +1,10 @@
 // used by ember-compiler
-export { preprocess } from './lib/parser/tokenizer-event-handlers';
+export {
+  preprocess,
+  TransformASTPlugin,
+  TransformASTPluginFactory,
+  Syntax
+} from './lib/parser/tokenizer-event-handlers';
 
 // needed for tests only
 export { default as builders } from './lib/builders';

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -306,7 +306,27 @@ export const syntax: Syntax = {
   Walker
 };
 
-export function preprocess(html: string, options?: any): AST.Program {
+/**
+ * TransformASTPlugins can make changes to the Glimmer template AST before
+ * compilation begins. Plugins implement a `transform()` method that takes a
+ * `Program` AST node and should return the modified program.
+ */
+export interface TransformASTPlugin {
+  syntax: Syntax;
+  transform(program: AST.Program): AST.Program;
+}
+
+export interface TransformASTPluginFactory {
+  new (options: PreprocessOptions): TransformASTPlugin;
+}
+
+export interface PreprocessOptions {
+  plugins?: {
+    ast?: TransformASTPluginFactory[]
+  };
+}
+
+export function preprocess(html: string, options?: PreprocessOptions): AST.Program {
   let ast = (typeof html === 'object') ? html : parse(html);
   let combined = new TokenizerEventHandlers(html, options).acceptNode(ast);
 

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -1,4 +1,4 @@
-import { preprocess as parse, Walker } from '@glimmer/syntax';
+import { preprocess as parse, Walker, Syntax, AST } from '@glimmer/syntax';
 
 const { test } = QUnit;
 
@@ -7,10 +7,14 @@ QUnit.module('[glimmer-syntax] Plugins - AST Transforms');
 test('AST plugins can be provided to the compiler', assert => {
   assert.expect(1);
 
-  function Plugin() { }
-  Plugin.prototype.transform = function() {
-    assert.ok(true, 'transform was called!');
-  };
+  class Plugin {
+    syntax: Syntax;
+
+    transform(program: AST.Program): AST.Program {
+      assert.ok(true, 'transform was called!');
+      return program;
+    }
+  }
 
   parse('<div></div>', {
     plugins: {
@@ -22,10 +26,13 @@ test('AST plugins can be provided to the compiler', assert => {
 test('provides syntax package as `syntax` prop if value is null', assert => {
   assert.expect(1);
 
-  function Plugin() { }
-  Plugin.prototype.transform = function() {
-    assert.equal(this.syntax.Walker, Walker);
-  };
+  class Plugin {
+    syntax: Syntax;
+    transform(program: AST.Program): AST.Program {
+      assert.equal(this.syntax.Walker, Walker);
+      return program;
+    }
+  }
 
   parse('<div></div>', {
     plugins: {
@@ -37,12 +44,21 @@ test('provides syntax package as `syntax` prop if value is null', assert => {
 test('AST plugins can modify the AST', assert => {
   assert.expect(1);
 
-  let expected = "OOOPS, MESSED THAT UP!";
-
-  function Plugin() { }
-  Plugin.prototype.transform = function() {
-    return expected;
-  };
+  class Plugin {
+    syntax: Syntax;
+    transform(): AST.Program {
+      return {
+        type: 'Program',
+        body: [],
+        blockParams: [],
+        isSynthetic: true,
+        loc: {
+          start: { line: 0, column: 0 },
+          end: { line: 0, column: 1 }
+        }
+      } as AST.Program;
+    }
+  }
 
   let ast = parse('<div></div>', {
     plugins: {
@@ -50,25 +66,44 @@ test('AST plugins can modify the AST', assert => {
     }
   });
 
-  assert.equal(ast, expected, 'return value from AST transform is used');
+  assert.ok(ast['isSynthetic'], 'return value from AST transform is used');
 });
 
 test('AST plugins can be chained', assert => {
   assert.expect(2);
 
-  let expected = "OOOPS, MESSED THAT UP!";
+  class Plugin {
+    syntax: Syntax;
+    transform(): AST.Program {
+      return {
+        type: 'Program',
+        body: [],
+        blockParams: [],
+        isFromFirstPlugin: true,
+        loc: {
+          start: { line: 0, column: 0 },
+          end: { line: 0, column: 1 }
+        }
+      } as AST.Program;
+    }
+  }
 
-  function Plugin() { }
-  Plugin.prototype.transform = function() {
-    return expected;
-  };
-
-  function SecondaryPlugin() { }
-  SecondaryPlugin.prototype.transform = function(ast: any) {
-    assert.equal(ast, expected, 'return value from AST transform is used');
-
-    return 'BOOM!';
-  };
+  class SecondaryPlugin {
+    syntax: Syntax;
+    transform(program: AST.Program) {
+      assert.equal(program['isFromFirstPlugin'], true, 'AST from first plugin is passed to second');
+      return {
+        type: 'Program',
+        body: [],
+        blockParams: [],
+        isFromSecondPlugin: true,
+        loc: {
+          start: { line: 0, column: 0 },
+          end: { line: 0, column: 1 }
+        }
+      } as AST.Program;
+    }
+  }
 
   let ast = parse('<div></div>', {
     plugins: {
@@ -79,5 +114,5 @@ test('AST plugins can be chained', assert => {
     }
   });
 
-  assert.equal(ast, 'BOOM!', 'return value from last AST transform is used');
+  assert.equal(ast['isFromSecondPlugin'], true, 'return value from last AST transform is used');
 });


### PR DESCRIPTION
You can pass AST transform plugins to the `preprocess`/`precompile` options but previously the options hash was untyped. This PR adds types for the options hash as well as types for AST plugins.