### PR TITLE
Rename all instances of `referer` to `referrer`

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -106,7 +106,7 @@ export class BundleCompiler {
       Builder,
       lookup,
       asPartial,
-      referer: specifier
+      referrer: specifier
     };
   }
 
@@ -159,27 +159,27 @@ class BundlingLookup implements CompileTimeLookup<Specifier> {
     return this.delegate.getComponentLayout(specifier);
   }
 
-  lookupHelper(name: string, referer: Specifier): Option<number> {
-    if (this.delegate.hasHelperInScope(name, referer)) {
-      let specifier = this.delegate.resolveHelperSpecifier(name, referer);
+  lookupHelper(name: string, referrer: Specifier): Option<number> {
+    if (this.delegate.hasHelperInScope(name, referrer)) {
+      let specifier = this.delegate.resolveHelperSpecifier(name, referrer);
       return this.registerSpecifier(specifier);
     } else {
       return null;
     }
   }
 
-  lookupComponentSpec(name: string, referer: Specifier): Option<number> {
-    if (this.delegate.hasComponentInScope(name, referer)) {
-      let specifier = this.delegate.resolveComponentSpecifier(name, referer);
+  lookupComponentSpec(name: string, referrer: Specifier): Option<number> {
+    if (this.delegate.hasComponentInScope(name, referrer)) {
+      let specifier = this.delegate.resolveComponentSpecifier(name, referrer);
       return this.registerSpecifier(specifier);
     } else {
       return null;
     }
   }
 
-  lookupModifier(name: string, referer: Specifier): Option<number> {
-    if (this.delegate.hasModifierInScope(name, referer)) {
-      let specifier = this.delegate.resolveModifierSpecifier(name, referer);
+  lookupModifier(name: string, referrer: Specifier): Option<number> {
+    if (this.delegate.hasModifierInScope(name, referrer)) {
+      let specifier = this.delegate.resolveModifierSpecifier(name, referrer);
       return this.registerSpecifier(specifier);
     } else {
       return null;

--- a/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
+++ b/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
@@ -77,13 +77,13 @@ export interface CompilerDelegate {
    * `hasHelperInScope` returns `false`, the compiler will treat `currentTime`
    * as a value rather than a helper.
    */
-  hasHelperInScope(helperName: string, referer: Specifier): boolean;
+  hasHelperInScope(helperName: string, referrer: Specifier): boolean;
 
   /**
    * If the delegate returns `true` from `hasHelperInScope()`, the compiler will
    * next ask the delegate to provide a specifier corresponding to the helper function.
    */
-  resolveHelperSpecifier(helperName: string, referer: Specifier): Specifier;
+  resolveHelperSpecifier(helperName: string, referrer: Specifier): Specifier;
 
   /**
    * During compilation, the compiler will ask the delegate about each element
@@ -95,14 +95,14 @@ export interface CompilerDelegate {
    * modifier does not exist in scope, return `false`. Note that returning
    * `false` will cause the compilation process to fail.
    */
-  hasModifierInScope(modifierName: string, referer: Specifier): boolean;
+  hasModifierInScope(modifierName: string, referrer: Specifier): boolean;
 
   /**
    * If the delegate returns `true` from `hasModifierInScope()`, the compiler
    * will next ask the delegate to provide a specifier corresponding to the
    * element modifier function.
    */
-  resolveModifierSpecifier(modifierName: string, referer: Specifier): Specifier;
+  resolveModifierSpecifier(modifierName: string, referrer: Specifier): Specifier;
 
   /**
    * During compilation, the compiler will ask the delegate about each partial
@@ -119,12 +119,12 @@ export interface CompilerDelegate {
    * return `false` from `hasPartialInScope` to disable the feature entirely.
    * Components replace all use cases for partials with better performance.
    */
-  hasPartialInScope(partialName: string, referer: Specifier): boolean;
+  hasPartialInScope(partialName: string, referrer: Specifier): boolean;
 
   /**
    * If the delegate returns `true` from `hasPartialInScope()`, the compiler
    * will next ask the delegate to provide a specifier corresponding to the
    * partial template.
    */
-  resolvePartialSpecifier(partialName: string, referer: Specifier): Specifier;
+  resolvePartialSpecifier(partialName: string, referrer: Specifier): Specifier;
 }

--- a/packages/@glimmer/bundle-compiler/test/initial-render-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/initial-render-test.ts
@@ -60,8 +60,8 @@ export class RuntimeResolver implements IRuntimeResolver<Specifier> {
     throw new Error("Method not implemented.");
   }
 
-  lookupComponent(name: string, referer: Specifier): Option<ComponentSpec> {
-    let moduleName = this.modules.resolve(name, referer, 'ui/components');
+  lookupComponent(name: string, referrer: Specifier): Option<ComponentSpec> {
+    let moduleName = this.modules.resolve(name, referrer, 'ui/components');
 
     if (!moduleName) return null;
 
@@ -121,8 +121,8 @@ export class Modules {
     this.registry[name] = new Module(value, type);
   }
 
-  resolve(name: string, referer: Specifier, defaultRoot?: string): Option<string> {
-    let local = referer.module && referer.module.replace(/^((.*)\/)?([^\/]*)$/, `$1${name}`);
+  resolve(name: string, referrer: Specifier, defaultRoot?: string): Option<string> {
+    let local = referrer.module && referrer.module.replace(/^((.*)\/)?([^\/]*)$/, `$1${name}`);
     if (local && this.registry[local]) {
       return local;
     } else if (defaultRoot && this.registry[`${defaultRoot}/${name}`]) {
@@ -138,13 +138,13 @@ export class Modules {
 class BundlingDelegate implements CompilerDelegate {
   constructor(private components: Dict<CompileTimeComponent>, private modules: Modules, private compileTimeModules: Modules, private compile: (specifier: Specifier) => VMHandle) {}
 
-  hasComponentInScope(componentName: string, referer: Specifier): boolean {
-    let name = this.modules.resolve(componentName, referer, 'ui/components');
+  hasComponentInScope(componentName: string, referrer: Specifier): boolean {
+    let name = this.modules.resolve(componentName, referrer, 'ui/components');
     return name ? this.modules.type(name) === 'component' : false;
   }
 
-  resolveComponentSpecifier(componentName: string, referer: Specifier): Specifier {
-    return specifierFor(this.modules.resolve(componentName, referer, 'ui/components')!, 'default');
+  resolveComponentSpecifier(componentName: string, referrer: Specifier): Specifier {
+    return specifierFor(this.modules.resolve(componentName, referrer, 'ui/components')!, 'default');
   }
 
   getComponentCapabilities(specifier: Specifier): ComponentCapabilities {
@@ -164,26 +164,26 @@ class BundlingDelegate implements CompilerDelegate {
     };
   }
 
-  hasHelperInScope(helperName: string, referer: Specifier): boolean {
-    let name = this.modules.resolve(helperName, referer);
+  hasHelperInScope(helperName: string, referrer: Specifier): boolean {
+    let name = this.modules.resolve(helperName, referrer);
     return name ? this.modules.type(name) === 'helper' : false;
   }
 
-  resolveHelperSpecifier(helperName: string, referer: Specifier): Specifier {
-    let path = this.modules.resolve(helperName, referer);
+  resolveHelperSpecifier(helperName: string, referrer: Specifier): Specifier {
+    let path = this.modules.resolve(helperName, referrer);
     return specifierFor(path!, 'default');
   }
 
-  hasModifierInScope(_modifierName: string, _referer: Specifier): boolean {
+  hasModifierInScope(_modifierName: string, _referrer: Specifier): boolean {
     return false;
   }
-  resolveModifierSpecifier(_modifierName: string, _referer: Specifier): Specifier {
+  resolveModifierSpecifier(_modifierName: string, _referrer: Specifier): Specifier {
     throw new Error("Method not implemented.");
   }
-  hasPartialInScope(_partialName: string, _referer: Specifier): boolean {
+  hasPartialInScope(_partialName: string, _referrer: Specifier): boolean {
     return false;
   }
-  resolvePartialSpecifier(_partialName: string, _referer: Specifier): Specifier {
+  resolvePartialSpecifier(_partialName: string, _referrer: Specifier): Specifier {
     throw new Error("Method not implemented.");
   }
 }
@@ -422,7 +422,7 @@ class BundlingRenderDelegate implements RenderDelegate {
       if (component.type === "Curly" || component.type === "Dynamic") {
         let block = compiler.preprocess(spec, component.template);
         let options = compiler.compileOptions(spec);
-        let parsedLayout = { block, referer: spec };
+        let parsedLayout = { block, referrer: spec };
         let wrapped = new WrappedBuilder(options, parsedLayout, EMBERISH_CURLY_CAPABILITIES);
         compiler.addCustom(spec, wrapped);
 
@@ -437,7 +437,7 @@ class BundlingRenderDelegate implements RenderDelegate {
         symbolTable = {
           hasEval: block.hasEval,
           symbols: block.symbols,
-          referer: key,
+          referrer: key,
         };
 
         this.speficiersToSymbolTable.set(spec, symbolTable);

--- a/packages/@glimmer/compiler/test/compile-options-test.ts
+++ b/packages/@glimmer/compiler/test/compile-options-test.ts
@@ -14,7 +14,7 @@ QUnit.module('[glimmer-compiler] Compile options', {
 QUnit.test('moduleName option is passed into meta', assert => {
   let moduleName = 'It ain\'t hard to tell';
   let template = env.compile('Hi, {{name}}!', { moduleName });
-  assert.equal(template.referer.moduleName, moduleName, 'Template has the moduleName');
+  assert.equal(template.referrer.moduleName, moduleName, 'Template has the moduleName');
 });
 
 QUnit.module('[glimmer-compiler] precompile', {

--- a/packages/@glimmer/debug/lib/stack-check.ts
+++ b/packages/@glimmer/debug/lib/stack-check.ts
@@ -212,10 +212,10 @@ export function CheckValue<T>(value: T, desc = String(value)): Checker<T> {
 }
 
 export const CheckBlockSymbolTable: Checker<BlockSymbolTable> =
-  CheckInterface({ parameters: CheckArray(CheckNumber), referer: CheckOpaque });
+  CheckInterface({ parameters: CheckArray(CheckNumber), referrer: CheckOpaque });
 
 export const CheckProgramSymbolTable: Checker<ProgramSymbolTable> =
-  CheckInterface({ hasEval: CheckBoolean, symbols: CheckArray(CheckString), referer: CheckOpaque });
+  CheckInterface({ hasEval: CheckBoolean, symbols: CheckArray(CheckString), referrer: CheckOpaque });
 
 export const CheckElement: Checker<Simple.Element> =
   CheckInterface({ nodeType: CheckValue(1), tagName: CheckString, nextSibling: CheckOpaque });

--- a/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
+++ b/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
@@ -6,7 +6,7 @@ export interface Symbols {
 }
 
 export interface SymbolTable {
-  referer: Opaque;
+  referrer: Opaque;
 }
 
 export interface ProgramSymbolTable extends SymbolTable {

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -16,9 +16,9 @@ export default class CompilableTemplate<S extends SymbolTable, Specifier> implem
   static topLevel<Specifier>(block: SerializedTemplateBlock, options: CompileOptions<Specifier>): ICompilableTemplate<ProgramSymbolTable> {
     return new CompilableTemplate<ProgramSymbolTable, Specifier>(
       block.statements,
-      { block, referer: options.referer },
+      { block, referrer: options.referrer },
       options,
-      { referer: options.referer, hasEval: block.hasEval, symbols: block.symbols }
+      { referrer: options.referrer, hasEval: block.hasEval, symbols: block.symbols }
     );
   }
 
@@ -31,10 +31,10 @@ export default class CompilableTemplate<S extends SymbolTable, Specifier> implem
     if (compiled !== null) return compiled;
 
     let { options, statements, containingLayout } = this;
-    let { referer } = containingLayout;
+    let { referrer } = containingLayout;
     let { program, lookup, macros, asPartial, Builder } = options;
 
-    let builder = new Builder(program, lookup, referer, macros, containingLayout, asPartial);
+    let builder = new Builder(program, lookup, referrer, macros, containingLayout, asPartial);
 
     for (let i = 0; i < statements.length; i++) {
       compileStatement(statements[i], builder);

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -76,5 +76,5 @@ export interface ComponentBuilder {
 export interface ParsedLayout<Specifier = Opaque> {
   id?: Option<string>;
   block: SerializedTemplateBlock;
-  referer: Specifier;
+  referrer: Specifier;
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -67,10 +67,10 @@ export interface CompileTimeLookup<Specifier> {
   // produce any actual objects. The main use-case for producing objects is handled above,
   // with getCapabilities and getLayout, which drastically shrinks the size of the object
   // that the core interface is forced to reify.
-  lookupHelper(name: string, referer: Specifier): Option<number>;
-  lookupModifier(name: string, referer: Specifier): Option<number>;
-  lookupComponentSpec(name: string, referer: Specifier): Option<number>;
-  lookupPartial(name: string, referer: Specifier): Option<number>;
+  lookupHelper(name: string, referrer: Specifier): Option<number>;
+  lookupModifier(name: string, referrer: Specifier): Option<number>;
+  lookupComponentSpec(name: string, referrer: Specifier): Option<number>;
+  lookupPartial(name: string, referrer: Specifier): Option<number>;
 }
 
 export interface OpcodeBuilderConstructor {
@@ -93,7 +93,7 @@ export abstract class OpcodeBuilder<Specifier> {
   constructor(
     public program: CompileTimeProgram,
     public lookup: CompileTimeLookup<Specifier>,
-    public referer: Specifier,
+    public referrer: Specifier,
     public macros: Macros,
     public containingLayout: ParsedLayout,
     public asPartial: boolean
@@ -174,8 +174,8 @@ export abstract class OpcodeBuilder<Specifier> {
     this.push(Op.PushComponentSpec, this.constants.handle(handle));
   }
 
-  pushDynamicComponentManager(referer: Specifier) {
-    this.push(Op.PushDynamicComponentManager, this.constants.serializable(referer));
+  pushDynamicComponentManager(referrer: Specifier) {
+    this.push(Op.PushDynamicComponentManager, this.constants.serializable(referrer));
   }
 
   prepareArgs(state: Register) {
@@ -229,8 +229,8 @@ export abstract class OpcodeBuilder<Specifier> {
 
   // partial
 
-  invokePartial(referer: Specifier, symbols: string[], evalInfo: number[]) {
-    let _meta = this.constants.serializable(referer);
+  invokePartial(referrer: Specifier, symbols: string[], evalInfo: number[]) {
+    let _meta = this.constants.serializable(referrer);
     let _symbols = this.constants.stringArray(symbols);
     let _evalInfo = this.constants.array(evalInfo);
 
@@ -552,14 +552,14 @@ export abstract class OpcodeBuilder<Specifier> {
 
   inlineBlock(block: SerializedInlineBlock): CompilableBlock {
     let { parameters, statements } = block;
-    let symbolTable = { parameters, referer: this.containingLayout.referer };
+    let symbolTable = { parameters, referrer: this.containingLayout.referrer };
     let options = {
       program: this.program,
       macros: this.macros,
       Builder: this.constructor as OpcodeBuilderConstructor,
       lookup: this.lookup,
       asPartial: this.asPartial,
-      referer: this.referer
+      referrer: this.referrer
     };
 
     return new CompilableTemplate(statements, this.containingLayout, options, symbolTable);
@@ -640,7 +640,7 @@ export abstract class OpcodeBuilder<Specifier> {
 
     this.jumpUnless('ELSE');
 
-    this.pushDynamicComponentManager(this.referer);
+    this.pushDynamicComponentManager(this.referrer);
     this.invokeComponent(null, null, null, false, null, null);
 
     this.exit();
@@ -836,7 +836,7 @@ export abstract class OpcodeBuilder<Specifier> {
 
     this.jumpUnless('ELSE');
 
-    this.pushDynamicComponentManager(this.referer);
+    this.pushDynamicComponentManager(this.referrer);
     this.invokeComponent(null, params, hash, synthetic, block, inverse);
 
     this.label('ELSE');
@@ -854,11 +854,11 @@ export abstract class OpcodeBuilder<Specifier> {
   }
 
   curryComponent(definition: WireFormat.Expression, /* TODO: attrs: Option<RawInlineBlock>, */ params: Option<WireFormat.Core.Params>, hash: WireFormat.Core.Hash, synthetic: boolean) {
-    let referer = this.referer;
+    let referrer = this.referrer;
 
     expr(definition, this);
     this.compileArgs(params, hash, synthetic);
-    this.push(Op.CurryComponent, this.constants.serializable(referer));
+    this.push(Op.CurryComponent, this.constants.serializable(referrer));
   }
 
   abstract pushBlock(block: Option<CompilableBlock>): void;

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -55,10 +55,10 @@ STATEMENTS.add(Ops.FlushElement, (_sexp: S.FlushElement, builder) => {
 });
 
 STATEMENTS.add(Ops.Modifier, (sexp: S.Modifier, builder) => {
-  let { lookup, referer } = builder;
+  let { lookup, referrer } = builder;
   let [, name, params, hash] = sexp;
 
-  let specifier = lookup.lookupModifier(name, referer);
+  let specifier = lookup.lookupModifier(name, referrer);
 
   if (specifier) {
     builder.compileArgs(params, hash, true);
@@ -163,8 +163,8 @@ STATEMENTS.add(Ops.Block, (sexp: S.Block, builder) => {
 STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
   let [, tag, _attrs, args, block] = sexp;
 
-  let { lookup, referer } = builder;
-  let handle = lookup.lookupComponentSpec(tag, referer);
+  let { lookup, referrer } = builder;
+  let handle = lookup.lookupComponentSpec(tag, referrer);
 
   if (handle !== null) {
     let capabilities = lookup.getCapabilities(handle);
@@ -194,7 +194,7 @@ STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
 STATEMENTS.add(Ops.Partial, (sexp: S.Partial, builder) => {
   let [, name, evalInfo] = sexp;
 
-  let { referer } = builder;
+  let { referrer } = builder;
 
   builder.startLabels();
 
@@ -210,7 +210,7 @@ STATEMENTS.add(Ops.Partial, (sexp: S.Partial, builder) => {
 
   builder.jumpUnless('ELSE');
 
-  builder.invokePartial(referer, builder.evalSymbols()!, evalInfo);
+  builder.invokePartial(referrer, builder.evalSymbols()!, evalInfo);
   builder.popScope();
   builder.popFrame();
 
@@ -262,10 +262,10 @@ export function expr<Specifier>(expression: WireFormat.Expression, builder: Opco
 }
 
 EXPRESSIONS.add(Ops.Unknown, (sexp: E.Unknown, builder) => {
-  let { lookup, asPartial, referer } = builder;
+  let { lookup, asPartial, referrer } = builder;
   let name = sexp[1];
 
-  let specifier = lookup.lookupHelper(name, referer);
+  let specifier = lookup.lookupHelper(name, referrer);
 
   if (specifier !== null) {
     builder.compileArgs(null, null, true);
@@ -287,7 +287,7 @@ EXPRESSIONS.add(Ops.Concat, (sexp: E.Concat, builder) => {
 });
 
 EXPRESSIONS.add(Ops.Helper, (sexp: E.Helper, builder) => {
-  let { lookup, referer } = builder;
+  let { lookup, referrer } = builder;
   let [, name, params, hash] = sexp;
 
   // TODO: triage this in the WF compiler
@@ -299,7 +299,7 @@ EXPRESSIONS.add(Ops.Helper, (sexp: E.Helper, builder) => {
     return;
   }
 
-  let specifier = lookup.lookupHelper(name, referer);
+  let specifier = lookup.lookupHelper(name, referrer);
 
   if (specifier !== null) {
     builder.compileArgs(params, hash, true);
@@ -797,5 +797,5 @@ export interface TemplateOptions<Specifier> {
 
 export interface CompileOptions<Specifier> extends TemplateOptions<Specifier> {
   asPartial: boolean;
-  referer: Specifier;
+  referrer: Specifier;
 }

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -20,14 +20,14 @@ import { EMPTY_ARRAY } from "@glimmer/util";
 
 export class WrappedBuilder<Specifier> implements ICompilableTemplate<ProgramSymbolTable> {
   public symbolTable: ProgramSymbolTable;
-  private referer: Specifier;
+  private referrer: Specifier;
 
   constructor(public options: CompileOptions<Specifier>, private layout: ParsedLayout<Specifier>, private capabilities: ComponentCapabilities) {
     let { block } = layout;
-    let referer = this.referer = layout.referer;
+    let referrer = this.referrer = layout.referrer;
 
     this.symbolTable = {
-      referer,
+      referrer,
       hasEval: block.hasEval,
       symbols: block.symbols.concat([ATTRS_BLOCK])
     };
@@ -62,11 +62,11 @@ export class WrappedBuilder<Specifier> implements ICompilableTemplate<ProgramSym
     //        DidRenderLayout
     //        Exit
 
-    let { options, layout, referer } = this;
+    let { options, layout, referrer } = this;
     let { program, lookup, macros, asPartial } = options;
     let { Builder } = options;
 
-    let b = new Builder(program, lookup, referer, macros, layout, asPartial);
+    let b = new Builder(program, lookup, referrer, macros, layout, asPartial);
 
     b.startLabels();
 
@@ -117,9 +117,9 @@ export class WrappedBuilder<Specifier> implements ICompilableTemplate<ProgramSym
 }
 
 function blockFor<Specifier>(layout: ParsedLayout, options: CompileOptions<Specifier>): CompilableTemplate<BlockSymbolTable, Specifier> {
-  let { block, referer } = layout;
+  let { block, referrer } = layout;
 
-  return new CompilableTemplate(block.statements, layout, options, { referer, parameters: EMPTY_ARRAY });
+  return new CompilableTemplate(block.statements, layout, options, { referrer, parameters: EMPTY_ARRAY });
 }
 
 export class ComponentBuilder<Specifier> implements IComponentBuilder {

--- a/packages/@glimmer/program/lib/internal.ts
+++ b/packages/@glimmer/program/lib/internal.ts
@@ -1,5 +1,5 @@
 import { Unique, RuntimeResolver as IResolver } from '@glimmer/interfaces';
 
 export type Specifier = Unique<'Specifier'>;
-export type Referer = Unique<'Referer'>;
+export type Referrer = Unique<'Referrer'>;
 export type Resolver = IResolver<Specifier>;

--- a/packages/@glimmer/runtime/lib/template.ts
+++ b/packages/@glimmer/runtime/lib/template.ts
@@ -43,7 +43,7 @@ export interface Template<Specifier = Opaque> {
   /**
    * Template meta (both compile time and environment specific).
    */
-  referer: Specifier;
+  referrer: Specifier;
 
   hasEval: boolean;
 
@@ -112,7 +112,7 @@ export default function templateFactory({ id: templateId, meta, block }: Seriali
     if (!parsedBlock) {
       parsedBlock = JSON.parse(block);
     }
-    return new ScannableTemplate(options, { id, block: parsedBlock, referer: newMeta });
+    return new ScannableTemplate(options, { id, block: parsedBlock, referrer: newMeta });
   };
   return { id, meta, create };
 }
@@ -123,7 +123,7 @@ export class ScannableTemplate<Specifier = Opaque> implements Template<Specifier
   public symbols: string[];
   public hasEval: boolean;
   public id: string;
-  public referer: Specifier;
+  public referrer: Specifier;
   private statements: Statement[];
 
   constructor(private options: TemplateOptions<Specifier>, private parsedLayout: ParsedLayout<Specifier>) {
@@ -131,7 +131,7 @@ export class ScannableTemplate<Specifier = Opaque> implements Template<Specifier
     this.symbols = block.symbols;
     this.hasEval = block.hasEval;
     this.statements = block.statements;
-    this.referer = parsedLayout.referer;
+    this.referrer = parsedLayout.referrer;
     this.id = parsedLayout.id || `client-${clientId++}`;
   }
 
@@ -158,11 +158,11 @@ export class ScannableTemplate<Specifier = Opaque> implements Template<Specifier
 }
 
 export function compilable<Specifier>(layout: ParsedLayout<Specifier>, options: TemplateOptions<Opaque>, asPartial: boolean) {
-  let { block, referer } = layout;
+  let { block, referrer } = layout;
   let { hasEval, symbols } = block;
-  let compileOptions = assign({}, options, { asPartial, referer });
+  let compileOptions = assign({}, options, { asPartial, referrer });
 
-  return new CompilableTemplate(block.statements, layout, compileOptions, { referer, hasEval, symbols });
+  return new CompilableTemplate(block.statements, layout, compileOptions, { referrer, hasEval, symbols });
 }
 
 export function elementBuilder({ mode, env, cursor }: Pick<RenderLayoutOptions, 'mode' | 'env' | 'cursor'>) {

--- a/packages/@glimmer/runtime/test/template-test.ts
+++ b/packages/@glimmer/runtime/test/template-test.ts
@@ -69,7 +69,7 @@ QUnit.test("meta is accessible from factory", assert => {
 QUnit.test("meta is accessible from template", assert => {
   let factory = templateFactory(serializedTemplate);
   let template = factory.create(env.compileOptions);
-  assert.deepEqual(template.referer, {
+  assert.deepEqual(template.referrer, {
     version: 12,
     lang: 'es',
     moduleName: "template/module/name"
@@ -81,8 +81,8 @@ QUnit.test("can inject per environment things into meta", assert => {
   let factory = templateFactory<TestMeta, OwnerMeta>(serializedTemplate);
 
   let template = factory.create(env.compileOptions, { owner });
-  assert.strictEqual(template.referer.owner, owner, 'is owner');
-  assert.deepEqual(template.referer, {
+  assert.strictEqual(template.referrer.owner, owner, 'is owner');
+  assert.deepEqual(template.referrer, {
     version: 12,
     lang: 'es',
     moduleName: "template/module/name",

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
@@ -187,7 +187,7 @@ export class EmberishCurlyComponentManager extends AbstractEmberishCurlyComponen
 
     return resolver.compileTemplate(handle, layout.name, (source, options) => {
       let template = createTemplate(source);
-      let builder = new WrappedBuilder(assign({}, options, { asPartial: false, referer: null }), template, CURLY_CAPABILITIES);
+      let builder = new WrappedBuilder(assign({}, options, { asPartial: false, referrer: null }), template, CURLY_CAPABILITIES);
       return {
         handle: builder.compile(),
         symbolTable: builder.symbolTable

--- a/packages/@glimmer/test-helpers/lib/environment/components/tagless.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/tagless.ts
@@ -13,7 +13,7 @@ export class StaticTaglessComponentManager extends BasicComponentManager {
 
     return resolver.compileTemplate(handle, name, (source, options) => {
       let template = createTemplate(source, {});
-      let compileOptions = assign({}, options, { asPartial: false, referer: null });
+      let compileOptions = assign({}, options, { asPartial: false, referrer: null });
       let builder = new WrappedBuilder(compileOptions, template, capabilities);
 
       return {

--- a/packages/@glimmer/test-helpers/lib/environment/generic/macros.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/generic/macros.ts
@@ -24,7 +24,7 @@ export class TestMacros extends Macros {
 
       let lookup = builder.lookup;
 
-      let specifier = lookup.lookupComponentSpec(name, builder.referer);
+      let specifier = lookup.lookupComponentSpec(name, builder.referrer);
 
       if (specifier !== null) {
         builder.component.static(specifier, [params, hashToArgs(hash), template, inverse]);
@@ -36,7 +36,7 @@ export class TestMacros extends Macros {
 
     inlines.addMissing((name, params, hash, builder) => {
       let lookup = builder.lookup;
-      let handle = lookup.lookupComponentSpec(name, builder.referer);
+      let handle = lookup.lookupComponentSpec(name, builder.referrer);
 
       if (handle !== null) {
         builder.component.static(handle, [params!, hashToArgs(hash), null, null]);

--- a/packages/@glimmer/test-helpers/lib/environment/lazy-env.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/lazy-env.ts
@@ -86,7 +86,7 @@ export class TestResolver implements RuntimeResolver<TestSpecifier> {
     return handle;
   }
 
-  lookup(type: LookupType, name: string, _referer?: TestSpecifier): Option<number> {
+  lookup(type: LookupType, name: string, _referrer?: TestSpecifier): Option<number> {
     if (this.registry[type].hasName(name)) {
       return this.registry[type].getHandle(name);
     } else {
@@ -108,26 +108,26 @@ export class TestResolver implements RuntimeResolver<TestSpecifier> {
     return invocation;
   }
 
-  lookupHelper(name: string, referer?: TestSpecifier): Option<number> {
-    return this.lookup('helper', name, referer);
+  lookupHelper(name: string, referrer?: TestSpecifier): Option<number> {
+    return this.lookup('helper', name, referrer);
   }
 
-  lookupModifier(name: string, referer?: TestSpecifier): Option<number> {
-    return this.lookup('modifier', name, referer);
+  lookupModifier(name: string, referrer?: TestSpecifier): Option<number> {
+    return this.lookup('modifier', name, referrer);
   }
 
-  lookupComponent(name: string, referer?: TestSpecifier): Option<ComponentSpec> {
-    let handle = this.lookupComponentHandle(name, referer);
+  lookupComponent(name: string, referrer?: TestSpecifier): Option<ComponentSpec> {
+    let handle = this.lookupComponentHandle(name, referrer);
     if (handle === null) return null;
     return this.resolve(handle) as ComponentSpec;
   }
 
-  lookupComponentHandle(name: string, referer?: TestSpecifier): Option<number> {
-    return this.lookup('component', name, referer);
+  lookupComponentHandle(name: string, referrer?: TestSpecifier): Option<number> {
+    return this.lookup('component', name, referrer);
   }
 
-  lookupPartial(name: string, referer?: TestSpecifier): Option<number> {
-    return this.lookup('partial', name, referer);
+  lookupPartial(name: string, referrer?: TestSpecifier): Option<number> {
+    return this.lookup('partial', name, referrer);
   }
 
   resolve<T>(handle: number): T {

--- a/packages/@glimmer/test-helpers/lib/environment/lookup.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/lookup.ts
@@ -38,20 +38,20 @@ export class LookupResolver {
     };
   }
 
-  lookupHelper(name: string, referer: TestSpecifier): Option<number> {
-    return this.resolver.lookupHelper(name, referer);
+  lookupHelper(name: string, referrer: TestSpecifier): Option<number> {
+    return this.resolver.lookupHelper(name, referrer);
   }
 
-  lookupModifier(name: string, referer: TestSpecifier): Option<number> {
-    return this.resolver.lookupModifier(name, referer);
+  lookupModifier(name: string, referrer: TestSpecifier): Option<number> {
+    return this.resolver.lookupModifier(name, referrer);
   }
 
-  lookupComponentSpec(name: string, referer: TestSpecifier): Option<number> {
-    return this.resolver.lookupComponentHandle(name, referer);
+  lookupComponentSpec(name: string, referrer: TestSpecifier): Option<number> {
+    return this.resolver.lookupComponentHandle(name, referrer);
   }
 
-  lookupPartial(name: string, referer: TestSpecifier): Option<number> {
-    return this.resolver.lookupPartial(name, referer);
+  lookupPartial(name: string, referrer: TestSpecifier): Option<number> {
+    return this.resolver.lookupPartial(name, referrer);
   }
 
 }

--- a/packages/@glimmer/test-helpers/lib/environment/shared.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/shared.ts
@@ -32,5 +32,5 @@ export function createTemplate(templateSource: string, meta: TemplateMeta = {}):
   let wrapper: SerializedTemplateWithLazyBlock<TemplateMeta> = JSON.parse(precompile(templateSource, { meta }));
   let block: SerializedTemplateBlock = JSON.parse(wrapper.block);
 
-  return { block, referer: meta };
+  return { block, referrer: meta };
 }


### PR DESCRIPTION
Even though the "referer" misspelling is canonized in HTTP, the instances where we are using the term are not even referring (pun) to the HTTP header. It seems best to use the correct English spelling of the word, as one canonized misspelling ought to be enough for everybody.