### PR TITLE
Remove absolute path to test components

### DIFF
--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -1,6 +1,7 @@
 import { AbstractRenderTest, test, skip } from "../abstract-test-case";
 import { classes } from '../environment';
-import { EmberishGlimmerComponent, EmberishCurlyComponent } from "@glimmer/test-helpers";
+import { EmberishGlimmerComponent } from "../environment/components/emberish-glimmer";
+import { EmberishCurlyComponent } from '../environment/components/emberish-curly';
 
 export class EmberishComponentTests extends AbstractRenderTest {
   @skip


### PR DESCRIPTION
Fixes Rollup warning:

```
Rollup warning: '@glimmer/test-helpers' is imported by tmp/rollup-cache_path-qCu7eVT2.tmp/@glimmer/test-helpers/lib/suites/ember-components.js, but could not be resolved – treating it as an external dependency
```