### PR TITLE
Start location fix for dynamic attributes

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -103,6 +103,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
 
       // Attribute values
       case "beforeAttributeValue":
+        this.beginAttributeValue(false);
         appendDynamicAttributeValuePart(this.currentAttribute!, mustache);
         tokenizer.state = 'attributeValueUnquoted';
         break;

--- a/packages/@glimmer/syntax/test/loc-node-test.ts
+++ b/packages/@glimmer/syntax/test/loc-node-test.ts
@@ -291,6 +291,18 @@ data-barf="herpy"
   }
 });
 
+test("element dynamic attribute", function() {
+  let ast = parse(`<img src={{blah}}>`);
+
+  let [div] = ast.body;
+  if (assertNodeType(div, 'ElementNode')) {
+    let [src] = div.attributes;
+    locEqual(src, 1, 5, 1, 17);
+    let value = src.value;
+    locEqual(value, 1, 9, 1, 17);
+  }
+});
+
 test("concat statement", function() {
   let ast = parse(`
     <div data-foo="{{if foo

--- a/packages/@glimmer/syntax/test/loc-node-test.ts
+++ b/packages/@glimmer/syntax/test/loc-node-test.ts
@@ -294,11 +294,11 @@ data-barf="herpy"
 test("element dynamic attribute", function() {
   let ast = parse(`<img src={{blah}}>`);
 
-  let [div] = ast.body;
-  if (assertNodeType(div, 'ElementNode')) {
-    let [src] = div.attributes;
+  let [img] = ast.body;
+  if (assertNodeType(img, 'ElementNode')) {
+    let [src] = img.attributes;
     locEqual(src, 1, 5, 1, 17);
-    let value = src.value;
+    let { value } = src;
     locEqual(value, 1, 9, 1, 17);
   }
 });


### PR DESCRIPTION
Made sure to call beginAttributeValue when parsing a dynamic mustache attribute. Also added a small test to make sure that it works.

Resolves #615 