### PR TITLE
Remove ToBoolean conversions

### DIFF
--- a/packages/@glimmer/reference/lib/validators.ts
+++ b/packages/@glimmer/reference/lib/validators.ts
@@ -285,7 +285,7 @@ export abstract class CachedReference<T> implements VersionedReference<T> {
   value(): T {
     let { tag, lastRevision, lastValue } = this;
 
-    if (!lastRevision || !tag.validate(lastRevision)) {
+    if (lastRevision === null || !tag.validate(lastRevision)) {
       lastValue = this.lastValue = this.compute();
       this.lastRevision = tag.value();
     }


### PR DESCRIPTION
This removes the ToBoolean conversions that were being done in the refs and tags. We should know the actual type of the thing we are comparing as we type things with `Option` which is `T | null`.