### PR TITLE
fix for constant float/negative values

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -12,6 +12,7 @@ import {
   ConstantOther,
   Constants,
   ConstantString,
+  ConstantFloat
 } from '../../environment/constants';
 import { ModifierManager } from '../../modifier/interfaces';
 import { ComponentBuilder as IComponentBuilder } from '../../opcode-builder';
@@ -372,28 +373,33 @@ export abstract class BasicOpcodeBuilder {
   }
 
   primitive(_primitive: string | number | null | undefined | boolean) {
-    let flag: 0 | 1 | 2 = 0;
+    let flag: 0 | 1 | 2 | 3 = 0;
     let primitive: number;
     switch (typeof _primitive) {
       case 'number':
-        primitive = _primitive as number;
+        if (_primitive as number % 1 === 0 && _primitive as number > 0) {
+          primitive = _primitive as number;
+        } else {
+          primitive = this.float(_primitive as number);
+          flag = 1;
+        }
         break;
       case 'string':
         primitive = this.string(_primitive as string);
-        flag = 1;
+        flag = 2;
         break;
       case 'boolean':
         primitive = (_primitive as any) | 0;
-        flag = 2;
+        flag = 3;
         break;
       case 'object':
         // assume null
         primitive = 2;
-        flag = 2;
+        flag = 3;
         break;
       case 'undefined':
         primitive = 3;
-        flag = 2;
+        flag = 3;
         break;
       default:
         throw new Error('Invalid primitive passed to pushPrimitive');
@@ -504,6 +510,10 @@ export abstract class BasicOpcodeBuilder {
 
   string(_string: string): ConstantString {
     return this.constants.string(_string);
+  }
+
+  float(num: number): ConstantFloat {
+    return this.constants.float(num);
   }
 
   protected names(_names: string[]): ConstantArray {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -1,12 +1,14 @@
 import { Opaque, Option, SymbolTable } from '@glimmer/interfaces';
-import { ConstReference, Reference, VersionedPathReference } from '@glimmer/reference';
 import {
+  VersionedPathReference,
   CONSTANT_TAG,
   isConst,
   isModified,
   ReferenceCache,
   Revision,
-  Tag,
+  ConstReference,
+  Reference,
+  Tag
 } from '@glimmer/reference';
 import { initializeGuid } from '@glimmer/util';
 import Environment from '../../environment';
@@ -49,9 +51,12 @@ APPEND_OPCODES.add(Op.PrimitiveReference, (vm, { op1: primitive }) => {
       stack.push(PrimitiveReference.create(value));
       break;
     case 1:
-      stack.push(PrimitiveReference.create(vm.constants.getString(value)));
+      stack.push(PrimitiveReference.create(vm.constants.getFloat(value)));
       break;
     case 2:
+      stack.push(PrimitiveReference.create(vm.constants.getString(value)));
+      break;
+    case 3:
       switch (value) {
         case 0: stack.push(FALSE_REFERENCE); break;
         case 1: stack.push(TRUE_REFERENCE); break;

--- a/packages/@glimmer/runtime/lib/environment/constants.ts
+++ b/packages/@glimmer/runtime/lib/environment/constants.ts
@@ -5,6 +5,7 @@ import { Block } from "../syntax/interfaces";
 export type ConstantType = 'slice' | 'block' | 'reference' | 'string' | 'number' | 'expression';
 export type ConstantReference =  number;
 export type ConstantString = number;
+export type ConstantFloat = number;
 export type ConstantExpression = number;
 export type ConstantSlice = number;
 export type ConstantBlock = number;
@@ -18,6 +19,7 @@ export class Constants {
   private references: VersionedPathReference<Opaque>[] = [];
   private strings: string[] = [];
   private expressions: Opaque[] = [];
+  private floats: number[] = [];
   private arrays: number[][] = [];
   private blocks: Block[] = [];
   private functions: Function[] = [];
@@ -35,6 +37,14 @@ export class Constants {
 
   getString(value: ConstantString): string {
     return this.strings[value - 1];
+  }
+
+  getFloat(value: ConstantFloat): number {
+    return this.floats[value - 1];
+  }
+
+  float(value: number): ConstantFloat {
+    return this.floats.push(value);
   }
 
   string(value: string): ConstantString {

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -510,6 +510,14 @@ module("[glimmer runtime] Initial render", tests => {
       compilesTo('<div>{{testing title}}</div>', '<div>hello</div>', { title: 'hello' });
     });
 
+    test("The compiler can handle simple helpers with float and negative number parameters", () => {
+      env.registerHelper('testing', function(params, hash) {
+        return params[0] as number - (hash['arg1'] as number);
+      });
+      render(compile('<div>{{testing -1 arg1=0.234}}</div>'), {});
+      equalTokens(root, '<div>-1.234</div>');
+    });
+
     test("GH#13999 The compiler can handle simple helpers with inline null parameter", assert => {
       let value;
       env.registerHelper('say-hello', function(params) {


### PR DESCRIPTION
This backports #573 onto the released version of glimmer-vm that currently works with Ember.

I tested it against both Ember and Liquid Fire's test suites and it looks good.