### PR TITLE
Don't emit `UpdateModiferOpcode` is `Modifier` tag is constant

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -2,6 +2,7 @@
 import {
   CachedReference,
   combineTagged,
+  CONSTANT_TAG,
   isConst as isConstReference,
   isModified,
   PathReference,
@@ -343,11 +344,13 @@ APPEND_OPCODES.add(Op.Modifier, (vm, { op1: _manager }) => {
     vm.newDestroyable(destructor);
   }
 
-  vm.updateWith(new UpdateModifierOpcode(
-    tag,
-    manager,
-    modifier,
-  ));
+  if (tag !== CONSTANT_TAG) {
+    vm.updateWith(new UpdateModifierOpcode(
+      tag,
+      manager,
+      modifier,
+    ));
+  }
 });
 
 export class UpdateModifierOpcode extends UpdatingOpcode {

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -86,6 +86,14 @@ function assertInvariants(assert: Assert, result: RenderResult, msg?: string) {
   assert.strictEqual(result.lastNode(), root.lastChild, `The lastNode of the result is the same as the root's lastChild${msg ? ': ' + msg : ''}`);
 }
 
+function assertHasUpdateOpcodes(assert: Assert, result) {
+  assert.ok(result.updating._head, "There should be update opcodes");
+}
+
+function assertHasNoUpdateOpcodes(assert: Assert, result) {
+  assert.equal(result.updating._head, null, "There shouldn't be update opcodes");
+}
+
 module("[glimmer-runtime] Updating", hooks => {
   hooks.beforeEach(() => commonSetup());
 
@@ -2867,6 +2875,7 @@ QUnit.module("Updating Element Modifiers", hooks => {
     assert.equal(valueNode, manager.installedElements[0]);
     assert.equal(manager.updatedElements.length, 0);
     assert.equal(manager.destroyedModifiers.length, 0);
+    assertHasUpdateOpcodes(assert, result);
 
     rerender();
 
@@ -2908,6 +2917,7 @@ QUnit.module("Updating Element Modifiers", hooks => {
     assert.equal(valueNode, manager.installedElements[0]);
     assert.equal(manager.updatedElements.length, 0);
     assert.equal(manager.destroyedModifiers.length, 0);
+    assertHasNoUpdateOpcodes(assert, result);
 
     rerender();
 


### PR DESCRIPTION
Supersedes https://github.com/glimmerjs/glimmer-vm/pull/432

We currently always emit an `UpdateModiferOpcode`, even when the tag is constant. We should only emit an update opcode if the tag is non constant.

fixes https://github.com/glimmerjs/glimmer-vm/issues/429