### PR TITLE
Fix Mixins For Rehydration

### DIFF
--- a/packages/@glimmer/test-helpers/index.ts
+++ b/packages/@glimmer/test-helpers/index.ts
@@ -35,7 +35,6 @@ export {
   VersionedObject,
   SimpleRootReference,
   AbstractRenderTest,
-  RehydrationTests,
   RenderTests,
   OPEN,
   CLOSE,
@@ -44,5 +43,6 @@ export {
   module,
   test,
   Content,
-  renderTemplate
+  renderTemplate,
+  content
 } from './lib/abstract-test-case';


### PR DESCRIPTION
There was an issue with the mixin pattern that you are supposed to use in TS 2.2, this introduced type errors that got past CI. As a work around we can just use a sub-class for the rehydration tests.