### PR TITLE
[BUGFIX] Pop args from the stack for static invocations

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -387,6 +387,10 @@ export abstract class OpcodeBuilder<Specifier> {
     return this.push(Op.Pop, count);
   }
 
+  popArgs() {
+    this.push(Op.PopArgs);
+  }
+
   // vm
 
   pushRemoteElement() {
@@ -739,7 +743,7 @@ export abstract class OpcodeBuilder<Specifier> {
     this.createComponent(Register.s0, block !== null, inverse !== null);
 
     if (capabilities.createArgs) {
-      this.pop();
+      this.popArgs();
     }
 
     this.registerComponentDestructor(Register.s0);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -278,6 +278,11 @@ APPEND_OPCODES.add(Op.CreateComponent, (vm, { op1: flags, op2: _state }) => {
   }
 });
 
+APPEND_OPCODES.add(Op.PopArgs, (vm) => {
+  let args = check(vm.stack.pop(), CheckArguments);
+  args.clear();
+});
+
 APPEND_OPCODES.add(Op.RegisterComponentDestructor, (vm, { op1: _state }) => {
   let { manager, component } = check(vm.fetchValue(_state), CheckComponentState);
 

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
@@ -198,7 +198,7 @@ export class EmberishCurlyComponentManager extends AbstractEmberishCurlyComponen
 }
 
 export class EmberishCurlyComponent extends GlimmerObject {
-  public static positionalParams: string[] | string;
+  public static positionalParams: string[] | string = [];
 
   public dirtinessTag: TagWrapper<DirtyableTag> = DirtyableTag.create();
   public layout: { name: string, handle: number };

--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -1,32 +1,17 @@
-import { AbstractRenderTest, test, skip } from "../abstract-test-case";
+import { AbstractRenderTest, test } from "../abstract-test-case";
 import { classes } from '../environment';
 import { EmberishGlimmerComponent } from "../environment/components/emberish-glimmer";
-import { EmberishCurlyComponent } from '../environment/components/emberish-curly';
 
 export class EmberishComponentTests extends AbstractRenderTest {
-  @skip
   @test({ kind: 'glimmer' })
-  "[BUG: Load to s0 is wrong]"() {
+  "[BUG: #644 popping args should be balanced]"() {
     class MainComponent extends EmberishGlimmerComponent {
       salutation = 'Glimmer';
     }
     this.registerComponent('Glimmer', 'Main', '<div><HelloWorld @name={{salutation}} /></div>', MainComponent);
     this.registerComponent('Glimmer', 'HelloWorld', '<h1>Hello {{@name}}!</h1>');
     this.render('<Main />');
-    this.assertHTML('<h1>Hello Glimmer!</h1>');
-  }
-
-  @skip
-  @test({ kind: 'curly' })
-  "[BUG: Curly recursive call stack curly]"() {
-    class MainComponent extends EmberishCurlyComponent {
-      tag = 'div';
-      salutation = 'Glimmer';
-    }
-    this.registerComponent('Curly', 'test-main', '<div>{{hello-world name=salutation}}</div>', MainComponent);
-    this.registerComponent('Curly', 'hello-world', '<h1>Hello {{name}}!</h1>');
-    this.render('{{test-main}}');
-    this.assertHTML('<h1>Hello Glimmer!</h1>');
+    this.assertHTML('<div><h1>Hello Glimmer!</h1></div>');
   }
 
   @test

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -348,6 +348,12 @@ OPCODE_METADATA(Op.PushArgs, {
   stackChange: 1
 });
 
+OPCODE_METADATA(Op.PopArgs, {
+  name: 'PopArgs',
+  ops: [],
+  skipCheck: true
+});
+
 OPCODE_METADATA(Op.PrepareArgs, {
   name: 'PrepareArgs',
   ops: [Register('state')],

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -708,6 +708,24 @@ export const enum Op {
   PushArgs,
 
   /**
+   * Operation: Pops Arguments from the stack and clears the next N args.
+   *
+   * Format:
+   *   (PopArgs)
+   *
+   * Operand Stack:
+   *   ..., [VersionedPathReference ...], Arguments  →
+   *   ...
+   *
+   * Description:
+   * The arguments object contains the information of how many user
+   * supplied args the component was invoked with. To clear them from
+   * the stack we must pop it from the stack and call `clear` on it
+   * to remove the argument values from the stack.
+   */
+  PopArgs,
+
+  /**
    * Operation: ...
    * Format:
    *   (PrepareArgs state:u32)


### PR DESCRIPTION
Prior to this fix static invocations with args were not balanced. This was due to the fact that we only popped the `Arguments` off the stack but did not clear the actual arg values from the stack. This would cause the `load` to `s0` (saved register 0) to be incorrect when popping the frame.