### PR TITLE
Don't rely on callerScope to yield

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -882,8 +882,13 @@ export abstract class OpcodeBuilder<Specifier> {
     }
   }
 
+  pushBlockScope(): void {
+    this.push(Op.PushBlockScope);
+  }
+
   pushYieldableBlock(block: Option<CompilableBlock>): void {
     this.pushSymbolTable(block && block.symbolTable);
+    this.pushBlockScope();
     this.pushBlock(block);
   }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
@@ -4,6 +4,7 @@ import { Tag, TagWrapper, VersionedPathReference, Reference } from "@glimmer/ref
 import { Arguments } from '../../vm/arguments';
 import { ComponentState } from './component';
 import { ComponentManager } from '../../internal-interfaces';
+import { Scope } from '../../environment';
 import { BlockSymbolTable } from "@glimmer/interfaces";
 import { ICompilableTemplate } from "@glimmer/opcode-compiler";
 
@@ -16,6 +17,8 @@ export const CheckReference: Checker<Reference> =
   CheckInterface({ tag: CheckTag, value: CheckFunction });
 
 export const CheckArguments = CheckInstanceof(Arguments);
+
+export const CheckScope = CheckInstanceof(Scope);
 
 export const CheckComponentManager: Checker<ComponentManager> =
   CheckInterface({ getCapabilities: CheckFunction });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -20,7 +20,7 @@ import {
   PublicComponentSpec
 } from '../../component/interfaces';
 import { normalizeStringValue } from '../../dom/normalize';
-import { DynamicScope, ScopeBlock, ScopeSlot } from '../../environment';
+import { DynamicScope, ScopeBlock, ScopeSlot, Scope } from '../../environment';
 import { APPEND_OPCODES, UpdatingOpcode } from '../../opcodes';
 import { UNDEFINED_REFERENCE } from '../../references';
 import { UpdatingVM, VM } from '../../vm';
