### PR TITLE
First Pass At Encoder

### DIFF
--- a/packages/@glimmer/encoder/index.ts
+++ b/packages/@glimmer/encoder/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/encoder';

--- a/packages/@glimmer/encoder/lib/encoder.ts
+++ b/packages/@glimmer/encoder/lib/encoder.ts
@@ -1,0 +1,43 @@
+import { Op } from "@glimmer/vm";
+
+export const ARG_SHIFT = 8;
+const MAX_SIZE                = 0b1111111111111111;
+export const TYPE_SIZE        = 0b11111111;
+export const TYPE_MASK        = 0b0000000011111111;
+export const OPERAND_LEN_MASK = 0b0000111100000000;
+
+export class InstructionEncoder {
+  constructor(public buffer: number[]) {}
+  typePos = 0;
+  size = 0;
+  encode(type: Op, ...operands: number[]) {
+    if (type > TYPE_SIZE) {
+      throw new Error(`Opcode type over 8-bits. Got ${type}.`);
+    }
+
+    this.buffer.push((type | (operands.length << ARG_SHIFT)));
+
+    this.typePos = this.buffer.length - 1;
+
+    operands.forEach(op => {
+      if (op > MAX_SIZE) {
+        throw new Error(`Operand over 16-bits. Got ${op}.`);
+      }
+      this.buffer.push(op);
+    });
+
+    this.size = this.buffer.length;
+  }
+
+  compact(program: number[]) {
+    return String.fromCharCode(...program);
+  }
+
+  patch(position: number, operand: number) {
+    if (this.buffer[position + 1] === -1) {
+      this.buffer[position + 1] = operand;
+    } else {
+      throw new Error('Trying to patch operand in populated slot instead of a reserved slot.');
+    }
+  }
+}

--- a/packages/@glimmer/encoder/lib/encoder.ts
+++ b/packages/@glimmer/encoder/lib/encoder.ts
@@ -4,7 +4,7 @@ export const ARG_SHIFT = 8;
 const MAX_SIZE                = 0b1111111111111111;
 export const TYPE_SIZE        = 0b11111111;
 export const TYPE_MASK        = 0b0000000011111111;
