### PR TITLE
Use const enums for primitive value type flag

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -12,7 +12,7 @@ import {
   LazyConstants
 } from '../../environment/constants';
 import { ComponentBuilder as IComponentBuilder } from '../../opcode-builder';
-import { Primitive } from '../../references';
+import { Primitive, PrimitiveType } from '../../references';
 import { expr, ATTRS_BLOCK } from '../../syntax/functions';
 import { BlockSyntax, CompilableTemplate } from '../../syntax/interfaces';
 import RawInlineBlock from '../../syntax/raw-block';
@@ -384,7 +384,7 @@ export abstract class OpcodeBuilder<Layout extends AbstractTemplate<ProgramSymbo
   }
 
   primitive(_primitive: Primitive) {
-    let flag: 0 | 1 | 2 | 3 = 0;
+    let type: PrimitiveType = PrimitiveType.NUMBER;
     let primitive: number;
     switch (typeof _primitive) {
       case 'number':
@@ -392,31 +392,31 @@ export abstract class OpcodeBuilder<Layout extends AbstractTemplate<ProgramSymbo
           primitive = _primitive as number;
         } else {
           primitive = this.float(_primitive as number);
-          flag = 1;
+          type = PrimitiveType.FLOAT;
         }
         break;
       case 'string':
         primitive = this.string(_primitive as string);
-        flag = 2;
+        type = PrimitiveType.STRING;
         break;
       case 'boolean':
         primitive = (_primitive as any) | 0;
-        flag = 3;
+        type = PrimitiveType.BOOLEAN_OR_VOID;
         break;
       case 'object':
         // assume null
         primitive = 2;
-        flag = 3;
+        type = PrimitiveType.BOOLEAN_OR_VOID;
         break;
       case 'undefined':
         primitive = 3;
-        flag = 3;
+        type = PrimitiveType.BOOLEAN_OR_VOID;
         break;
       default:
         throw new Error('Invalid primitive passed to pushPrimitive');
     }
 
-    this.push(Op.Primitive, primitive << 3 | flag);
+    this.push(Op.Primitive, primitive << 3 | type);
   }
 
   pushPrimitiveReference(primitive: Primitive) {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -14,7 +14,7 @@ import { initializeGuid } from '@glimmer/util';
 import { Handle } from '../../environment';
 import { LazyConstants } from '../../environment/constants';
 import { APPEND_OPCODES, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
-import { Primitive, PrimitiveReference } from '../../references';
+import { Primitive, PrimitiveReference, PrimitiveType } from '../../references';
 import { CompilableTemplate } from '../../syntax/interfaces';
 import { VM, UpdatingVM } from '../../vm';
 import { Arguments } from '../../vm/arguments';
@@ -33,20 +33,20 @@ APPEND_OPCODES.add(Op.Constant, (vm: VM & { constants: LazyConstants }, { op1: o
 
 APPEND_OPCODES.add(Op.Primitive, (vm, { op1: primitive }) => {
   let stack = vm.stack;
-  let flag = primitive & 7; // 111
+  let flag: PrimitiveType = primitive & 7; // 111
   let value = primitive >> 3;
 
   switch (flag) {
-    case 0:
+    case PrimitiveType.NUMBER:
       stack.push(value);
       break;
-    case 1:
+    case PrimitiveType.FLOAT:
       stack.push(vm.constants.getFloat(value));
       break;
-    case 2:
+    case PrimitiveType.STRING:
       stack.push(vm.constants.getString(value));
       break;
-    case 3:
+    case PrimitiveType.BOOLEAN_OR_VOID:
       switch (value) {
         case 0: stack.push(false); break;
         case 1: stack.push(true); break;

--- a/packages/@glimmer/runtime/lib/references.ts
+++ b/packages/@glimmer/runtime/lib/references.ts
@@ -3,6 +3,13 @@ import { ConstReference, PathReference, Reference, Tag } from '@glimmer/referenc
 
 export type Primitive = undefined | null | boolean | number | string;
 
+export const enum PrimitiveType {
+  NUMBER          = 0b00,
+  FLOAT           = 0b01,
+  STRING          = 0b10,
+  BOOLEAN_OR_VOID = 0b11
+}
+
 export class PrimitiveReference<T extends Primitive> extends ConstReference<T> implements PathReference<T> {
   static create<T extends Primitive>(value: T): PrimitiveReference<T> {
     if (value === undefined) {


### PR DESCRIPTION
We use a 3-bit flag to indicate the type of primitives passed around the system, which ultimately dictates which pool they get placed into. This PR replaces the hardcoded integer flags with a const enum that uses the binary literal notation from ES2015, which in my opinion help convey the intent of the bitwise operations better.

Because it is a const enum, TypeScript inlines the values in the compiled output, so the actual artifact produced is exactly the same.

<img width="1539" alt="glimmer-runtime js dist 2017-08-11 09-28-59" src="https://user-images.githubusercontent.com/90888/29215061-8c51c276-7e77-11e7-9080-29c81b33f469.png">
