### PR TITLE
[CLEANUP] Remove the use of angle type assertion

### DIFF
--- a/packages/@glimmer/object-reference/lib/meta.ts
+++ b/packages/@glimmer/object-reference/lib/meta.ts
@@ -90,7 +90,7 @@ class Meta implements IMeta, HasGuid {
   static for(obj: any): IMeta {
     if (obj === null || obj === undefined) return new Meta(obj, {});
     if (hasOwnProperty.call(obj, '_meta') && obj._meta) return obj._meta;
-    if (!Object.isExtensible(obj)) return <any>new ConstMeta(obj);
+    if (!Object.isExtensible(obj)) return new ConstMeta(obj) as any;
 
     let MetaToUse: typeof Meta = Meta;
 

--- a/packages/@glimmer/object-reference/lib/references/path.ts
+++ b/packages/@glimmer/object-reference/lib/references/path.ts
@@ -45,7 +45,7 @@ export default class PathReference<T> implements IPathReference<T>, HasGuid {
 
   get(prop: string): IPathReference<any> {
     let chains = this._getChains();
-    if (<string>prop in chains) return chains[prop];
+    if (prop as string in chains) return chains[prop];
     return (chains[prop] = new PathReference(this, prop));
   }
 

--- a/packages/@glimmer/object-reference/lib/references/root.ts
+++ b/packages/@glimmer/object-reference/lib/references/root.ts
@@ -21,13 +21,13 @@ export default class RootReference<T> implements IRootReference<T>, IPathReferen
 
   get<U>(prop: string): IPathReference<U> {
     let chains = this.chains;
-    if (<string>prop in chains) return chains[prop];
+    if (prop as string in chains) return chains[prop];
     return (chains[prop] = new PathReference(this, prop));
   }
 
   chainFor<U>(prop: string): Option<IPathReference<U>> {
     let chains = this.chains;
-    if (<string>prop in chains) return chains[prop];
+    if (prop as string in chains) return chains[prop];
     return null;
   }
 

--- a/packages/@glimmer/object/lib/computed.ts
+++ b/packages/@glimmer/object/lib/computed.ts
@@ -90,7 +90,7 @@ function wrapAccessor(home: Object, accessorName: string, _desc: ComputedDescrip
   if (get && get.length > 0) {
     originalGet = function(this: any) { return (get as any).call(this, accessorName); };
   } else {
-    originalGet = <ComputedGetCallback>_desc.get;
+    originalGet = _desc.get as ComputedGetCallback;
   }
 
   let set = _desc.set;
@@ -100,7 +100,7 @@ function wrapAccessor(home: Object, accessorName: string, _desc: ComputedDescrip
       return (set as any).call(this, accessorName, value);
     };
   } else {
-    originalSet = <ComputedGetCallback>_desc.set;
+    originalSet = _desc.set as ComputedGetCallback;
   }
 
   let cacheGet = function(this: any) {
@@ -188,10 +188,10 @@ export function computed(...args: any[]) {
 
   if (typeof last === 'function') {
     return new ComputedBlueprint({
-      get: <ComputedGetCallback | LegacyComputedGetCallback>last
+      get: last as ComputedGetCallback | LegacyComputedGetCallback
     }).property(...deps);
   } else if (typeof last === 'object') {
-    return new ComputedBlueprint(<ComputedDescriptor>last).property(...deps);
+    return new ComputedBlueprint(last as ComputedDescriptor).property(...deps);
   } else {
     throw new TypeError("computed expects a function or an object as last argument");
   }

--- a/packages/@glimmer/object/lib/descriptors.ts
+++ b/packages/@glimmer/object/lib/descriptors.ts
@@ -11,7 +11,7 @@ class AliasMethodDescriptor extends Descriptor {
   }
 
   define(target: Object, key: string, _home: Object) {
-    let name = <string>this.name;
+    let name = this.name as string;
 
     Object.defineProperty(target, key, {
       enumerable: true,

--- a/packages/@glimmer/object/lib/mixin.ts
+++ b/packages/@glimmer/object/lib/mixin.ts
@@ -44,10 +44,10 @@ export class Mixin {
     if (args.length === 0) {
       return new this({}, []);
     } else if (extensions instanceof Mixin) {
-      return new this({}, <Mixin[]>args);
+      return new this({}, args as Mixin[]);
     } else {
       let deps = args.slice(0, -1).map(toMixin);
-      return new this(<Extensions>extensions, deps);
+      return new this(extensions as Extensions, deps);
     }
   }
 
@@ -86,11 +86,11 @@ export class Mixin {
       let rawConcat = extensions.concatenatedProperties;
 
       if (isArray(rawConcat)) {
-        concat = (<string[]>rawConcat).slice();
+        concat = (rawConcat as string[]).slice();
       } else if (rawConcat === null || rawConcat === undefined) {
         concat = [];
       } else {
-        concat = [<string>rawConcat];
+        concat = [rawConcat as string];
       }
 
       delete extensions.concatenatedProperties;
@@ -102,11 +102,11 @@ export class Mixin {
       let rawMerged = extensions.mergedProperties;
 
       if (isArray(rawMerged)) {
-        merged = (<string[]>rawMerged).slice();
+        merged = (rawMerged as string[]).slice();
       } else if (rawMerged === null || rawMerged === undefined) {
         merged = [];
       } else {
-        merged = [<string>rawMerged];
+        merged = [rawMerged as string];
       }
 
       delete extensions.mergedProperties;
@@ -178,18 +178,18 @@ export class Mixin {
 
     Object.keys(this.extensions).forEach(key => {
       let extension: Blueprint = this.extensions![key];
-      let desc = extension.descriptor(target, <string>key, meta);
-      desc.define(target, <string>key, parent);
+      let desc = extension.descriptor(target, key as string, meta);
+      desc.define(target, key as string, parent);
     });
 
-    new ValueDescriptor({ value: ROOT }).define(target, <string>'_super');
+    new ValueDescriptor({ value: ROOT }).define(target, '_super' as string);
   }
 }
 
 export type Extension = Mixin | Extensions;
 
 export function extend<T extends GlimmerObject>(Parent: GlimmerObjectFactory<T>, ...extensions: Extension[]): GlimmerObjectFactory<any> {
-  let Super = <typeof GlimmerObject>Parent;
+  let Super = Parent as typeof GlimmerObject;
 
   let Subclass = class extends Super {};
   Subclass[CLASS_META] = InstanceMeta.fromParent(Parent[CLASS_META]);
@@ -217,7 +217,7 @@ export function relinkSubclasses(Parent: GlimmerObjectFactory<any>) {
 
 export function toMixin(extension: Extension): Mixin {
   if (extension instanceof Mixin) return extension;
-  else return new Mixin(<Object>extension, []);
+  else return new Mixin(extension as Object, []);
 }
 
 class ValueDescriptor extends Descriptor {
@@ -261,12 +261,12 @@ export class DataBlueprint extends Blueprint {
   descriptor(_target: Object, key: string, classMeta: ClassMeta): Descriptor {
     let { enumerable, configurable, writable, value } = this;
 
-    if (classMeta.hasConcatenatedProperty(<string>key)) {
-      classMeta.addConcatenatedProperty(<string>key, value);
-      value = classMeta.getConcatenatedProperty(<string>key);
-    } else if (classMeta.hasMergedProperty(<string>key)) {
-      classMeta.addMergedProperty(<string>key, value);
-      value = classMeta.getMergedProperty(<string>key);
+    if (classMeta.hasConcatenatedProperty(key as string)) {
+      classMeta.addConcatenatedProperty(key as string, value);
+      value = classMeta.getConcatenatedProperty(key as string);
+    } else if (classMeta.hasMergedProperty(key as string)) {
+      classMeta.addMergedProperty(key as string, value);
+      value = classMeta.getMergedProperty(key as string);
     }
 
     return new ValueDescriptor({ enumerable, configurable, writable, value });
@@ -312,7 +312,7 @@ class MethodBlueprint extends DataBlueprint {
 }
 
 export function wrapMethod(home: Object, methodName: string, original: (...args: any[]) => any) {
-  if (!(<string>methodName in home)) return maybeWrap(original);
+  if (!(methodName as string in home)) return maybeWrap(original);
 
   let superMethod = home[methodName];
 
@@ -329,7 +329,7 @@ export function wrapMethod(home: Object, methodName: string, original: (...args:
     }
   };
 
-  (<any>func).__wrapped = true;
+  (func as any).__wrapped = true;
 
   return func;
 }

--- a/packages/@glimmer/object/lib/object.ts
+++ b/packages/@glimmer/object/lib/object.ts
@@ -76,8 +76,8 @@ export class ClassMeta {
   }
 
   static for(object: ObjectWithMixins | InstanceWithMixins): Option<ClassMeta> {
-    if (CLASS_META in object) return (<ObjectWithMixins>object)[CLASS_META];
-    else if (object.constructor) return (<InstanceWithMixins>object).constructor[CLASS_META] || null;
+    if (CLASS_META in object) return (object as ObjectWithMixins)[CLASS_META];
+    else if (object.constructor) return (object as InstanceWithMixins).constructor[CLASS_META] || null;
     else return null;
   }
 
@@ -169,7 +169,7 @@ export class ClassMeta {
 
   hasConcatenatedProperty(property: string): boolean {
     if (!this.hasConcatenatedProperties) return false;
-    return <string>property in this.concatenatedProperties;
+    return property as string in this.concatenatedProperties;
   }
 
   getConcatenatedProperty(property: string): any[] {
@@ -177,13 +177,13 @@ export class ClassMeta {
   }
 
   getConcatenatedProperties(): string[] {
-    return <string[]>Object.keys(this.concatenatedProperties);
+    return Object.keys(this.concatenatedProperties) as string[];
   }
 
   addConcatenatedProperty(property: string, value: any) {
     this.hasConcatenatedProperties = true;
 
-    if (<string>property in this.concatenatedProperties) {
+    if (property as string in this.concatenatedProperties) {
       let val = this.concatenatedProperties[property].concat(value);
       this.concatenatedProperties[property] = val;
     } else {
@@ -193,7 +193,7 @@ export class ClassMeta {
 
   hasMergedProperty(property: string): boolean {
     if (!this.hasMergedProperties) return false;
-    return <string>property in this.mergedProperties;
+    return property as string in this.mergedProperties;
   }
 
   getMergedProperty(property: string): Object {
@@ -201,7 +201,7 @@ export class ClassMeta {
   }
 
   getMergedProperties(): string[] {
-    return <string[]>Object.keys(this.mergedProperties);
+    return Object.keys(this.mergedProperties) as string[];
   }
 
   addMergedProperty(property: string, value: Object) {
@@ -211,7 +211,7 @@ export class ClassMeta {
       throw new Error(`You passed in \`${JSON.stringify(value)}\` as the value for \`foo\` but \`foo\` cannot be an Array`);
     }
 
-    if (<string>property in this.mergedProperties && this.mergedProperties[property] && value) {
+    if (property as string in this.mergedProperties && this.mergedProperties[property] && value) {
       this.mergedProperties[property] = mergeMergedProperties(value, this.mergedProperties[property]);
     } else {
       value = value === null ? value : value || {};
@@ -318,7 +318,7 @@ export class InstanceMeta extends ClassMeta {
   public "df8be4c8-4e89-44e2-a8f9-550c8dacdca7": ClassMeta = ClassMeta.fromParent(null);
 
   static fromParent(parent: Option<InstanceMeta>): InstanceMeta {
-    return <InstanceMeta>super.fromParent(parent);
+    return super.fromParent(parent) as InstanceMeta;
   }
 
   reset(parent: InstanceMeta) {
@@ -383,7 +383,7 @@ export default class GlimmerObject {
 
   constructor(attrs?: Object | null) {
     if (attrs) assign(this, attrs);
-    (<typeof GlimmerObject>this.constructor)[CLASS_META].init(this, attrs || null);
+    (this.constructor as typeof GlimmerObject)[CLASS_META].init(this, attrs || null);
     this._super = ROOT;
     initializeGuid(this);
     this.init();

--- a/packages/@glimmer/object/lib/utils.ts
+++ b/packages/@glimmer/object/lib/utils.ts
@@ -17,7 +17,7 @@ export const checkHasSuper = (function () {
 }());
 
 export function ROOT(..._args: any[]) {}
-(<any>ROOT).__hasSuper = false;
+(ROOT as any).__hasSuper = false;
 
 export function hasSuper(func: Function) {
   if (func['__hasSuper'] === undefined) {

--- a/packages/@glimmer/object/test/ember-metal-alias-method-test.ts
+++ b/packages/@glimmer/object/test/ember-metal-alias-method-test.ts
@@ -9,21 +9,21 @@ function validateAliasMethod(obj: { fooMethod(): string; barMethod(): string }) 
 }
 
 QUnit.test('methods of another name are aliased when the mixin is applied', function() {
-  let MyMixin = <Mixin>Mixin.create({
+  let MyMixin = Mixin.create({
     fooMethod() { return 'FOO'; },
     barMethod: aliasMethod('fooMethod')
-  });
+  }) as Mixin;
 
   let obj = MyMixin.apply({});
   validateAliasMethod(obj);
 });
 
 QUnit.test('should follow aliasMethods all the way down', assert => {
-  let MyMixin = <Mixin>Mixin.create({
+  let MyMixin = Mixin.create({
     bar: aliasMethod('foo'), // put first to break ordered iteration
     baz() { return 'baz'; },
     foo: aliasMethod('baz')
-  });
+  }) as Mixin;
 
   let obj = MyMixin.apply({});
   assert.equal(get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');

--- a/packages/@glimmer/object/test/object-test.ts
+++ b/packages/@glimmer/object/test/object-test.ts
@@ -2,11 +2,11 @@ import GlimmerObject, { computed } from '@glimmer/object';
 import { UpdatableReference, metaFor, setProperty } from '@glimmer/object-reference';
 import { Reference } from '@glimmer/reference';
 
-let Wrapper = <any>GlimmerObject.extend({
+let Wrapper = GlimmerObject.extend({
   fullName: computed(function(this: any) {
     return this.model && this.model.fullName;
   }).property('model.fullName')
-});
+}) as any;
 
 let Model = GlimmerObject.extend({
   fullName: computed(function(this: any) {
@@ -147,7 +147,7 @@ function root<T>(obj: T): UpdatableReference<T> {
 }
 
 QUnit.test("Simple computed properties", assert => {
-  let name = <any>new Name({ first: "Godfrey", last: "Chan" });
+  let name = new Name({ first: "Godfrey", last: "Chan" }) as any;
 
   let ref = metaFor(name).root().get('fullName');
 

--- a/packages/@glimmer/runtime/lib/vm/attributes/dynamic.ts
+++ b/packages/@glimmer/runtime/lib/vm/attributes/dynamic.ts
@@ -150,7 +150,7 @@ export class InputValueDynamicAttribute extends DefaultDynamicProperty {
   }
 
   update(value: Opaque) {
-    let input = <HTMLInputElement>this.attribute.element;
+    let input = this.attribute.element as HTMLInputElement;
     let currentValue = input.value;
     let normalizedValue = normalizeStringValue(value);
     if (currentValue !== normalizedValue) {
@@ -167,7 +167,7 @@ export class OptionSelectedDynamicAttribute extends DefaultDynamicProperty {
   }
 
   update(value: Opaque): void {
-    let option = <HTMLOptionElement>this.attribute.element;
+    let option = this.attribute.element as HTMLOptionElement;
 
     if (value) {
       option.selected = true;

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -99,7 +99,7 @@ export function appendViewFor(template: string, context: Object = {}) {
 }
 
 export function assertAppended(content: string) {
-  equalTokens((<HTMLElement>document.querySelector('#qunit-fixture')), content);
+  equalTokens((document.querySelector('#qunit-fixture') as HTMLElement), content);
 }
 
 function assertText(expected: string) {
@@ -731,8 +731,8 @@ QUnit.test('static arbitrary number of positional parameters', function () {
       {{sample-component "Foo" 4 "Bar" 5 "Baz"}}
       {{!sample-component "Foo" 4 "Bar" 5 "Baz"}}</div>`);
 
-  let first = <Element>view.element.firstChild;
-  let second = <Element>first.nextSibling;
+  let first = view.element.firstChild as Element;
+  let second = first.nextSibling as Element;
   // let third = <Element>second.nextSibling;
 
   assertElementIsEmberishElement(first, 'div', 'Foo4Bar');

--- a/packages/@glimmer/test-helpers/lib/helpers.ts
+++ b/packages/@glimmer/test-helpers/lib/helpers.ts
@@ -175,7 +175,7 @@ let ieSVGInnerHTML = (function () {
   let div = document.createElement('div');
   let node = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   div.appendChild(node);
-  let clone = <HTMLDivElement>div.cloneNode(true);
+  let clone = div.cloneNode(true) as HTMLDivElement;
   return clone.innerHTML === '<svg xmlns="http://www.w3.org/2000/svg" />';
 })();
 

--- a/packages/@glimmer/util/lib/collections.ts
+++ b/packages/@glimmer/util/lib/collections.ts
@@ -24,13 +24,13 @@ export class DictSet<T extends SetMember> implements Set<T> {
   }
 
   add(obj: T): Set<T> {
-    if (typeof obj === 'string') this.dict[<any>obj] = obj;
-    else this.dict[ensureGuid(<any>obj)] = obj;
+    if (typeof obj === 'string') this.dict[obj as any] = obj;
+    else this.dict[ensureGuid(obj as any)] = obj;
     return this;
   }
 
   delete(obj: T) {
-    if (typeof obj === 'string') delete this.dict[<any>obj];
+    if (typeof obj === 'string') delete this.dict[obj as any];
     else if ((obj as any)._guid) delete this.dict[(obj as any)._guid];
   }
 }

--- a/packages/@glimmer/util/lib/list-utils.ts
+++ b/packages/@glimmer/util/lib/list-utils.ts
@@ -47,15 +47,15 @@ export class LinkedList<T extends LinkedListNode> implements Slice<T> {
   }
 
   nextNode(node: T): T {
-    return <trust>node.next;
+    return node.next as trust;
   }
 
   forEachNode(callback: (node: T) => void) {
     let node = this._head;
 
     while (node !== null) {
-      callback(<trust>node);
-      node = <trust>node.next;
+      callback(node as trust);
+      node = node.next as trust;
     }
   }
 
@@ -88,10 +88,10 @@ export class LinkedList<T extends LinkedListNode> implements Slice<T> {
 
   remove(node: T): T {
     if (node.prev) node.prev.next = node.next;
-    else this._head = <trust>node.next;
+    else this._head = node.next as trust;
 
     if (node.next) node.next.prev = node.prev;
-    else this._tail = <trust>node.prev;
+    else this._tail = node.prev as trust;
 
     return node;
   }

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
     "no-consecutive-blank-lines": [
       true
     ],
+    "no-angle-bracket-type-assertion": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-variable": true,


### PR DESCRIPTION
Most new type assertions added to code are `as` type assertions. Though
we don't care too much about `tsx`, the only linting rule available for
consistent type assertions is `no-angle-bracket-type-assertion`.

Also, some syntax highlighters doesn't work well with angle bracket type
assertions.