-export const OPERAND_LEN_MASK = 0b0000111100000000;
+export const OPERAND_LEN_MASK = 0b0000001100000000;
 
 export class InstructionEncoder {
   constructor(public buffer: number[]) {}

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@glimmer/encoder",
+  "version": "0.27.0",
+  "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/encoder",
+  "devDependencies": {
+    "typescript": "^2.2.0"
+  }
+}

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -4,4 +4,5 @@ export interface Opcode {
   op1: number;
   op2: number;
   op3: number;
+  size: number;
 }

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -34,10 +34,10 @@ export function debugSlice(program: CompileTimeProgram, start: number, end: numb
     (console as any).group(`%c${start}:${end}`, 'color: #999');
 
     for (let i=start; i<end;) {
-      let { type, op1, op2, op3, argSize } = program.opcode(i);
+      let { type, op1, op2, op3, size } = program.opcode(i);
       let [name, params] = debug(constants as Recast<CompileTimeConstants, DebugConstants>, type, op1, op2, op3);
       console.log(`${i}. ${logOpcode(name, params)}`);
-      i = i + (1 + argSize);
+      i = i + size;
     }
 
     console.groupEnd();

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -33,10 +33,11 @@ export function debugSlice(program: CompileTimeProgram, start: number, end: numb
 
     (console as any).group(`%c${start}:${end}`, 'color: #999');
 
-    for (let i=start; i<end; i= i + 4) {
-      let { type, op1, op2, op3 } = program.opcode(i);
+    for (let i=start; i<end;) {
+      let { type, op1, op2, op3, argSize } = program.opcode(i);
       let [name, params] = debug(constants as Recast<CompileTimeConstants, DebugConstants>, type, op1, op2, op3);
       console.log(`${i}. ${logOpcode(name, params)}`);
+      i = i + (1 + argSize);
     }
 
     console.groupEnd();

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -86,7 +86,6 @@ export interface OpcodeBuilderConstructor {
 export abstract class OpcodeBuilder<Specifier> {
   public constants: CompileTimeConstants;
 
-  // private buffer: number[] = [];
   private encoder = new InstructionEncoder([]);
   private labelsStack = new Stack<Labels>();
   private isComponentAttrs = false;

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -10,6 +10,7 @@
     "@glimmer/program": "^0.27.0",
     "@glimmer/vm": "^0.27.0",
     "@glimmer/local-debug-flags": "^0.27.0",
+    "@glimmer/encoder": "^0.27.0",
     "simple-html-tokenizer": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/@glimmer/program/lib/opcode.ts
+++ b/packages/@glimmer/program/lib/opcode.ts
@@ -1,11 +1,17 @@
 import { Heap } from './program';
+import { TYPE_MASK, OPERAND_LEN_MASK, ARG_SHIFT } from "@glimmer/encoder";
 
 export class Opcode {
   public offset = 0;
   constructor(private heap: Heap) {}
 
+  get size() {
+    let rawType = this.heap.getbyaddr(this.offset);
+    return ((rawType & OPERAND_LEN_MASK) >> ARG_SHIFT) + 1;
+  }
+
   get type() {
-    return this.heap.getbyaddr(this.offset);
+    return (this.heap.getbyaddr(this.offset) & TYPE_MASK);
   }
 
   get op1() {

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -44,13 +44,6 @@ export class Heap {
     this.heap[address] = value;
   }
 
-  reserve(): VMHandle {
-    this.table.push(0, 0, 0, 0);
-    let handle = this.handle;
-    this.handle += ENTRY_SIZE;
-    return handle as Recast<number, VMHandle>;
-  }
-
   malloc(): VMHandle {
     this.table.push(this.offset, 0, 0, 0);
     let handle = this.handle;

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -4,7 +4,8 @@
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/program",
   "dependencies": {
     "@glimmer/util": "^0.27.0",
-    "@glimmer/interfaces": "^0.27.0"
+    "@glimmer/interfaces": "^0.27.0",
+    "@glimmer/encoder": "^0.27.0"
   },
   "devDependencies": {
     "typescript": "^2.2.0"

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -1,4 +1,4 @@
-import { Option, Dict, Slice as ListSlice, initializeGuid, fillNulls, typePos, unreachable } from '@glimmer/util';
+import { Option, Dict, Slice as ListSlice, initializeGuid, fillNulls, unreachable } from '@glimmer/util';
 import { recordStackSize } from '@glimmer/debug';
 import { Op } from '@glimmer/vm';
 import { Tag } from '@glimmer/reference';
@@ -36,7 +36,7 @@ export class AppendOpcodes {
       /* tslint:disable */
       let [name, params] = debug(vm.constants, opcode.type, opcode.op1, opcode.op2, opcode.op3);
       // console.log(`${typePos(vm['pc'])}.`);
-      console.log(`${typePos(vm['pc'])}. ${logOpcode(name, params)}`);
+      console.log(`${vm['pc']}. ${logOpcode(name, params)}`);
 
       let debugParams = [];
       for (let prop in params) {
@@ -81,7 +81,7 @@ export class AppendOpcodes {
       if (metadata && metadata.check && typeof expectedChange! === 'number' && expectedChange! !== actualChange) {
         let [name, params] = debug(vm.constants, opcode.type, opcode.op1, opcode.op2, opcode.op3);
 
-        throw new Error(`Error in ${name}:\n\n${typePos(vm['pc'])}. ${logOpcode(name, params)}\n\nStack changed by ${actualChange}, expected ${expectedChange!}`);
+        throw new Error(`Error in ${name}:\n\n${(vm['pc'] + (opcode.argSize + 1))}. ${logOpcode(name, params)}\n\nStack changed by ${actualChange}, expected ${expectedChange!}`);
       }
     }
 

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -81,13 +81,13 @@ export class AppendOpcodes {
       if (metadata && metadata.check && typeof expectedChange! === 'number' && expectedChange! !== actualChange) {
         let [name, params] = debug(vm.constants, opcode.type, opcode.op1, opcode.op2, opcode.op3);
 
-        throw new Error(`Error in ${name}:\n\n${(vm['pc'] + (opcode.argSize + 1))}. ${logOpcode(name, params)}\n\nStack changed by ${actualChange}, expected ${expectedChange!}`);
+        throw new Error(`Error in ${name}:\n\n${(vm['pc'] + (opcode.size))}. ${logOpcode(name, params)}\n\nStack changed by ${actualChange}, expected ${expectedChange!}`);
       }
     }
 
     if (DEBUG) {
       /* tslint:disable */
-      console.log('%c -> pc: %d, ra: %d, fp: %d, sp: %d, s0: %O, s1: %O, t0: %O, t1: %O', 'color: orange', vm['pc'], vm['ra'], vm['fp'], vm['sp'], vm['s0'], vm['s1'], vm['t0'], vm['t1']);
+      console.log('%c -> pc: %d, ra: %d, fp: %d, sp: %d, s0: %O, s1: %O, t0: %O, t1: %O', 'color: orange', vm['pc'] + vm['program'].opcode(vm['pc']).size, vm['ra'], vm['fp'], vm['sp'], vm['s0'], vm['s1'], vm['t0'], vm['t1']);
       console.log('%c -> eval stack', 'color: red', vm.stack.toArray());
       console.log('%c -> scope', 'color: green', vm.scope()['slots'].map(s => s && s['value'] ? s['value']() : s));
       console.log('%c -> elements', 'color: blue', vm.elements()['cursorStack']['stack'].map((c: any) => c.element));

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -179,7 +179,7 @@ export default class VM<Specifier> implements PublicVM {
 
   // Jump to an address in `program`
   goto(offset: number) {
-    let addr = this.pc + offset - this.currentOpSize;
+    let addr = (this.pc + offset) - this.currentOpSize;
     this.pc = addr;
   }
 
@@ -315,6 +315,7 @@ export default class VM<Specifier> implements PublicVM {
     let state = this.capture(0);
     let tracker = this.elements().pushBlockList(updating);
     let artifacts = this.stack.peek<ReferenceIterator>().artifacts;
+
     let addr = (this.pc + relativeStart) - this.currentOpSize;
     let start = this.heap.gethandle(addr);
 

--- a/packages/@glimmer/util/lib/platform-utils.ts
+++ b/packages/@glimmer/util/lib/platform-utils.ts
@@ -15,7 +15,3 @@ export function expect<T>(val: Maybe<T>, message: string): T {
 export function unreachable(message = "unreachable"): Error {
   return new Error(message);
 }
-
-export function typePos(lastOperand: number): number {
-  return lastOperand - 4;
-}


### PR DESCRIPTION
This is the first pass at the encoder. Here are the important changes:

- The opcode type is now assumed to bit an 8-bit int, leaving us space for 177 additional instructions (hopefully it doesn't come to this 👻 )
- Prior to this commit we hard coded the opcode size to 4 in numerous places. While opcodes in the VM allow for an operation size of 4 (1 type and 3 operands), majority of the operations have 0 or 1 operands. This meant the program that we compiled was much larger than it needed to be. To solve this problem we compact the 8-bit type and the operand length (2-bits).
- Encoding the length of the operation means the VM now knows how to deal with variable length operations.

We are currently assuming a 16-bit layout for opcodes:

```
E = Empty
L = Operand length
O = Operand
T = Opcode type

EEEEEEELLTTTTTTTT OOOOOOOOOOOOOOOO OOOOOOOOOOOOOOOO OOOOOOOOOOOOOOOO
```
The next step will be work on the actual program and constant pool compaction.

