### PR TITLE
[BREAKING] Make the manager decide what tag to use

### DIFF
--- a/packages/@glimmer/reference/lib/validators.ts
+++ b/packages/@glimmer/reference/lib/validators.ts
@@ -81,7 +81,15 @@ export function isVolatile({ tag }: Tagged): boolean {
   return tag === VOLATILE_TAG;
 }
 
+export function isVolatileTag(tag: Tag): boolean {
+  return tag === VOLATILE_TAG;
+}
+
 export function isConst({ tag }: Tagged): boolean {
+  return tag === CONSTANT_TAG;
+}
+
+export function isConstTag(tag: Tag): boolean {
   return tag === CONSTANT_TAG;
 }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -4,7 +4,8 @@ import {
   Revision,
   Tag,
   VersionedReference,
-  isConst
+  isConst,
+  isConstTag
 } from '@glimmer/reference';
 import { Opaque, Option } from '@glimmer/util';
 import { Simple } from '@glimmer/interfaces';
@@ -83,7 +84,6 @@ APPEND_OPCODES.add(Op.Modifier, (vm, { op1: _manager }) => {
   let manager = vm.constants.getOther<ModifierManager<Opaque>>(_manager);
   let stack = vm.stack;
   let args = stack.pop<Arguments>();
-  let tag = args.tag;
   let { constructing: element, updateOperations } = vm.elements();
   let dynamicScope = vm.dynamicScope();
   let modifier = manager.create(element as Simple.FIX_REIFICATION<Element>, args, dynamicScope, updateOperations);
@@ -97,11 +97,13 @@ APPEND_OPCODES.add(Op.Modifier, (vm, { op1: _manager }) => {
     vm.newDestroyable(destructor);
   }
 
-  if (!isConst(args)) {
+  let tag = manager.getTag(modifier);
+
+  if (!isConstTag(tag)) {
     vm.updateWith(new UpdateModifierOpcode(
       tag,
       manager,
-      modifier,
+      modifier
     ));
   }
 });

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -39,6 +39,10 @@ export interface ComponentManager<T extends Component> {
   // it should use in the layout.
   getSelf(component: T): VersionedPathReference<Opaque>;
 
+  // Convert the opaque component into a `RevisionTag` that determins when
+  // the component's update hooks need to be called (if at all).
+  getTag(component: T): Tag;
+
   // The `didCreateElement` hook is run for non-tagless components after the
   // element as been created, but before it has been appended ("flushed") to
   // the DOM. This hook allows the manager to save off the element, as well as
@@ -58,15 +62,8 @@ export interface ComponentManager<T extends Component> {
   // the `didCreate` callbacks.
   didCreate(component: T): void;
 
-  // Convert the opaque component into a `RevisionTag` that determins when
-  // the component's update hooks need to be called, in addition to any
-  // outside changes captured in the input arguments. If it returns null,
-  // the update hooks will only be called when one or more of the input
-  // arguments has changed.
-  getTag(component: T): Option<Tag>;
-
-  // When the input arguments have changed, and top-down revalidation has
-  // begun, the manager's `update` hook is called.
+  // When the component's tag has invalidated, the manager's `update` hook is
+  // called.
   update(component: T, dynamicScope: DynamicScope): void;
 
   // This hook is run after the entire layout has been updated.

--- a/packages/@glimmer/runtime/lib/modifier/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/modifier/interfaces.ts
@@ -3,18 +3,24 @@ import { DOMChanges } from '../dom/helper';
 import { DynamicScope } from '../environment';
 import { Destroyable } from '@glimmer/util';
 import { Option } from "@glimmer/interfaces";
+import { Tag } from '@glimmer/reference';
 
 export interface ModifierManager<T> {
   // Create is meant to only produce the state bucket
   create(element: Element, args: IArguments, dynamicScope: DynamicScope, dom: DOMChanges): T;
+
+  // Convert the opaque modifier into a `RevisionTag` that determins when
+  // the modifier's update hooks need to be called (if at all).
+  getTag(component: T): Tag;
+
   // At initial render, the modifier gets a chance to install itself on the
   // element it is managing. It can also return a bucket of state that
   // it could use at update time. From the perspective of Glimmer, this
   // is an opaque token.
   install(modifier: T): void;
 
-  // When the args have changed, the modifier's `update` hook is called
-  // with its state bucket as well as the updated args.
+  // When the modifier's tag has invalidated, the manager's `update` hook is
+  // called.
   update(modifier: T): void;
 
   // Convert the opaque token into an object that implements Destroyable.


### PR DESCRIPTION
This is a follow-up from 1908dbe.

Currently we automatically combine the tag from the args object with an optional dirtiness tag returned by Manager#getTag. After this change the component/modifier is responsible for fully deciding what tag to use.

To preserve the existing behavior, just continue to combine the args tag (which you could save off in `create`) with whatever you were returning before. However, this also allows the component to opt-out of updating by returning a `CONSTANT_TAG` if it doesn't use the args.

With this, components will get const-optimization correctly.