### PR TITLE
[BREAKING] Update ASTPluginResult to use `visitor` (no plural form).

### DIFF
--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -3,6 +3,7 @@ export {
   preprocess,
   PreprocessOptions,
   ASTPlugin,
+  ASTPluginBuilder,
   ASTPluginEnvironment,
   Syntax
 } from './lib/parser/tokenizer-event-handlers';

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -311,13 +311,13 @@ export const syntax: Syntax = {
   ASTPlugins can make changes to the Glimmer template AST before
   compilation begins.
 */
-export interface ASTPlugin {
-  (env: ASTPluginEnvironment): ASTPluginResult;
+export interface ASTPluginBuilder {
+  (env: ASTPluginEnvironment): ASTPlugin;
 }
 
-export interface ASTPluginResult {
+export interface ASTPlugin {
   name: string;
-  visitors: NodeVisitor;
+  visitor: NodeVisitor;
 }
 
 export interface ASTPluginEnvironment {
@@ -327,7 +327,7 @@ export interface ASTPluginEnvironment {
 
 export interface PreprocessOptions {
   plugins?: {
-    ast?: ASTPlugin[];
+    ast?: ASTPluginBuilder[];
   };
 }
 
@@ -342,7 +342,7 @@ export function preprocess(html: string, options?: PreprocessOptions): AST.Progr
 
       let pluginResult = transform(env);
 
-      traverse(program, pluginResult.visitors);
+      traverse(program, pluginResult.visitor);
     }
   }
 

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -3,7 +3,8 @@ import {
   Syntax,
   Walker,
   AST,
-  ASTPlugin
+  ASTPluginEnvironment,
+  ASTPluginBuilder
 } from '@glimmer/syntax';
 
 const { test } = QUnit;
@@ -18,7 +19,7 @@ test('function based AST plugins can be provided to the compiler', assert => {
       ast: [
         () => ({
           name: 'plugin-a',
-          visitors: {
+          visitor: {
             Program() {
               assert.ok(true, 'transform was called!');
             }
@@ -38,7 +39,7 @@ test('plugins are provided the syntax package', assert => {
         ({ syntax }) => {
           assert.equal(syntax.Walker, Walker);
 
-          return { name: 'plugin-a', visitors: {} };
+          return { name: 'plugin-a', visitor: {} };
         }
       ]
     }
@@ -46,13 +47,13 @@ test('plugins are provided the syntax package', assert => {
 });
 
 test('can support the legacy AST transform API via ASTPlugin', assert => {
-  function ensurePlugin(FunctionOrPlugin: any): ASTPlugin {
+  function ensurePlugin(FunctionOrPlugin: any): ASTPluginBuilder {
     if (FunctionOrPlugin.prototype && FunctionOrPlugin.prototype.transform) {
-      return (env) => {
+      return (env: ASTPluginEnvironment) => {
         return {
           name: 'plugin-a',
 
-          visitors: {
+          visitor: {
             Program(node: AST.Program) {
               let plugin = new FunctionOrPlugin(env);
 
@@ -90,7 +91,7 @@ test('AST plugins can be chained', assert => {
   let first = () => {
     return {
       name: 'first',
-      visitors: {
+      visitor: {
         Program(program: AST.Program) {
           program['isFromFirstPlugin'] = true;
         }
@@ -101,7 +102,7 @@ test('AST plugins can be chained', assert => {
   let second = () => {
     return {
       name: 'second',
-      visitors: {
+      visitor: {
         Program(node: AST.Program) {
           assert.equal(node['isFromFirstPlugin'], true, 'AST from first plugin is passed to second');
 
@@ -114,7 +115,7 @@ test('AST plugins can be chained', assert => {
   let third = () => {
     return {
       name: 'third',
-      visitors: {
+      visitor: {
         Program(node: AST.Program) {
           assert.equal(node['isFromSecondPlugin'], true, 'AST from second plugin is passed to third');
 


### PR DESCRIPTION
The recent refactor mistakenly used the plural form (`visitors`), and should have used `visitor`.

This fixes the mistake mentioned in https://github.com/glimmerjs/glimmer-vm/commit/28652d4ea214f1c7bf0251d4b4b23853d9f0a787#commitcomment-22696220.

/cc @mmun @chriseppstein