### PR TITLE
Convert `SyntaxError` and `TraversalError` to ES5 syntax

### DIFF
--- a/packages/@glimmer/syntax/lib/errors/syntax-error.ts
+++ b/packages/@glimmer/syntax/lib/errors/syntax-error.ts
@@ -1,23 +1,32 @@
 import * as AST from '../types/nodes';
 
-/*
+export interface SyntaxError extends Error {
+  location: AST.SourceLocation;
+  constructor: SyntaxErrorConstructor;
+}
+
+export interface SyntaxErrorConstructor {
+  new (message: string, location: AST.SourceLocation): SyntaxError;
+  readonly prototype: SyntaxError;
+}
+
+/**
  * Subclass of `Error` with additional information
  * about location of incorrect markup.
  */
-class SyntaxError {
-  message: string;
-  stack: string;
-  location: AST.SourceLocation;
+const SyntaxError: SyntaxErrorConstructor = (function () {
+  SyntaxError.prototype = Object.create(Error.prototype);
+  SyntaxError.prototype.constructor = SyntaxError;
 
-  constructor(message: string, location: AST.SourceLocation) {
+  function SyntaxError(this: SyntaxError, message: string, location: AST.SourceLocation) {
     let error = Error.call(this, message);
 
     this.message = message;
     this.stack = error.stack;
     this.location = location;
   }
-}
 
-SyntaxError.prototype = Object.create(Error.prototype);
+  return SyntaxError as any;
+}());
 
 export default SyntaxError;

--- a/packages/@glimmer/syntax/lib/traversal/errors.ts
+++ b/packages/@glimmer/syntax/lib/traversal/errors.ts
@@ -1,14 +1,34 @@
 import * as AST from '../types/nodes';
 import { Option } from '@glimmer/interfaces';
 
-class TraversalError extends Error {
-  constructor(message: string, public node: AST.Node, public parent: Option<AST.Node>, public key: string) {
-    super(message);
-  }
+export interface TraversalError extends Error {
+  constructor: TraversalErrorConstructor;
+  key: string;
+  node: AST.Node;
+  parent: Option<AST.Node>;
 }
 
-TraversalError.prototype = Object.create(Error.prototype);
-TraversalError.prototype.constructor = TraversalError;
+export interface TraversalErrorConstructor {
+  new (message: string, node: AST.Node, parent: Option<AST.Node>, key: string): TraversalError;
+  readonly prototype: TraversalError;
+}
+
+const TraversalError: TraversalErrorConstructor = (function () {
+  TraversalError.prototype = Object.create(Error.prototype);
+  TraversalError.prototype.constructor = TraversalError;
+
+  function TraversalError(this: TraversalError, message: string, node: AST.Node, parent: Option<AST.Node>, key: string) {
+    let error = Error.call(this, message);
+
+    this.key = key;
+    this.message = message;
+    this.node = node;
+    this.parent = parent;
+    this.stack = error.stack;
+  }
+
+  return TraversalError as any;
+}());
 
 export default TraversalError;
 


### PR DESCRIPTION
The `prototype` property on classes is readonly.

This is basically copypasta from @krisselden. Thanks!