### PR TITLE
[BREAKING] Use plain functions for AST plugins.

### DIFF
--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -2,17 +2,14 @@ import { preprocess } from "@glimmer/syntax";
 import TemplateCompiler, { CompileOptions } from "./template-compiler";
 import { SerializedTemplateWithLazyBlock, TemplateJavascript, TemplateMeta } from "@glimmer/wire-format";
 import { Option } from "@glimmer/interfaces";
-import { TransformASTPluginFactory } from "@glimmer/syntax";
+import { PreprocessOptions } from "@glimmer/syntax";
 
 export interface TemplateIdFn {
   (src: string): Option<string>;
 }
 
-export interface PrecompileOptions<T extends TemplateMeta> extends CompileOptions<T> {
+export interface PrecompileOptions<T extends TemplateMeta> extends CompileOptions<T>, PreprocessOptions {
   id?: TemplateIdFn;
-  plugins?: {
-    ast?: TransformASTPluginFactory[]
-  };
 }
 
 declare function require(id: string): any;

--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -1,8 +1,9 @@
 // used by ember-compiler
 export {
   preprocess,
-  TransformASTPlugin,
-  TransformASTPluginFactory,
+  PreprocessOptions,
+  ASTPlugin,
+  ASTPluginEnvironment,
   Syntax
 } from './lib/parser/tokenizer-event-handlers';
 

--- a/packages/@glimmer/syntax/lib/traversal/traverse.ts
+++ b/packages/@glimmer/syntax/lib/traversal/traverse.ts
@@ -7,37 +7,21 @@ import {
 import * as nodes from '../types/nodes';
 import { Option } from "@glimmer/interfaces";
 
-export interface NodeVisitor {
-  All?: NodeHandler<nodes.BaseNode>;
-  Program?: NodeHandler<nodes.Program>;
-  MustacheStatement?: NodeHandler<nodes.MustacheStatement>;
-  BlockStatement?: NodeHandler<nodes.BlockStatement>;
-  ElementModifierStatement?: NodeHandler<nodes.ElementModifierStatement>;
-  PartialStatement?: NodeHandler<nodes.PartialStatement>;
-  CommentStatement?: NodeHandler<nodes.CommentStatement>;
-  MustacheCommentStatement?: NodeHandler<nodes.MustacheCommentStatement>;
-  ElementNode?: NodeHandler<nodes.ElementNode>;
-  AttrNode?: NodeHandler<nodes.AttrNode>;
-  TextNode?: NodeHandler<nodes.TextNode>;
-  ConcatStatement?: NodeHandler<nodes.ConcatStatement>;
-  SubExpression?: NodeHandler<nodes.SubExpression>;
-  PathExpression?: NodeHandler<nodes.PathExpression>;
-  StringLiteral?: NodeHandler<nodes.StringLiteral>;
-  BooleanLiteral?: NodeHandler<nodes.BooleanLiteral>;
-  NumberLiteral?: NodeHandler<nodes.NumberLiteral>;
-  UndefinedLiteral?: NodeHandler<nodes.UndefinedLiteral>;
-  NullLiteral?: NodeHandler<nodes.NullLiteral>;
-  Hash?: NodeHandler<nodes.Hash>;
-  HashPair?: NodeHandler<nodes.HashPair>;
+export type NodeHandler<T extends nodes.Node> = NodeHandlerFunction<T> | EnterExitNodeHandler<T>;
+
+export type SpecificNodeVisitor = {
+  [P in keyof nodes.Nodes]?: NodeHandler<nodes.Nodes[P]>;
+};
+
+export interface NodeVisitor extends SpecificNodeVisitor {
+  All?: NodeHandler<nodes.Node>;
 }
 
-export type NodeHandler<T> = NodeHandlerFunction<T> | EnterExitNodeHandler<T>;
-
-export interface NodeHandlerFunction<T> {
-  (node: T): any | null | undefined;
+export interface NodeHandlerFunction<T extends nodes.Node> {
+  (this: null, node: T): any | null | undefined;
 }
 
-export interface EnterExitNodeHandler<T> {
+export interface EnterExitNodeHandler<T extends nodes.Node> {
   enter?: NodeHandlerFunction<T>;
   exit?: NodeHandlerFunction<T>;
   keys?: any;


### PR DESCRIPTION
This changes AST Plugins to be "plain functions" with the following interface:

```ts
import { AST, Syntax } from '@glimmer/syntax';

export type NodeVisitor = {
  [P in keyof AST.Nodes]?: NodeHandler<AST.Nodes[P]>;
};

export interface ASTPluginResult {
  name: string;
  visitors: NodeVisitor;
}

export interface ASTPlugin {
  (env: ASTPluginEnvironment): ASTPluginResult;
}

export interface ASTPluginEnvironment {
  meta?: any;
  syntax: Syntax;
}
```

The current system of instantiation is fairly confusing and makes a number of use cases pretty difficult (where you need to preserve some other outside state that you access from within your plugin's `transform`).

The old API can easily be reimplemented in terms of the plain functions in consumers (e.g. Ember for compatibility):

```js
let uuid = 0;

  function ensurePlugin(FunctionOrPlugin: any): ASTPlugin {
    if (FunctionOrPlugin.prototype && FunctionOrPlugin.prototype.transform) {
      return (env) => {
        return {
          name: 'legacy-transform' + (++uuid) ,
          visitors: {
            Program(node: AST.Program) {
              let plugin = new FunctionOrPlugin(env);

              plugin.syntax = env.syntax;

              return plugin.transform(node);
            }
          }
        };
      };
    } else {
      return FunctionOrPlugin;
    }
  }
```

A test exists for this (to ensure Ember can provide backwards compat).