### PR TITLE
Cleanup DOM Helper

### DIFF
--- a/packages/@glimmer/runtime/lib/compat/inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/inner-html-fix.ts
@@ -1,5 +1,5 @@
 import { Bounds, ConcreteBounds } from '../bounds';
-import { moveNodesBefore, DOMChanges, DOMTreeConstruction } from '../dom/helper';
+import { moveNodesBefore, DOMOperations } from '../dom/helper';
 import { Option } from '@glimmer/util';
 
 interface Wrapper {
@@ -24,16 +24,16 @@ let innerHTMLWrapper = {
 // Fix:      Wrap the innerHTML we are about to set in its parents, apply the
 //           wrapped innerHTML on a div, then move the unwrapped nodes into the
 //           target position.
-export function domChanges(document: Option<Document>, DOMChangesClass: typeof DOMChanges): typeof DOMChanges {
-  if (!document) return DOMChangesClass;
+export function applyInnerHTMFix(document: Option<Document>, DOMClass: typeof DOMOperations): typeof DOMOperations {
+  if (!document) return DOMClass;
 
   if (!shouldApplyFix(document)) {
-    return DOMChangesClass;
+    return DOMClass;
   }
 
   let div = document.createElement('div');
 
-  return class DOMChangesWithInnerHTMLFix extends DOMChangesClass {
+  return class DOMChangesWithInnerHTMLFix extends DOMClass {
     insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
       if (html === null || html === '') {
         return super.insertHTMLBefore(parent, nextSibling, html);
@@ -47,33 +47,6 @@ export function domChanges(document: Option<Document>, DOMChangesClass: typeof D
       }
 
       return fixInnerHTML(parent, wrapper, div, html, nextSibling);
-    }
-  };
-}
-
-export function treeConstruction(document: Option<Document>, DOMTreeConstructionClass: typeof DOMTreeConstruction): typeof DOMTreeConstruction {
-  if (!document) return DOMTreeConstructionClass;
-
-  if (!shouldApplyFix(document)) {
-    return DOMTreeConstructionClass;
-  }
-
-  let div = document.createElement('div');
-
-  return class DOMTreeConstructionWithInnerHTMLFix extends DOMTreeConstructionClass {
-    insertHTMLBefore(parent: HTMLElement, referenceNode: Node, html: string): Bounds {
-      if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, referenceNode, html);
-      }
-
-      let parentTag = parent.tagName.toLowerCase();
-      let wrapper = innerHTMLWrapper[parentTag];
-
-      if(wrapper === undefined) {
-        return super.insertHTMLBefore(parent, referenceNode, html);
-      }
-
-      return fixInnerHTML(parent, wrapper, div, html, referenceNode);
     }
   };
 }

--- a/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
@@ -1,5 +1,5 @@
 import { Bounds, ConcreteBounds } from '../bounds';
-import { moveNodesBefore, DOMChanges, DOMTreeConstruction } from '../dom/helper';
+import { moveNodesBefore, DOMOperations } from '../dom/helper';
 import { Option, unwrap } from '@glimmer/util';
 
 export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
@@ -16,16 +16,16 @@ export type SVG_NAMESPACE = typeof SVG_NAMESPACE;
 //           approach is used. A pre/post SVG tag is added to the string, then
 //           that whole string is added to a div. The created nodes are plucked
 //           out and applied to the target location on DOM.
-export function domChanges(document: Option<Document>, DOMChangesClass: typeof DOMChanges, svgNamespace: SVG_NAMESPACE): typeof DOMChanges {
-  if (!document) return DOMChangesClass;
+export function applySVGInnerHTMLFix(document: Option<Document>, DOMClass: typeof DOMOperations, svgNamespace: SVG_NAMESPACE): typeof DOMOperations {
+  if (!document) return DOMClass;
 
   if (!shouldApplyFix(document, svgNamespace)) {
-    return DOMChangesClass;
+    return DOMClass;
   }
 
   let div = document.createElement('div');
 
-  return class DOMChangesWithSVGInnerHTMLFix extends DOMChangesClass {
+  return class DOMChangesWithSVGInnerHTMLFix extends DOMClass {
     insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
       if (html === null || html === '') {
         return super.insertHTMLBefore(parent, nextSibling, html);
@@ -36,30 +36,6 @@ export function domChanges(document: Option<Document>, DOMChangesClass: typeof D
       }
 
       return fixSVG(parent, div, html, nextSibling);
-    }
-  };
-}
-
-export function treeConstruction(document: Option<Document>, TreeConstructionClass: typeof DOMTreeConstruction, svgNamespace: SVG_NAMESPACE): typeof DOMTreeConstruction {
-  if (!document) return TreeConstructionClass;
-
-  if (!shouldApplyFix(document, svgNamespace)) {
-    return TreeConstructionClass;
-  }
-
-  let div = document.createElement('div');
-
-  return class TreeConstructionWithSVGInnerHTMLFix extends TreeConstructionClass {
-    insertHTMLBefore(parent: HTMLElement, reference: Node, html: string): Bounds {
-      if (html === null || html === '') {
-        return super.insertHTMLBefore(parent, reference, html);
-      }
-
-      if (parent.namespaceURI !== svgNamespace) {
-        return super.insertHTMLBefore(parent, reference, html);
-      }
-
-      return fixSVG(parent, div, html, reference);
     }
   };
 }

--- a/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
@@ -1,5 +1,5 @@
 import { Bounds } from '../bounds';
-import { DOMChanges, DOMTreeConstruction } from '../dom/helper';
+import { DOMOperations } from '../dom/helper';
 import { Option } from '@glimmer/util';
 
 // Patch:    Adjacent text node merging fix
@@ -14,14 +14,14 @@ import { Option } from '@glimmer/util';
 //           Note that this fix must only apply to the previous text node, as
 //           the base implementation of `insertHTMLBefore` already handles
 //           following text nodes correctly.
-export function domChanges(document: Option<Document>, DOMChangesClass: typeof DOMChanges): typeof DOMChanges {
-  if (!document) return DOMChangesClass;
+export function applyTextNodeMergingFix(document: Option<Document>, DOMClass: typeof DOMOperations): typeof DOMOperations {
+  if (!document) return DOMClass;
 
   if (!shouldApplyFix(document)) {
-    return DOMChangesClass;
+    return DOMClass;
   }
 
-  return class DOMChangesWithTextNodeMergingFix extends DOMChangesClass {
+  return class DOMChangesWithTextNodeMergingFix extends DOMClass {
     private uselessComment: Comment;
 
     constructor(document: Document) {
@@ -43,45 +43,6 @@ export function domChanges(document: Option<Document>, DOMChangesClass: typeof D
       }
 
       let bounds = super.insertHTMLBefore(parent, nextSibling, html);
-
-      if (didSetUselessComment) {
-        parent.removeChild(this.uselessComment);
-      }
-
-      return bounds;
-    }
-  };
-}
-
-export function treeConstruction(document: Option<Document>, TreeConstructionClass: typeof DOMTreeConstruction): typeof DOMTreeConstruction {
-  if (!document) return TreeConstructionClass;
-
-  if (!shouldApplyFix(document)) {
-    return TreeConstructionClass;
-  }
-
-  return class TreeConstructionWithTextNodeMergingFix extends TreeConstructionClass {
-    private uselessComment: Comment;
-
-    constructor(document: Document) {
-      super(document);
-      this.uselessComment = this.createComment('') as Comment;
-    }
-
-    insertHTMLBefore(parent: HTMLElement, reference: Node, html: string): Bounds {
-      if (html === null) {
-        return super.insertHTMLBefore(parent, reference, html);
-      }
-
-      let didSetUselessComment = false;
-
-      let nextPrevious = reference ? reference.previousSibling : parent.lastChild;
-      if (nextPrevious && nextPrevious instanceof Text) {
-        didSetUselessComment = true;
-        parent.insertBefore(this.uselessComment, reference);
-      }
-
-      let bounds = super.insertHTMLBefore(parent, reference, html);
 
       if (didSetUselessComment) {
         parent.removeChild(this.uselessComment);

--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -1,15 +1,12 @@
 import { Bounds, ConcreteBounds } from '../bounds';
 import {
-  domChanges as domChangesTableElementFix,
-  treeConstruction as treeConstructionTableElementFix
+  applyInnerHTMFix
 } from '../compat/inner-html-fix';
 import {
-  domChanges as domChangesSvgElementFix,
-  treeConstruction as treeConstructionSvgElementFix
+  applySVGInnerHTMLFix
 } from '../compat/svg-inner-html-fix';
 import {
-  domChanges as domChangesNodeMergingFix,
-  treeConstruction as treeConstructionNodeMergingFix
+  applyTextNodeMergingFix
 } from '../compat/text-node-merging-fix';
 import { Simple } from '@glimmer/interfaces';
 
@@ -135,9 +132,9 @@ export namespace DOM {
   }
 
   let appliedTreeContruction = TreeConstruction;
-  appliedTreeContruction = treeConstructionNodeMergingFix(doc, appliedTreeContruction);
-  appliedTreeContruction = treeConstructionTableElementFix(doc, appliedTreeContruction);
-  appliedTreeContruction = treeConstructionSvgElementFix(doc, appliedTreeContruction, SVG_NAMESPACE);
+  appliedTreeContruction = applyTextNodeMergingFix(doc, appliedTreeContruction) as typeof TreeConstruction;
+  appliedTreeContruction = applyInnerHTMFix(doc, appliedTreeContruction) as typeof TreeConstruction;
+  appliedTreeContruction = applySVGInnerHTMLFix(doc, appliedTreeContruction, SVG_NAMESPACE) as typeof TreeConstruction;
 
   export const DOMTreeConstruction = appliedTreeContruction;
   export type DOMTreeConstruction = TreeConstruction;
@@ -157,10 +154,6 @@ export class DOMChanges extends DOMOperations {
 
   removeAttribute(element: Simple.Element, name: string) {
     element.removeAttribute(name);
-  }
-
-  insertBefore(element: Simple.Element, node: Simple.Node, reference: Option<Simple.Node>) {
-    element.insertBefore(node, reference);
   }
 
   insertAfter(element: Simple.Element, node: Simple.Node, reference: Simple.Node) {
@@ -208,9 +201,9 @@ export function insertHTMLBefore(this: void, _useless: Simple.Element, _parent: 
 
 let helper = DOMChanges;
 
-helper = domChangesNodeMergingFix(doc, helper);
-helper = domChangesTableElementFix(doc, helper);
-helper = domChangesSvgElementFix(doc, helper, SVG_NAMESPACE);
+helper = applyTextNodeMergingFix(doc, helper) as typeof DOMChanges;
+helper = applyInnerHTMFix(doc, helper) as typeof DOMChanges;
+helper = applySVGInnerHTMLFix(doc, helper, SVG_NAMESPACE) as typeof DOMChanges;
 
 export default helper;
 export const DOMTreeConstruction = DOM.DOMTreeConstruction;


### PR DESCRIPTION
This removes duplicate code for applying fixes and instead just casts the type back once the fixes have been applied.