### PR TITLE
[WIP] Experimental Opcode DCE

### DIFF
--- a/packages/@glimmer/runtime/lib/bootstrap.ts
+++ b/packages/@glimmer/runtime/lib/bootstrap.ts
@@ -1,9 +1,1 @@
 import './opcodes';
-import './compiled/opcodes/expressions';
-import './compiled/opcodes/component';
-import './compiled/opcodes/content';
-import './compiled/opcodes/debugger';
-import './compiled/opcodes/dom';
-import './compiled/opcodes/partial';
-import './compiled/opcodes/vm';
-import './compiled/opcodes/lists';

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -21,7 +21,7 @@ import {
 } from '../../component/interfaces';
 import { normalizeStringValue } from '../../dom/normalize';
 import { DynamicScope, Handle, ScopeBlock, ScopeSlot, Opcode } from '../../environment';
-import { UpdatingOpcode } from '../../opcodes';
+import { UpdatingOpcode } from '../../updating-opcodes';
 import { AbstractTemplate } from './builder';
 import { UNDEFINED_REFERENCE } from '../../references';
 import { ATTRS_BLOCK } from '../../syntax/functions';

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -3,9 +3,12 @@ import { isConst, Reference, VersionedPathReference, Tag, VersionedReference } f
 import { Op } from '@glimmer/vm';
 import { DynamicContentWrapper } from '../../vm/content/dynamic';
 import { isComponentDefinition } from '../../component/interfaces';
-import { APPEND_OPCODES, UpdatingOpcode } from '../../opcodes';
+import { UpdatingOpcode } from '../../opcodes';
 import { ConditionalReference } from '../../references';
