### PR TITLE
Bundle Compiler refactoring pass

### DIFF
--- a/packages/@glimmer/bundle-compiler/index.ts
+++ b/packages/@glimmer/bundle-compiler/index.ts
@@ -1,1 +1,20 @@
-export * from './lib/templates';
+export {
+  BundleCompiler,
+  BundleCompilerOptions,
+  BundleCompileOptions,
+  BundleCompilationResult
+} from './lib/bundle-compiler';
+
+export {
+  CompilerDelegate
+} from './lib/compiler-delegate';
+
+export {
+  Specifier,
+  specifierFor
+} from './lib/specifiers';
+
+export {
+  SpecifierMap,
+  LookupMap
+} from './lib/specifier-map';

--- a/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
+++ b/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
@@ -1,0 +1,130 @@
+import { ProgramSymbolTable } from "@glimmer/interfaces";
+import { ICompilableTemplate, ComponentCapabilities } from "@glimmer/opcode-compiler";
+
+import { Specifier } from "./specifiers";
+
+/**
+ * A CompilerDelegate helps the BundleCompiler map external references it finds
+ * in a template, such as other components and helpers, to their corresponding
+ * implementation.
+ *
+ * For example, if the compiler comes across the string `<MyOtherComponent />`
+ * in a template, it needs to know what template and component class on disk
+ * `MyOtherComponent` refers to. By moving this decision-making to the delegate,
+ * host environments can implement their own resolution semantics rather than
+ * having resolution hardcoded into Glimmer.
+ *
+ * Because resolution often depends on where a component was invoked, many hooks
+ * take a referrer, or the specifier for the template where the invocation was
+ * found, as the second argument.
+ *
+ * For example, if the template with the specifier
+ * `{ module: 'src/ui/components/MyComponent.js', name: 'template' }` contains
+ * the string `<MyOtherComponent />`, the compiler would invoke
+ * `hasComponentInScope` with `'MyOtherComponent'` as the first argument and this
+ * specifier as the second argument.
+ *
+ * The CompilerDelegate is also responsible for describing the capabilities of a
+ * particular component by returning a ComponentCapabilities descriptor. Glimmer
+ * uses this information to perform additional optimizations during the
+ * compilation phase.
+ */
+export interface CompilerDelegate {
+  /**
+   * During compilation, the compiler will ask the delegate about each component
+   * invocation found in the passed template. If the component exists in scope,
+   * the delegate should return `true`. If the component does not exist in
+   * scope, return `false`. Note that returning `false` will cause the
+   * compilation process to fail.
+   */
+  hasComponentInScope(componentName: string, referrer: Specifier): boolean;
+
+  /**
+   * If the delegate returns `true` from `hasComponentInScope()`, the compiler
+   * will next ask the delegate to turn the relative specifier into an
+   * globally-unique absolute specifier. By providing this unique identifier,
+   * the compiler avoids having to compile the same component multiple times if
+   * invoked from different locations.
+   */
+  resolveComponentSpecifier(componentName: string, referrer: Specifier): Specifier;
+
+  /**
+   * The compiler calls this hook with the return value of
+   * `resolveComponentSpecifier`, and it should return the required capabilities
+   * for the given component via a ComponentCapabilities descriptor.
+   */
+  getComponentCapabilities(specifier: Specifier): ComponentCapabilities;
+
+  /**
+   * This hook is called with the return value of `resolveComponentSpecifier`,
+   * and it should return a compilable template that the compiler adds to the
+   * set of templates to compile for the bundle.
+   */
+  getComponentLayout(specifier: Specifier): ICompilableTemplate<ProgramSymbolTable>;
+
+  /**
+   * During compilation, the compiler will ask the delegate about each possible
+   * helper invocation found in the passed template. If the helper exists in
+   * scope, the delegate should return `true`. If the helper does not exist
+   * in scope, return `false`.
+   *
+   * Unlike with component resolution, note that returning `false` from this
+   * hook does not always cause compilation to fail. That's because helpers may
+   * be ambiguous with value expressions.
+   *
+   * For example, if the compiler encounters `{{currentTime}}` in a template, it
+   * will call `hasHelperInScope` with `'currentTime'` as the first argument. If
+   * `hasHelperInScope` returns `false`, the compiler will treat `currentTime`
+   * as a value rather than a helper.
+   */
+  hasHelperInScope(helperName: string, referer: Specifier): boolean;
+
+  /**
+   * If the delegate returns `true` from `hasHelperInScope()`, the compiler will
+   * next ask the delegate to provide a specifier corresponding to the helper function.
+   */
+  resolveHelperSpecifier(helperName: string, referer: Specifier): Specifier;
+
+  /**
+   * During compilation, the compiler will ask the delegate about each element
+   * modifier invocation found in the passed template. Element modifiers are
+   * mustaches that appear in the attribute position of elements, like
+   * `<div {{elementModifier}}>`.
+   *
+   * If the modifier exists in scope, the delegate should return `true`. If the
+   * modifier does not exist in scope, return `false`. Note that returning
+   * `false` will cause the compilation process to fail.
+   */
+  hasModifierInScope(modifierName: string, referer: Specifier): boolean;
+
+  /**
+   * If the delegate returns `true` from `hasModifierInScope()`, the compiler
+   * will next ask the delegate to provide a specifier corresponding to the
+   * element modifier function.
+   */
+  resolveModifierSpecifier(modifierName: string, referer: Specifier): Specifier;
+
+  /**
+   * During compilation, the compiler will ask the delegate about each partial
+   * invocation found in the passed template. Partials are invoked with a
+   * special `partial` helper, like `{{partial "partialName"}}`.
+   *
+   * If the partial exists in scope, the delegate should return `true`. If the
+   * partial does not exist in scope, return `false`. Note that returning
+   * `false` will cause the compilation process to fail.
+   *
+   * Partials should be avoided because they disable many compiler
+   * optimizations. Only legacy environments with backwards-compatibility
+   * constraints should implement partials. New environments should always
+   * return `false` from `hasPartialInScope` to disable the feature entirely.
+   * Components replace all use cases for partials with better performance.
+   */
+  hasPartialInScope(partialName: string, referer: Specifier): boolean;
+
+  /**
+   * If the delegate returns `true` from `hasPartialInScope()`, the compiler
+   * will next ask the delegate to provide a specifier corresponding to the
+   * partial template.
+   */
+  resolvePartialSpecifier(partialName: string, referer: Specifier): Specifier;
+}

