### PR TITLE
Implement rehydration for `in-element`

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -38,6 +38,7 @@ APPEND_OPCODES.add(Op.OpenDynamicElement, vm => {
 APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
   let elementRef = vm.stack.pop<Reference<Simple.Element>>();
   let nextSiblingRef = vm.stack.pop<Reference<Option<Simple.Node>>>();
+  let guid = vm.stack.pop<Reference<string>>().value();
 
   let element: Simple.Element;
   let nextSibling: Option<Simple.Node>;
@@ -58,7 +59,7 @@ APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
     vm.updateWith(new Assert(cache));
   }
 
-  vm.elements().pushRemoteElement(element, nextSibling);
+  vm.elements().pushRemoteElement(element, guid, nextSibling);
 });
 
 APPEND_OPCODES.add(Op.PopRemoteElement, vm => vm.elements().popRemoteElement());

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -708,23 +708,22 @@ export function populateBuiltins(blocks: Blocks = new Blocks(), inlines: Inlines
 
     builder.returnTo('END');
 
-    if (hash && hash[0].length) {
-      let [ keys, values ] = hash;
+    let [ keys, values ] = hash!;
 
-      if (keys.length === 1 && keys[0] === 'nextSibling') {
-        expr(values[0], builder);
+    for (let i = 0; i < keys.length; i++) {
+      let key = keys[i];
+      if (key === 'nextSibling' || key === 'guid') {
+        expr(values[i], builder);
       } else {
         throw new Error(`SYNTAX ERROR: #in-element does not take a \`${keys[0]}\` option`);
       }
-    } else {
-      expr(null, builder);
     }
 
     expr(params[0], builder);
 
     builder.dup();
 
-    builder.enter(3);
+    builder.enter(4);
 
     builder.jumpUnless('ELSE');
 

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -67,7 +67,7 @@ export class Fragment implements Bounds {
 }
 
 export interface DOMStack {
-  pushRemoteElement(element: Simple.Element, nextSibling: Option<Simple.Node>): void;
+  pushRemoteElement(element: Simple.Element, guid: string, nextSibling: Option<Simple.Node>): void;
   popRemoteElement(): void;
   popElement(): void;
   openElement(tag: string, _operations?: ElementOperations): Simple.Element;
@@ -244,9 +244,8 @@ export class NewElementBuilder implements ElementBuilder {
     this.popElement();
   }
 
-  pushRemoteElement(element: Simple.Element, nextSibling: Option<Simple.Node> = null) {
+  pushRemoteElement(element: Simple.Element, _guid: string, nextSibling: Option<Simple.Node> = null) {
     this.pushElement(element, nextSibling);
-
     let tracker = new RemoteBlockTracker(element);
     this.pushBlockTracker(tracker, true);
   }

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -4,25 +4,23 @@ import { Environment } from '../environment';
 import Bounds, { bounds } from '../bounds';
 import { Simple, Option, Opaque } from "@glimmer/interfaces";
 import { DynamicContentWrapper } from './content/dynamic';
-import { expect, assert } from "@glimmer/util";
+import { expect, assert, Stack } from "@glimmer/util";
 
 export class RehydrateBuilder extends NewElementBuilder implements ElementBuilder {
-  // The node that will be compared against the last operation
-  private _candidate: Option<Simple.Node>;
-
   // The last node that matched
   private lastMatchedNode: Option<Simple.Node> = null;
   private unmatchedAttributes: Option<Simple.Attribute[]> = null;
   private blockDepth = 0;
+  private candidateStack = new Stack<Option<Simple.Node>>();
 
   constructor(env: Environment, parentNode: Simple.Element, nextSibling: Option<Simple.Node>) {
     super(env, parentNode, nextSibling);
     if (nextSibling) throw new Error("Rehydration with nextSibling not supported");
-    this._candidate = parentNode.firstChild;
+    this.candidateStack.push(parentNode.firstChild);
   }
 
   get candidate(): Option<Simple.Node> {
-    let candidate = this._candidate;
+    let candidate = this.candidateStack.pop();
     if (!candidate) return null;
 
     if (isComment(candidate) && getCloseBoundsDepth(candidate) === this.blockDepth) {
@@ -49,11 +47,11 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       current = remove(current);
     }
 
-    this._candidate = null;
+    this.candidateStack.push(null);
   }
 
   private clearBlock(depth: number) {
-    let current: Option<Simple.Node> = this._candidate;
+    let current: Option<Simple.Node> = this.candidateStack.pop();
 
     while (current && !(isComment(current) && getCloseBoundsDepth(current) === depth)) {
       current = remove(current);
@@ -61,7 +59,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
 
     assert(current && isComment(current) && getCloseBoundsDepth(current) === depth, 'An opening block should be paired with a closing block comment');
 
-    this._candidate = remove(current!);
+    this.candidateStack.push(remove(current!));
   }
 
   __openBlock(): void {
@@ -71,7 +69,8 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       if (isComment(candidate)) {
         let depth = getOpenBoundsDepth(candidate);
         if (depth !== null) this.blockDepth = depth;
-        this._candidate = remove(candidate);
+        ;
+        this.candidateStack.push(remove(candidate));
         return;
       } else {
         this.clearMismatch(candidate);
@@ -80,13 +79,13 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
   }
 
   __closeBlock(): void {
-    let { _candidate: candidate } = this;
+    let candidate = this.candidateStack.pop();
 
     if (candidate) {
       if (isComment(candidate)) {
         let depth = getCloseBoundsDepth(candidate);
         if (depth !== null) this.blockDepth = depth - 1;
-        this._candidate = remove(candidate);
+        this.candidateStack.push(remove(candidate));
         return;
       } else {
         this.clearMismatch(candidate);
@@ -126,7 +125,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
   }
 
   private markerBounds(): Option<Bounds> {
-    let { _candidate } = this;
+    let _candidate = this.candidateStack.pop();
 
     if (_candidate && isMarker(_candidate)) {
       let first = _candidate;
@@ -147,7 +146,8 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
 
     if (candidate) {
       if (isEmpty(candidate)) {
-        let next = this._candidate = remove(candidate);
+        let next = remove(candidate);
+        this.candidateStack.push(next);
         let text = this.dom.createTextNode(string);
         this.dom.insertBefore(this.element, text, next);
         return text;
@@ -156,10 +156,10 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       if (isTextNode(candidate)) {
         candidate.nodeValue = string;
         this.lastMatchedNode = candidate;
-        this._candidate = candidate.nextSibling;
+        this.candidateStack.push(candidate.nextSibling);
         return candidate;
       } else if (candidate && (isSeparator(candidate) || isEmpty(candidate))) {
-        this._candidate = candidate.nextSibling;
+        this.candidateStack.push(candidate.nextSibling);
         remove(candidate);
         return this.__appendText(string);
       } else {
@@ -172,12 +172,12 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
   }
 
   __appendComment(string: string): Simple.Comment {
-    let { _candidate } = this;
+    let _candidate = this.candidateStack.pop();
 
     if (_candidate && isComment(_candidate)) {
       _candidate.nodeValue = string;
       this.lastMatchedNode = _candidate;
-      this._candidate = _candidate.nextSibling;
+      this.candidateStack.push(_candidate.nextSibling);
       return _candidate;
     } else if (_candidate) {
       this.clearMismatch(_candidate);
@@ -187,11 +187,11 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
   }
 
   __openElement(tag: string, _operations?: ElementOperations): Simple.Element {
-    let { _candidate } = this;
+    let _candidate = this.candidateStack.pop();
 
     if (_candidate && isElement(_candidate) && _candidate.tagName === tag.toUpperCase()) {
       this.unmatchedAttributes = [].slice.call(_candidate.attributes);
-      this._candidate = _candidate.firstChild;
+      this.candidateStack.push(_candidate.nextSibling);
       return _candidate;
     } else if (_candidate) {
       this.clearMismatch(_candidate);
@@ -256,29 +256,53 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       this.clearMismatch(candidate);
     }
 
-    this._candidate = this.element.nextSibling;
+    this.candidateStack.push(this.element.nextSibling);
     this.lastMatchedNode = this.element;
     super.willCloseElement();
   }
 
-  pushRemoteElement(_element: Simple.Element, _nextSibling: Option<Simple.Node> = null) {
-    throw unimplemented();
+  getMarker(element: Simple.Element, guid: string): Simple.Node {
+    let marker = element.firstChild;
+    if (marker && marker['id'] === guid) {
+      return marker;
+    }
+
+    throw new Error('Cannot find serialized cursor for `in-element`');
+  }
+
+  pushRemoteElement(element: Simple.Element, cursorId: string, _nextSibling: Option<Simple.Node> = null) {
+
+    let marker = this.getMarker(element, cursorId);
+
+    if (marker.parentNode === element) {
+      let candidate = marker.nextSibling;
+
+      remove(marker);
+
+      this.candidateStack.push(candidate);
+      this.candidateStack.push(this.candidate);
+      super.pushRemoteElement(element, cursorId, _nextSibling);
+      this.lastMatchedNode = element;
+    }
+
   }
 
   popRemoteElement() {
-    throw unimplemented();
+    super.popRemoteElement();
+    this.candidateStack.pop();
+    this.candidateStack.pop();
   }
 
   didAppendBounds(bounds: Bounds): Bounds {
     super.didAppendBounds(bounds);
     let last = bounds.lastNode();
-    this._candidate = last && last.nextSibling;
+    this.candidateStack.push(last && last.nextSibling);
     return bounds;
   }
 
   didOpenElement(element: Simple.Element): Simple.Element {
     super.didOpenElement(element);
-    this._candidate = element.firstChild;
+    this.candidateStack.push(element.firstChild);
     return element;
   }
 
@@ -349,8 +373,4 @@ function findByName(array: Simple.Attribute[], name: string): Simple.Attribute |
   }
 
   return undefined;
-}
-
-function unimplemented() {
-  return new Error('Not implemented');
 }

--- a/packages/@glimmer/runtime/lib/vm/serialize-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/serialize-builder.ts
@@ -2,9 +2,19 @@ import { NewElementBuilder, ElementBuilder } from "./element-builder";
 
 import Bounds, { bounds, currentNode } from '../bounds';
 import { Simple } from "@glimmer/interfaces";
+import { Option } from "@glimmer/util";
 
 export class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
   private serializeBlockDepth = 0;
+
+  pushRemoteElement(element: Simple.Element, cursorId: string,  nextSibling: Option<Simple.Node> = null) {
+    let { dom } = this;
+    let script = dom.createElement('script');
+    script.setAttribute('id', cursorId);
+
+    dom.insertBefore(element, script, nextSibling);
+    super.pushRemoteElement(element, cursorId, nextSibling);
+  }
 
   __openBlock(): void {
     let depth = this.serializeBlockDepth++;

--- a/packages/@glimmer/test-helpers/index.ts
+++ b/packages/@glimmer/test-helpers/index.ts
@@ -13,7 +13,8 @@ export {
   getTextContent,
   strip,
   stripTight,
-  trimLines
+  trimLines,
+  blockStack
 } from './lib/helpers';
 
 export {

--- a/packages/@glimmer/test-helpers/lib/abstract-test-case.ts
+++ b/packages/@glimmer/test-helpers/lib/abstract-test-case.ts
@@ -1,7 +1,6 @@
 import { PathReference, Tagged, TagWrapper, RevisionTag, DirtyableTag, Tag } from "@glimmer/reference";
 import { RenderResult, RenderLayoutOptions } from "@glimmer/runtime";
 import { Opaque, Dict, dict, expect } from "@glimmer/util";
-import { NodeDOMTreeConstruction } from "@glimmer/node";
 import { Option } from "@glimmer/interfaces";
 import { UpdatableReference } from "@glimmer/object-reference";
 import { assign, equalTokens, normalizeInnerHTML } from "./helpers";
@@ -16,7 +15,6 @@ import {
   regex,
   BasicComponent
 } from "./environment";
-import * as SimpleDOM from "simple-dom";
 
 export const OPEN: { marker: "open-block" } = { marker: "open-block" };
 export const CLOSE: { marker: "close-block" } = { marker: "close-block" };
@@ -549,111 +547,7 @@ export class RenderTests extends AbstractRenderTest {
   }
 }
 
-export class RehydrationTests extends RenderTests {
-  serialized: string;
-  setupServer(template: string = this.template) {
-    let doc = new SimpleDOM.Document();
-    let env = new TestEnvironment({
-      document: doc,
-      appendOperations: new NodeDOMTreeConstruction(doc)
-    });
-    this.setup({ template, env });
-  }
-
-  setupClient(template: string = this.template) {
-    let env = new TestEnvironment();
-    let div = document.createElement('div');
-
-    expect(
-      this.serialized,
-      'Should have serialized HTML from `this.renderServerSide()`'
-    );
-
-    div.innerHTML = this.serialized;
-    this.element = div;
-    this.setup({ template, env });
-  }
-
-  setup({
-    template,
-    context,
-    env
-  }: {
-    template: string;
-    context?: Dict<Opaque>;
-    env?: TestEnvironment;
-  }) {
-    if (env) this.env = env;
-    this.template = template;
-    if (context) this.setProperties(context);
-  }
-
-  assertServerOutput(..._expected: Content[]) {
-    let serialized = this.serialize();
-    equalTokens(serialized, content([OPEN, ..._expected, CLOSE]));
-    this.serialized = serialized;
-  }
-
-  renderServerSide(context?: Dict<Opaque>): void {
-    if (context) {
-      this.context = context;
-    }
-    this.setupServer();
-    this.populateHelpers();
-    let { env } = this;
-    this.element = env.getAppendOperations().createElement("div") as HTMLDivElement;
-    let template = expect(this.template, "Must set up a template before calling renderServerSide");
-    // Emulate server-side render
-    renderTemplate(template, {
-      env,
-      self: new UpdatableReference(this.context),
-      cursor: { element: this.element, nextSibling: null },
-      dynamicScope: new TestDynamicScope(),
-      mode: 'serialize'
-    });
-
-    this.takeSnapshot();
-    this.serialized = this.serialize();
-  }
-
-  serialize() {
-    let serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-    let serialized = serializer.serializeChildren(this.element);
-    return serialized;
-  }
-
-  renderClientSide(context?: Dict<Opaque>) {
-    if (context) {
-      this.context = context;
-    }
-    this.setupClient();
-    this.populateHelpers();
-    let { env } = this;
-    this.element = env.getAppendOperations().createElement("div") as HTMLDivElement;
-    let template = expect(this.template, "Must set up a template before calling renderClientSide");
-    // Client-side rehydration
-    this.renderResult = renderTemplate(template, {
-      env,
-      self: new UpdatableReference(this.context),
-      cursor: { element: this.element, nextSibling: null },
-      dynamicScope: new TestDynamicScope(),
-      mode: 'rehydrate'
-    });
-  }
-
-  renderTemplate(template: string): RenderResult {
-    this.template = template;
-    this.renderServerSide();
-    this.renderClientSide();
-    return this.renderResult!;
-  }
-}
-
-function normalize(
-  oldSnapshot: NodesSnapshot,
-  newSnapshot: NodesSnapshot,
-  except: Array<Node>
-) {
+function normalize(oldSnapshot: NodesSnapshot, newSnapshot: NodesSnapshot, except: Array<Node>) {
   let oldIterator = new SnapshotIterator(oldSnapshot);
   let newIterator = new SnapshotIterator(newSnapshot);
 

--- a/packages/@glimmer/test-helpers/lib/helpers.ts
+++ b/packages/@glimmer/test-helpers/lib/helpers.ts
@@ -222,8 +222,29 @@ export function getTextContent(el: Node) {
   }
 }
 
-export function strip(strings: TemplateStringsArray) {
-  return strings[0].split('\n').map(s => s.trim()).join(' ');
+export function blockStack() {
+  let stack: number[] = [];
+
+  return (id: number) => {
+    if (stack.indexOf(id) > -1) {
+      let close = `<!--%-block:${id}%-->`;
+      stack.pop();
+      return close;
+    } else {
+      stack.push(id);
+      return `<!--%+block:${id}%-->`;
+    }
+  };
+}
+
+export function strip(strings: TemplateStringsArray, ...args: string[]) {
+  if (typeof strings === 'object') {
+    return strings.map((str: string, i: number) => {
+      return `${str.split('\n').map(s => s.trim()).join('')}${args[i] ? args[i] : ''}`;
+    }).join('');
+  } else {
+    return strings[0].split('\n').map((s: string) => s.trim()).join(' ');
+  }
 }
 
 export function stripTight(strings: TemplateStringsArray) {


### PR DESCRIPTION
Prior to this commit rehydrating `in-element` was not implemented. This PR changes both the serialization builder and rehydrating builder.

Given:

```
<outer>
  {{#-in-element myRemote}}
    <inner>I will be rendered into the remote</inner>
  {{/-in-element}}
</outer>
<remote></remote>
```

The following would be serialized as:

```
<main>
  <!--%+block:0%-->
  <outer>
      <!--%+block:1%-->
          <!---->
      <!--%-block:1%-->
  </outer>
  <!--%-block:0%-->
</main>
<remote>
  <script id="%cursor:0%"></script>
  <!--%+block:2%-->
  <inner>I will be rendered into the remote</inner>
  <!--%-block:2%-->
</remote>
```

You may notice we have to serialize the cursor position in the `<remote>` this allows for us to jump directly to that point and start re-hydrating the contents of the remote element.

Post re-hydrating the DOM will look like the following.

```
<main>
  <outer>
  <!---->
  </outer>
</main>
<remote>
  <inner>I will be rendered into the remote</inner>
</remote>
```