-import { UpdatingVM } from '../../vm';
+import { UpdatingVM, VM } from '../../vm';
+import { Opcode } from '../../environment';
+
+export const CONTENT_MAPPINGS = {};
 
 export class IsComponentDefinitionReference extends ConditionalReference {
   static create(inner: Reference<Opaque>): IsComponentDefinitionReference {
@@ -17,7 +20,7 @@ export class IsComponentDefinitionReference extends ConditionalReference {
   }
 }
 
-APPEND_OPCODES.add(Op.DynamicContent, (vm, { op1: isTrusting }) => {
+export function DynamicContent(vm: VM, { op1: isTrusting }: Opcode) {
   let reference = vm.stack.pop<VersionedPathReference<Opaque>>();
   let value = reference.value();
   let content: DynamicContentWrapper;
@@ -31,7 +34,9 @@ APPEND_OPCODES.add(Op.DynamicContent, (vm, { op1: isTrusting }) => {
   if (!isConst(reference)) {
     vm.updateWith(new UpdateDynamicContentOpcode(reference, content));
   }
-});
+}
+
+CONTENT_MAPPINGS[Op.DynamicContent] = DynamicContent;
 
 class UpdateDynamicContentOpcode extends UpdatingOpcode {
   public tag: Tag;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -3,7 +3,7 @@ import { isConst, Reference, VersionedPathReference, Tag, VersionedReference } f
 import { Op } from '@glimmer/vm';
 import { DynamicContentWrapper } from '../../vm/content/dynamic';
 import { isComponentDefinition } from '../../component/interfaces';
-import { UpdatingOpcode } from '../../opcodes';
+import { UpdatingOpcode } from '../../updating-opcodes';
 import { ConditionalReference } from '../../references';
 import { UpdatingVM, VM } from '../../vm';
 import { Opcode } from '../../environment';

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -1,11 +1,13 @@
 import { Opaque } from '@glimmer/interfaces';
 import { VersionedPathReference } from '@glimmer/reference';
 import { dict } from '@glimmer/util';
-import { Scope } from '../../environment';
-import { APPEND_OPCODES } from '../../opcodes';
+import { Scope, Opcode } from '../../environment';
 import { Op } from '@glimmer/vm';
+import { VM } from '../../vm';
 
 export type DebugGet = ((path: string) => Opaque);
+
+export const DEBUG_MAPPINGS = {};
 
 export type DebugCallback = ((context: Opaque, get: DebugGet) => void);
 
@@ -66,9 +68,11 @@ class ScopeInspector {
   }
 }
 
-APPEND_OPCODES.add(Op.Debugger, (vm, { op1: _symbols, op2: _evalInfo }) => {
+export function Debugger(vm: VM, { op1: _symbols, op2: _evalInfo }: Opcode) {
   let symbols = vm.constants.getStringArray(_symbols);
   let evalInfo = vm.constants.getArray(_evalInfo);
   let inspector = new ScopeInspector(vm.scope(), symbols, evalInfo);
   callback(vm.getSelf().value(), path => inspector.get(path).value());
-});
+};
+
+DEBUG_MAPPINGS[Op.Debugger] = Debugger;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -11,7 +11,7 @@ import { Opaque, Option } from '@glimmer/util';
 import { Simple } from '@glimmer/interfaces';
 import { Op, Register } from '@glimmer/vm';
 import { Modifier as IModifier, ModifierManager } from '../../modifier/interfaces';
-import { UpdatingOpcode } from '../../opcodes';
+import { UpdatingOpcode } from '../../updating-opcodes';
 import { UpdatingVM, VM } from '../../vm';
 import { Arguments } from '../../vm/arguments';
 import { Assert } from './vm';
@@ -36,6 +36,8 @@ DOM_MAPPINGS[Op.Comment] = Comment;
 export function OpenElement(vm: VM, { op1: tag }: Opcode) {
   vm.elements().openElement(vm.constants.getString(tag));
 }
+
+DOM_MAPPINGS[Op.OpenElement] = OpenElement;
 
 export function OpenDynamicElement(vm: VM) {
   let tagName = vm.stack.pop<Reference<string>>().value();

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -1,45 +1,54 @@
 import { Opaque, Option, BlockSymbolTable } from '@glimmer/interfaces';
 import { VersionedPathReference } from '@glimmer/reference';
 import { Op } from '@glimmer/vm';
-import { Helper, Handle, ScopeBlock } from '../../environment';
-import { APPEND_OPCODES } from '../../opcodes';
+import { Helper as IHelper, Handle, ScopeBlock, Opcode } from '../../environment';
 import { FALSE_REFERENCE, TRUE_REFERENCE } from '../../references';
-import { PublicVM } from '../../vm';
+import { PublicVM, VM } from '../../vm';
 import { Arguments } from '../../vm/arguments';
 import { ConcatReference } from '../expressions/concat';
 
 export type FunctionExpression<T> = (vm: PublicVM) => VersionedPathReference<T>;
 
-APPEND_OPCODES.add(Op.Helper, (vm, { op1: specifier }) => {
+export const EXPRESSION_MAPPINGS = {};
+
+export function Helper(vm: VM, { op1: specifier }: Opcode) {
   let stack = vm.stack;
-  let helper = vm.constants.resolveSpecifier<Helper>(specifier);
+  let helper = vm.constants.resolveSpecifier<IHelper>(specifier);
   let args = stack.pop<Arguments>();
   let value = helper(vm, args);
 
   args.clear();
 
   vm.stack.push(value);
-});
+}
 
-APPEND_OPCODES.add(Op.GetVariable, (vm, { op1: symbol }) => {
+EXPRESSION_MAPPINGS[Op.Helper] = Helper;
+
+export function GetVariable(vm: VM, { op1: symbol }: Opcode) {
   let expr = vm.referenceForSymbol(symbol);
   vm.stack.push(expr);
-});
+}
 
-APPEND_OPCODES.add(Op.SetVariable, (vm, { op1: symbol }) => {
+EXPRESSION_MAPPINGS[Op.GetVariable] = GetVariable;
+
+export function SetVariable(vm: VM, { op1: symbol }: Opcode) {
   let expr = vm.stack.pop<VersionedPathReference<Opaque>>();
   vm.scope().bindSymbol(symbol, expr);
-});
+}
 
-APPEND_OPCODES.add(Op.SetBlock, (vm, { op1: symbol }) => {
+EXPRESSION_MAPPINGS[Op.SetVariable] = SetVariable;
+
+export function SetBlock(vm: VM, { op1: symbol }: Opcode) {
   let handle = vm.stack.pop<Option<Handle>>();
   let table = vm.stack.pop<Option<BlockSymbolTable>>();
   let block: Option<ScopeBlock> = table ? [handle!, table] : null;
 
   vm.scope().bindBlock(symbol, block);
-});
+}
 
-APPEND_OPCODES.add(Op.ResolveMaybeLocal, (vm, { op1: _name }) => {
+EXPRESSION_MAPPINGS[Op.SetBlock] = SetBlock;
+
+export function ResolveMaybeLocal(vm: VM, { op1: _name }: Opcode) {
   let name = vm.constants.getString(_name);
   let locals = vm.scope().getPartialMap()!;
 
@@ -49,19 +58,25 @@ APPEND_OPCODES.add(Op.ResolveMaybeLocal, (vm, { op1: _name }) => {
   }
 
   vm.stack.push(ref);
-});
+}
 
-APPEND_OPCODES.add(Op.RootScope, (vm, { op1: symbols, op2: bindCallerScope }) => {
+EXPRESSION_MAPPINGS[Op.ResolveMaybeLocal] = ResolveMaybeLocal;
+
+export function RootScope(vm: VM, { op1: symbols, op2: bindCallerScope }: Opcode) {
   vm.pushRootScope(symbols, !!bindCallerScope);
-});
+}
 
-APPEND_OPCODES.add(Op.GetProperty, (vm, { op1: _key }) => {
+EXPRESSION_MAPPINGS[Op.RootScope] = RootScope;
+
+export function GetProperty(vm: VM, { op1: _key }: Opcode) {
   let key = vm.constants.getString(_key);
   let expr = vm.stack.pop<VersionedPathReference<Opaque>>();
   vm.stack.push(expr.get(key));
-});
+}
 
-APPEND_OPCODES.add(Op.GetBlock, (vm, { op1: _block }) => {
+EXPRESSION_MAPPINGS[Op.GetProperty] = GetProperty;
+
+export function GetBlock(vm: VM, { op1: _block }: Opcode) {
   let { stack } = vm;
   let block = vm.scope().getBlock(_block);
 
@@ -72,20 +87,26 @@ APPEND_OPCODES.add(Op.GetBlock, (vm, { op1: _block }) => {
     stack.push(null);
     stack.push(null);
   }
-});
+}
 
-APPEND_OPCODES.add(Op.HasBlock, (vm, { op1: _block }) => {
+EXPRESSION_MAPPINGS[Op.GetBlock] = GetBlock;
+
+export function HasBlock(vm: VM, { op1: _block }: Opcode) {
   let hasBlock = !!vm.scope().getBlock(_block);
   vm.stack.push(hasBlock ? TRUE_REFERENCE : FALSE_REFERENCE);
-});
+}
 
-APPEND_OPCODES.add(Op.HasBlockParams, (vm, { op1: _block }) => {
+EXPRESSION_MAPPINGS[Op.HasBlock] = HasBlock;
+
+export function HasBlockParams(vm: VM, { op1: _block }: Opcode) {
   let block = vm.scope().getBlock(_block);
   let hasBlockParams = block && block[1].parameters.length;
   vm.stack.push(hasBlockParams ? TRUE_REFERENCE : FALSE_REFERENCE);
-});
+}
 
-APPEND_OPCODES.add(Op.Concat, (vm, { op1: count }) => {
+EXPRESSION_MAPPINGS[Op.HasBlockParams] = HasBlockParams;
+
+export function Concat(vm: VM, { op1: count }: Opcode) {
   let out: Array<VersionedPathReference<Opaque>> = new Array(count);
 
   for (let i = count; i > 0; i--) {
@@ -94,4 +115,6 @@ APPEND_OPCODES.add(Op.Concat, (vm, { op1: count }) => {
   }
 
   vm.stack.push(new ConcatReference(out));
-});
+}
+
+EXPRESSION_MAPPINGS[Op.Concat] = Concat;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/index.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/index.ts
@@ -7,19 +7,20 @@ import { EXPRESSION_MAPPINGS } from './expressions';
 import { LIST_MAPPINGS } from './lists';
 import { PARTIAL_MAPPINGS } from './partial';
 import { VM_MAPPINGS } from './vm';
+import { assign } from "@glimmer/util";
 
 export const operations = new Array(Op.Size);
 
-let operationsMap = {
-  ...COMPONENT_MAPPINGS,
-  ...CONTENT_MAPPINGS,
-  ...DEBUG_MAPPINGS,
-  ...DOM_MAPPINGS,
-  ...EXPRESSION_MAPPINGS,
-  ...LIST_MAPPINGS,
-  ...PARTIAL_MAPPINGS,
-  ...VM_MAPPINGS
-};
+let operationsMap = assign({},
+  COMPONENT_MAPPINGS,
+  CONTENT_MAPPINGS,
+  DEBUG_MAPPINGS,
+  DOM_MAPPINGS,
+  EXPRESSION_MAPPINGS,
+  LIST_MAPPINGS,
+  PARTIAL_MAPPINGS,
+  VM_MAPPINGS
+);
 
 for (let key in operationsMap) {
   operations[key] = operationsMap[key];

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/index.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/index.ts
@@ -7,14 +7,6 @@ import { EXPRESSION_MAPPINGS } from './expressions';
 import { LIST_MAPPINGS } from './lists';
 import { PARTIAL_MAPPINGS } from './partial';
 import { VM_MAPPINGS } from './vm';
-export * from './component';
-export * from './content';
-export * from './debugger';
-export * from './dom';
-export * from './lists';
-export * from './expressions';
-export * from './partial';
-export * from './vm';
 
 export const operations = new Array(Op.Size);
 
@@ -29,6 +21,6 @@ let operationsMap = {
   ...VM_MAPPINGS
 };
 
-Object.keys(operationsMap).map(t => parseInt(t, 10)).forEach((op: number) => {
-  operations[op] = operationsMap[op];
-});
+for (let key in operationsMap) {
+  operations[key] = operationsMap[key];
+}

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/index.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/index.ts
@@ -1,0 +1,34 @@
+import { Op } from '@glimmer/vm';
+import { COMPONENT_MAPPINGS } from './component';
+import { CONTENT_MAPPINGS } from './content';
+import { DEBUG_MAPPINGS } from './debugger';
+import { DOM_MAPPINGS } from './dom';
+import { EXPRESSION_MAPPINGS } from './expressions';
+import { LIST_MAPPINGS } from './lists';
+import { PARTIAL_MAPPINGS } from './partial';
+import { VM_MAPPINGS } from './vm';
+export * from './component';
+export * from './content';
+export * from './debugger';
+export * from './dom';
+export * from './lists';
+export * from './expressions';
+export * from './partial';
+export * from './vm';
+
+export const operations = new Array(Op.Size);
+
+let operationsMap = {
+  ...COMPONENT_MAPPINGS,
+  ...CONTENT_MAPPINGS,
+  ...DEBUG_MAPPINGS,
+  ...DOM_MAPPINGS,
+  ...EXPRESSION_MAPPINGS,
+  ...LIST_MAPPINGS,
+  ...PARTIAL_MAPPINGS,
+  ...VM_MAPPINGS
+};
+
+Object.keys(operationsMap).map(t => parseInt(t, 10)).forEach((op: number) => {
+  operations[op] = operationsMap[op];
+});

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
@@ -1,12 +1,15 @@
 import { VersionedReference, VersionedPathReference } from '@glimmer/reference';
 import { TemplateMeta } from '@glimmer/wire-format';
 import { Op } from '@glimmer/vm';
-import { APPEND_OPCODES } from '../../opcodes';
 import { PartialDefinition } from '../../partial';
 import { assert, dict } from "@glimmer/util";
 import { Opaque } from "@glimmer/interfaces";
+import { VM } from '../../vm';
+import { Opcode } from '../../environment';
 
-APPEND_OPCODES.add(Op.InvokePartial, (vm, { op1: _meta, op2: _symbols, op3: _evalInfo }) => {
+export const PARTIAL_MAPPINGS = {};
+
+export function InvokePartial(vm: VM, { op1: _meta, op2: _symbols, op3: _evalInfo }: Opcode) {
   let { constants, constants: { resolver }, stack } = vm;
 
   let name = stack.pop<VersionedReference</*Opaque*/ string>>().value();
@@ -56,4 +59,6 @@ APPEND_OPCODES.add(Op.InvokePartial, (vm, { op1: _meta, op2: _symbols, op3: _eva
     vm.pushFrame();
     vm.call(handle!);
   }
-});
+}
+
+PARTIAL_MAPPINGS[Op.InvokePartial] = InvokePartial;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -13,13 +13,21 @@ import {
 import { initializeGuid } from '@glimmer/util';
 import { Handle, Opcode } from '../../environment';
 import { LazyConstants } from '../../environment/constants';
-import { UpdatingOpcode } from '../../opcodes';
+import { UpdatingOpcode } from '../../updating-opcodes';
 import { Primitive as IPrimitive, PrimitiveReference as PrimitiveKlass, PrimitiveType } from '../../references';
 import { CompilableTemplate } from '../../syntax/interfaces';
 import { VM, UpdatingVM } from '../../vm';
 import { Arguments } from '../../vm/arguments';
 
 export const VM_MAPPINGS = {};
+
+export function Bug() { throw new Error('You compiled an operation that the VM does not know how to handle.'); }
+
+VM_MAPPINGS[Op.Bug] = Bug;
+
+export function Size() { console.log(`Glimmer has ${Op.Size} opcodes.`); }
+
+VM_MAPPINGS[Op.Size] = Size;
 
 export function ChildScope(vm: VM) { vm.pushChildScope(); }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -11,27 +11,39 @@ import {
   Tag
 } from '@glimmer/reference';
 import { initializeGuid } from '@glimmer/util';
-import { Handle } from '../../environment';
+import { Handle, Opcode } from '../../environment';
 import { LazyConstants } from '../../environment/constants';
-import { APPEND_OPCODES, UpdatingOpcode } from '../../opcodes';
-import { Primitive, PrimitiveReference, PrimitiveType } from '../../references';
+import { UpdatingOpcode } from '../../opcodes';
+import { Primitive as IPrimitive, PrimitiveReference as PrimitiveKlass, PrimitiveType } from '../../references';
 import { CompilableTemplate } from '../../syntax/interfaces';
 import { VM, UpdatingVM } from '../../vm';
 import { Arguments } from '../../vm/arguments';
 
-APPEND_OPCODES.add(Op.ChildScope, vm => vm.pushChildScope());
+export const VM_MAPPINGS = {};
 
-APPEND_OPCODES.add(Op.PopScope, vm => vm.popScope());
+export function ChildScope(vm: VM) { vm.pushChildScope(); }
 
-APPEND_OPCODES.add(Op.PushDynamicScope, vm => vm.pushDynamicScope());
+VM_MAPPINGS[Op.ChildScope] = ChildScope;
 
-APPEND_OPCODES.add(Op.PopDynamicScope, vm => vm.popDynamicScope());
+export function PopScope(vm: VM) { vm.popScope(); }
 
-APPEND_OPCODES.add(Op.Constant, (vm: VM & { constants: LazyConstants }, { op1: other }) => {
+VM_MAPPINGS[Op.PopScope] = PopScope;
+
+export function PushDynamicScope(vm: VM) { vm.pushDynamicScope(); }
+
+VM_MAPPINGS[Op.PushDynamicScope] = PushDynamicScope;
+
+export function PopDynamicScope(vm: VM) { vm.popDynamicScope(); }
+
+VM_MAPPINGS[Op.PopDynamicScope] = PopDynamicScope;
+
+export function Constant(vm: VM & { constants: LazyConstants }, { op1: other }: Opcode) {
   vm.stack.push(vm.constants.getOther(other));
-});
+}
 
-APPEND_OPCODES.add(Op.Primitive, (vm, { op1: primitive }) => {
+VM_MAPPINGS[Op.Constant] = Constant;
+
+export function Primitive(vm: VM, { op1: primitive }: Opcode) {
   let stack = vm.stack;
   let flag: PrimitiveType = primitive & 7; // 111
   let value = primitive >> 3;
@@ -55,46 +67,72 @@ APPEND_OPCODES.add(Op.Primitive, (vm, { op1: primitive }) => {
       }
       break;
   }
-});
+}
 
-APPEND_OPCODES.add(Op.PrimitiveReference, vm => {
+VM_MAPPINGS[Op.Primitive] = Primitive;
+
+export function PrimitiveReference(vm: VM) {
   let stack = vm.stack;
-  stack.push(PrimitiveReference.create(stack.pop<Primitive>()));
-});
+  stack.push(PrimitiveKlass.create(stack.pop<IPrimitive>()));
+}
 
-APPEND_OPCODES.add(Op.Dup, (vm, { op1: register, op2: offset }) => {
+VM_MAPPINGS[Op.PrimitiveReference] = PrimitiveReference;
+
+export function Dup(vm: VM, { op1: register, op2: offset }: Opcode) {
   let position = vm.fetchValue<number>(register) - offset;
   vm.stack.dup(position);
-});
+}
 
-APPEND_OPCODES.add(Op.Pop, (vm, { op1: count }) => vm.stack.pop(count));
+VM_MAPPINGS[Op.Dup] = Dup;
 
-APPEND_OPCODES.add(Op.Load, (vm, { op1: register }) => vm.load(register));
+export function Pop(vm: VM, { op1: count }: Opcode) { vm.stack.pop(count); }
 
-APPEND_OPCODES.add(Op.Fetch, (vm, { op1: register }) => vm.fetch(register));
+VM_MAPPINGS[Op.Pop] = Pop;
 
-APPEND_OPCODES.add(Op.BindDynamicScope, (vm, { op1: _names }) => {
+export function Load(vm: VM, { op1: register }: Opcode) { vm.load(register); }
+
+VM_MAPPINGS[Op.Load] = Load;
+
+export function Fetch(vm: VM, { op1: register }: Opcode) { vm.fetch(register); }
+
+VM_MAPPINGS[Op.Fetch] = Fetch;
+
+export function BindDynamicScope(vm: VM, { op1: _names }: Opcode) {
   let names = vm.constants.getArray(_names);
   vm.bindDynamicScope(names);
-});
+}
 
-APPEND_OPCODES.add(Op.PushFrame, vm => vm.pushFrame());
+VM_MAPPINGS[Op.BindDynamicScope] = BindDynamicScope;
 
-APPEND_OPCODES.add(Op.PopFrame, vm => vm.popFrame());
+export function PushFrame(vm: VM) { vm.pushFrame(); }
 
-APPEND_OPCODES.add(Op.Enter, (vm, { op1: args }) => vm.enter(args));
+VM_MAPPINGS[Op.PushFrame] = PushFrame;
 
-APPEND_OPCODES.add(Op.Exit, (vm) => vm.exit());
+export function PopFrame(vm: VM) { vm.popFrame(); }
 
-APPEND_OPCODES.add(Op.CompileBlock, vm => {
+VM_MAPPINGS[Op.PopFrame] = PopFrame;
+
+export function Enter(vm: VM, { op1: args }: Opcode) { vm.enter(args); }
+
+VM_MAPPINGS[Op.Enter] = Enter;
+
+export function Exit(vm: VM) { vm.exit(); }
+
+VM_MAPPINGS[Op.Exit] = Exit;
+
+export function CompileBlock(vm: VM) {
   let stack = vm.stack;
   let block = stack.pop<Option<CompilableTemplate> | 0>();
   stack.push(block ? block.compile() : null);
-});
+}
 
-APPEND_OPCODES.add(Op.InvokeStatic, vm => vm.call(vm.stack.pop<Handle>()));
+VM_MAPPINGS[Op.CompileBlock] = CompileBlock;
 
-APPEND_OPCODES.add(Op.InvokeYield, vm => {
+export function InvokeStatic(vm: VM) { vm.call(vm.stack.pop<Handle>()); }
+
+VM_MAPPINGS[Op.InvokeStatic] = InvokeStatic;
+
+export function InvokeYield(vm: VM) {
   let { stack } = vm;
 
   let handle = stack.pop<Option<Handle>>();
@@ -126,11 +164,15 @@ APPEND_OPCODES.add(Op.InvokeYield, vm => {
 
   vm.pushFrame();
   vm.call(handle!);
-});
+}
 
-APPEND_OPCODES.add(Op.Jump, (vm, { op1: target }) => vm.goto(target));
+VM_MAPPINGS[Op.InvokeYield] = InvokeYield;
 
-APPEND_OPCODES.add(Op.JumpIf, (vm, { op1: target }) => {
+export function Jump(vm: VM, { op1: target }: Opcode) { vm.goto(target); }
+
+VM_MAPPINGS[Op.Jump] = Jump;
+
+export function JumpIf(vm: VM, { op1: target }: Opcode) {
   let reference = vm.stack.pop<VersionedPathReference<Opaque>>();
 
   if (isConst(reference)) {
@@ -146,9 +188,11 @@ APPEND_OPCODES.add(Op.JumpIf, (vm, { op1: target }) => {
 
     vm.updateWith(new Assert(cache));
   }
-});
+}
 
-APPEND_OPCODES.add(Op.JumpUnless, (vm, { op1: target }) => {
+VM_MAPPINGS[Op.JumpIf] = JumpIf;
+
+export function JumpUnless(vm: VM, { op1: target }: Opcode) {
   let reference = vm.stack.pop<VersionedPathReference<Opaque>>();
 
   if (isConst(reference)) {
@@ -164,17 +208,26 @@ APPEND_OPCODES.add(Op.JumpUnless, (vm, { op1: target }) => {
 
     vm.updateWith(new Assert(cache));
   }
-});
+}
 
-APPEND_OPCODES.add(Op.Return, vm => vm.return());
-APPEND_OPCODES.add(Op.ReturnTo, (vm, { op1: relative }) => {
+VM_MAPPINGS[Op.JumpUnless] = JumpUnless;
+
+export function Return(vm: VM) { vm.return(); }
+
+VM_MAPPINGS[Op.Return] = Return;
+
+export function ReturnTo(vm: VM, { op1: relative }: Opcode) {
   vm.returnTo(relative);
-});
+}
 
-APPEND_OPCODES.add(Op.ToBoolean, vm => {
+VM_MAPPINGS[Op.ReturnTo] = ReturnTo;
+
+export function ToBoolean(vm: VM) {
   let { env, stack } = vm;
   stack.push(env.toConditionalReference(stack.pop<Reference>()));
-});
+}
+
+VM_MAPPINGS[Op.ToBoolean] = ToBoolean;
 
 export class Assert extends UpdatingOpcode {
   public type = 'assert';

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -1,7 +1,6 @@
-import { Opaque, Option, Slice as ListSlice, initializeGuid, unreachable, typePos } from '@glimmer/util';
+import { Opaque, Option, unreachable, typePos } from '@glimmer/util';
 import { Op, Register } from '@glimmer/vm';
-import { Tag } from '@glimmer/reference';
-import { VM, UpdatingVM } from './vm';
+import { VM } from './vm';
 import { Opcode, Program } from './environment';
 import { Constants, LazyConstants } from './environment/constants';
 import { DEBUG } from '@glimmer/local-debug-flags';
@@ -211,23 +210,3 @@ export class AppendOpcodes {
 }
 
 export const APPEND_OPCODES = new AppendOpcodes(operations);
-
-export abstract class AbstractOpcode {
-  public type: string;
-  public _guid: number;
-
-  constructor() {
-    initializeGuid(this);
-  }
-}
-
-export abstract class UpdatingOpcode extends AbstractOpcode {
-  public abstract tag: Tag;
-
-  next: Option<UpdatingOpcode> = null;
-  prev: Option<UpdatingOpcode> = null;
-
-  abstract evaluate(vm: UpdatingVM): void;
-}
-
-export type UpdatingOpSeq = ListSlice<UpdatingOpcode>;

--- a/packages/@glimmer/runtime/lib/updating-opcodes.ts
+++ b/packages/@glimmer/runtime/lib/updating-opcodes.ts
@@ -1,0 +1,24 @@
+import { initializeGuid, ListSlice } from "@glimmer/util";
+import { Option } from "@glimmer/interfaces";
+import { Tag } from "@glimmer/reference";
+import { UpdatingVM } from './vm';
+
+export abstract class AbstractOpcode {
+  public type: string;
+  public _guid: number;
+
+  constructor() {
+    initializeGuid(this);
+  }
+}
+
+export abstract class UpdatingOpcode extends AbstractOpcode {
+  public abstract tag: Tag;
+
+  next: Option<UpdatingOpcode> = null;
+  prev: Option<UpdatingOpcode> = null;
+
+  abstract evaluate(vm: UpdatingVM): void;
+}
+
+export type UpdatingOpSeq = ListSlice<UpdatingOpcode>;

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -10,9 +10,9 @@ import RenderResult from './render-result';
 import { DEBUG } from '@glimmer/local-debug-flags';
 
 import {
-  APPEND_OPCODES,
-  UpdatingOpcode
+  APPEND_OPCODES
 } from '../opcodes';
+import { UpdatingOpcode } from '../updating-opcodes';
 
 import {
   Constants,

--- a/packages/@glimmer/runtime/lib/vm/render-result.ts
+++ b/packages/@glimmer/runtime/lib/vm/render-result.ts
@@ -2,7 +2,7 @@ import { Option, LinkedList } from '@glimmer/util';
 import Environment, { Program } from '../environment';
 import { DestroyableBounds, clear } from '../bounds';
 import UpdatingVM, { ExceptionHandler } from './update';
-import { UpdatingOpcode } from '../opcodes';
+import { UpdatingOpcode } from '../updating-opcodes';
 import { Simple } from '@glimmer/interfaces';
 
 export default class RenderResult implements DestroyableBounds, ExceptionHandler {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -18,7 +18,7 @@ import {
   INITIAL,
   Tag
 } from '@glimmer/reference';
-import { UpdatingOpcode, UpdatingOpSeq } from '../updating-opcodes';
+import { UpdatingOpcode } from '../updating-opcodes';
 import { Constants } from '../environment/constants';
 import { DOMChanges } from '../dom/helper';
 import { Simple } from '@glimmer/interfaces';
@@ -40,7 +40,7 @@ export default class UpdatingVM {
     this.alwaysRevalidate = alwaysRevalidate;
   }
 
-  execute(opcodes: UpdatingOpSeq, handler: ExceptionHandler) {
+  execute(opcodes: LinkedList<UpdatingOpcode>, handler: ExceptionHandler) {
     let { frameStack } = this;
 
     this.try(opcodes, handler);
@@ -67,7 +67,7 @@ export default class UpdatingVM {
     this.frame.goto(op);
   }
 
-  try(ops: UpdatingOpSeq, handler: Option<ExceptionHandler>) {
+  try(ops: LinkedList<UpdatingOpcode>, handler: Option<ExceptionHandler>) {
     this.frameStack.push(new UpdatingVMFrame(this, ops, handler));
   }
 
@@ -317,7 +317,7 @@ export class ListBlockOpcode extends BlockOpcode {
 class UpdatingVMFrame {
   private current: Option<UpdatingOpcode>;
 
-  constructor(private vm: UpdatingVM, private ops: UpdatingOpSeq, private exceptionHandler: Option<ExceptionHandler>) {
+  constructor(private vm: UpdatingVM, private ops: LinkedList<UpdatingOpcode>, private exceptionHandler: Option<ExceptionHandler>) {
     this.vm = vm;
     this.ops = ops;
     this.current = ops.head();

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -18,7 +18,7 @@ import {
   INITIAL,
   Tag
 } from '@glimmer/reference';
-import { UpdatingOpcode, UpdatingOpSeq } from '../opcodes';
+import { UpdatingOpcode, UpdatingOpSeq } from '../updating-opcodes';
 import { Constants } from '../environment/constants';
 import { DOMChanges } from '../dom/helper';
 import { Simple } from '@glimmer/interfaces';


### PR DESCRIPTION
This consolidates the side-effect modules to one place which we can overwrite at build time.

At build time we will know the exact Append opcodes we will execute at runtime. This means we can generate a custom `@glimmer/runtime/compiled/opcodes/index` at build time that clobbers the one we use to do development on the VM. The build would simply import only the operations needed at runtime and create a static operations array instead of one that is built at runtime. This will allow for things like rollup to shed the weight of the unused operations. Also in this mode we would nuke all the `* _MAPPINGS`

I would also argue that this makes moving around in the VM easier, meaning you have an actual symbol to lookup that is the same name as the operation. You will also have better debug-ability and ability to performance tune as you won't just see "anonymous function" in the profiler.

<img width="1198" alt="screen shot 2017-08-22 at 4 13 15 pm" src="https://user-images.githubusercontent.com/183799/29585363-e09638a4-8754-11e7-9426-0879f9ca32fa.png">