@@ -33,7 +33,7 @@ import { check, expectStackChange, CheckInstanceof, CheckFunction, CheckInterfac
 import { Op, Register } from '@glimmer/vm';
 import { TemplateMeta } from "@glimmer/wire-format";
 import { ATTRS_BLOCK } from '@glimmer/opcode-compiler';
-import { CheckReference, CheckArguments, CheckPathReference, CheckComponentState, CheckCompilableBlock } from './-debug-strip';
+import { CheckReference, CheckArguments, CheckPathReference, CheckComponentState, CheckScope, CheckCompilableBlock } from './-debug-strip';
 
 const ARGS = new Arguments();
 
@@ -441,9 +441,10 @@ APPEND_OPCODES.add(Op.InvokeComponentLayout, vm => {
     let bindBlock = (name: string) => {
       let symbol = symbols.indexOf(name);
       let handle = check(stack.pop(), CheckOr(CheckOption(CheckHandle), CheckOption(CheckCompilableBlock)));
+      let blockScope = check(stack.pop(), CheckOption(CheckScope)) as Option<Scope>; // FIXME(mmun): shouldn't need to cast this
       let table = check(stack.pop(), CheckOption(CheckBlockSymbolTable));
 
-      let block: Option<ScopeBlock> = table ? [handle!, table] : null;
+      let block: Option<ScopeBlock> = table ? [handle!, blockScope!, table] : null;
 
       if (symbol !== -1) {
         scope.bindBlock(symbol + 1, block);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -139,7 +139,8 @@ APPEND_OPCODES.add(Op.InvokeYield, vm => {
 
     // To balance the pop{Frame,Scope}
     vm.pushFrame();
-    vm.pushCallerScope();
+    let blockScope = vm.scope().getCallerScope()!;
+    vm.pushScope(blockScope);
 
     return;
   }
@@ -147,7 +148,13 @@ APPEND_OPCODES.add(Op.InvokeYield, vm => {
   let locals = table.parameters;
   let localsCount = locals.length;
 
-  vm.pushCallerScope(localsCount > 0);
+  {
+    let blockScope = vm.scope().getCallerScope()!;
+    if (localsCount > 0) {
+      blockScope = blockScope.child();
+    }
+    vm.pushScope(blockScope);
+  }
 
   let scope = vm.scope();
 

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -28,7 +28,7 @@ import { Simple, RuntimeResolver, BlockSymbolTable, VMHandle } from "@glimmer/in
 import { Component, ComponentManager } from "./internal-interfaces";
 import { Program } from "@glimmer/program";
 
-export type ScopeBlock = [VMHandle | ICompilableTemplate<BlockSymbolTable>, BlockSymbolTable];
+export type ScopeBlock = [VMHandle | ICompilableTemplate<BlockSymbolTable>, Scope, BlockSymbolTable];
 export type ScopeSlot = Option<VersionedPathReference<Opaque>> | Option<ScopeBlock>;
 
 export interface DynamicScope {

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -372,11 +372,6 @@ export default class VM<Specifier> implements PublicVM {
     this.scopeStack.push(this.scope().child());
   }
 
-  pushCallerScope(childScope = false) {
-    let callerScope = expect(this.scope().getCallerScope(), 'pushCallerScope is called when a caller scope is present');
-    this.scopeStack.push(childScope ? callerScope.child() : callerScope);
-  }
-
   pushDynamicScope(): DynamicScope {
     let child = this.dynamicScope().child();
     this.dynamicScopeStack.push(child);
@@ -388,6 +383,10 @@ export default class VM<Specifier> implements PublicVM {
     if (bindCaller) scope.bindCallerScope(this.scope());
     this.scopeStack.push(scope);
     return scope;
+  }
+
+  pushScope(scope: Scope) {
+    this.scopeStack.push(scope);
   }
 
   popScope() {

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -220,6 +220,11 @@ OPCODE_METADATA(Op.PushSymbolTable, {
   stackChange: 1
 });
 
+OPCODE_METADATA(Op.PushBlockScope, {
+  name: 'PushBlockScope',
+  stackChange: 1
+});
+
 OPCODE_METADATA(Op.CompileBlock, {
   name: 'CompileBlock'
 });
@@ -237,7 +242,8 @@ OPCODE_METADATA(Op.InvokeStatic, {
 
 OPCODE_METADATA(Op.InvokeYield, clearsArgs({
   name: 'InvokeYield',
-  argsPosition: 2
+  argsPosition: 3,
+  netPops: 1
 }));
 
 OPCODE_METADATA(Op.Jump, {
@@ -584,7 +590,7 @@ OPCODE_METADATA(Op.SetBlock, {
   name: 'SetBlock',
   ops: [ScopeSymbol('symbol')],
   operands: 1,
-  stackChange: -2
+  stackChange: -3
 });
 
 OPCODE_METADATA(Op.GetVariable, {
@@ -604,7 +610,7 @@ OPCODE_METADATA(Op.GetBlock, {
   name: 'GetBlock',
   ops: [ScopeBlock('block')],
   operands: 1,
-  stackChange: 2
+  stackChange: 3
 });
 
 OPCODE_METADATA(Op.HasBlock, {
@@ -617,7 +623,7 @@ OPCODE_METADATA(Op.HasBlock, {
 OPCODE_METADATA(Op.HasBlockParams, {
   name: 'HasBlockParams',
   ops: [ScopeBlock('block')],
-  stackChange: -1
+  stackChange: -2
 });
 
 OPCODE_METADATA(Op.Concat, {

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -433,6 +433,16 @@ export const enum Op {
   CompileBlock,
 
   /**
+   * Operation: Push a scope onto the stack.
+   * Format:
+   *   (PushBlockScope #Scope)
+   * Operand Stack:
+   *   ..., →
+   *   ..., Scope
+   */
+  PushBlockScope,
+
+  /**
    * Operation: Push a symbol table onto the stack.
    * Format:
    *   (PushSymbolTable #SymbolTable)


### PR DESCRIPTION
This PR is the first step towards first-class blocks and implementing [named blocks RFC](https://github.com/emberjs/rfcs/pull/226). In this PR we make sure that when we push a block onto the evaluation stack we also push the scope that the block is closing over.

---

A slightly longer explanation...

Prior to this PR, whenever we executed a `{{yield}}` inside a component, we assumed that the scope that the block closed over was the same scope that invoked the component itself.

In fact at the moment this is always true because there is no way to `{{yield}}` to a block other than the ones that were syntactically part of the component invocation.

With first-class blocks this changes. First-class blocks means that blocks are values and can be passed around as such. See [named blocks RFC](https://github.com/emberjs/rfcs/pull/226) for more deatils, but long story short, this means that it is no longer safe to assume that the block's scope is the same as the caller's scope. For example,

```hbs
{{!-- app.hbs --}}
{{#with "ComponentOne's caller scope" as |message|}}
  <ComponentOne>
    {{message}}
  </ComponentOne>
{{/with}}
```

```hbs
{{!-- components/component-one.hbs --}}
{{#with "ComponentTwo's caller scope" as |message|}}
  <ComponentTwo @main=@main />
{{/with}}
```

```hbs
{{!-- components/component-two.hbs --}}
{{yield}}
```

In this setup we'd expect the output to be

```hbs
<ComponentOne>
  <ComponenTwo>
    ComponentOne's caller scope
  </ComponenTwo>
</ComponentOne>
```