--- a/packages/@glimmer/bundle-compiler/lib/specifier-map.ts
+++ b/packages/@glimmer/bundle-compiler/lib/specifier-map.ts
@@ -1,0 +1,57 @@
+import { Opaque } from "@glimmer/util";
+
+import { Specifier } from "./specifiers";
+
+/**
+ * Maps a specifier to its associated handle, or unique integer ID. Host
+ * environments can use the specifier map provided at the end of compilation to
+ * build a data structure for converting handles into actual module values.
+ */
+export class SpecifierMap {
+  public bySpecifier = new LookupMap<Specifier, number>();
+  public byHandle = new LookupMap<number, Specifier>();
+
+  public byVMHandle = new LookupMap<number, Specifier>();
+  public vmHandleBySpecifier = new LookupMap<Specifier, number>();
+}
+
+export interface Mapping {
+  get(key: Opaque): Opaque;
+  set(key: Opaque, value: Opaque): void;
+  forEach(cb: (value: Opaque, key: Opaque) => void): void;
+}
+
+export class LookupMap<K, V> implements Mapping {
+  private pairs: Opaque[];
+  size = 0;
+  constructor() {
+    this.pairs = [];
+  }
+
+  set(key: K, value: V) {
+    let idx = this.pairs.indexOf(key);
+    if (idx === -1) {
+      this.pairs.push(key, value);
+      this.size++;
+    } else {
+      this.pairs[idx + 1] = value;
+    }
+  }
+
+  get(key: K): V | undefined {
+    let idx = this.pairs.indexOf(key);
+    if (idx > -1) {
+      return this.pairs[idx + 1] as V;
+    }
+
+    return undefined;
+  }
+
+  forEach(cb: (value: V, key: K) => void) {
+    for (let i = 0; i < this.pairs.length; i += 2) {
+      let value = this.pairs[i + 1];
+      let key = this.pairs[i];
+      cb(value as V, key as K);
+    }
+  }
+}

--- a/packages/@glimmer/bundle-compiler/lib/specifiers.ts
+++ b/packages/@glimmer/bundle-compiler/lib/specifiers.ts
@@ -1,0 +1,60 @@
+import { dict, Dict } from '@glimmer/util';
+
+export type ModuleName = string;
+export type NamedExport = string;
+
+/**
+ * Specifiers are a data structure that represents a single export for a given
+ * module. For example, given the file `person.js`:
+ *
+ *    export default class Person {
+ *      constructor(firstName, lastName) {
+ *        this.firstName = firstName;
+ *        this.lastName = lastName;
+ *      }
+ *    }
+ *
+ *    export const DEFAULT_PERSON = new Person('Yehuda', 'Katz');
+ *
+ * This file would be described by two specifiers:
+ *
+ *   // describes the Person class default export
+ *   { module: 'person.js', name: 'default' }
+ *   // describes the named export of the Yehuda Katz instance
+ *   { module: 'person.js', name: 'DEFAULT_PERSON' }
+ *
+ * Specifiers allow the Glimmer compiler and the host environment to refer to
+ * module exports symbolically at compile time. During compilation, each specifier
+ * is assigned a unique handle. At runtime, the host environment is responsible for
+ * providing the actual module export value for a given handle.
+ */
+export interface Specifier {
+  module: ModuleName;
+  name: NamedExport;
+}
+
+const SPECIFIERS = dict<Dict<Specifier>>();
+
+/**
+ * Returns a Specifier object for a given module/export name pair.
+ *
+ * Because the compiler relies on identity for checking specifier equality, the
+ * same object is guaranteed to be returned from this function if invoked with
+ * the same arguments multiple times. That is, `specifierFor('a', 'b') ===
+ * specifierFor('a', 'b')`.
+ *
+ * @param module the module identifier, usually a relative path
+ * @param name the export name (or 'default' for default exports)
+ * @returns {Specifier}
+ */
+export function specifierFor(module: ModuleName, name: NamedExport): Specifier {
+  let specifiers = SPECIFIERS[module];
+
+  if (!specifiers) specifiers = SPECIFIERS[module] = dict<Specifier>();
+
+  let specifier = specifiers[name];
+
+  if (!specifier) specifier = specifiers[name] = { module, name };
+
+  return specifier;
+}


### PR DESCRIPTION
Previously, all of the bundle compiler implementation was in a single file called `templates.ts`. This commit breaks that file into logical units and also adds some additional inline documentation.