### PR TITLE
Don't allocate empty arguments

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -124,11 +124,13 @@ export class Arguments implements IArguments {
   }
 
   capture(): ICapturedArguments {
+    let positional = this.positional.length === 0 ? EMPTY_POSITIONAL : this.positional.capture();
+    let named = this.named.length === 0 ? EMPTY_NAMED : this.named.capture();
     return {
       tag: this.tag,
       length: this.length,
-      positional: this.positional.capture(),
-      named: this.named.capture()
+      positional,
+      named
     };
   }
 


### PR DESCRIPTION
I don't know if there is a good reason to allocate these objects if there is nothing inside of them. The currying code looks like it only reads from the captured arguments.