### PR TITLE
Fix deps on the @glimmer/vm

### DIFF
--- a/build/broccoli/build-packages.js
+++ b/build/broccoli/build-packages.js
@@ -156,6 +156,7 @@ function transpileCommonJS(pkgName, esVersion, tree) {
         envFlags: {
           source: '@glimmer/local-debug-flags',
           flags: {
+            DEVMODE: false,
             DEBUG: false
           }
         },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -78,6 +78,3 @@ module.exports = function(_options) {
 
   return merge(output);
 }
-
-function transpileTypeScriptToJavaScript() {
-}

--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -7,6 +7,7 @@ import {
   ProgramSymbolTable,
   Recast,
   SymbolTable,
+  VMHandle,
 } from "@glimmer/interfaces";
 import {
   CompilableTemplate,
@@ -15,7 +16,6 @@ import {
   ComponentCapabilities,
   CompileTimeLookup,
   CompileOptions,
-  VMHandle,
   ICompilableTemplate,
   EagerOpcodeBuilder
 } from "@glimmer/opcode-compiler";

--- a/packages/@glimmer/bundle-compiler/test/initial-render-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/initial-render-test.ts
@@ -1,4 +1,4 @@
-import { Opaque, RuntimeResolver as IRuntimeResolver, Option, Dict, Recast, Simple, ProgramSymbolTable } from "@glimmer/interfaces";
+import { Opaque, RuntimeResolver as IRuntimeResolver, Option, Dict, Recast, Simple, ProgramSymbolTable, VMHandle } from "@glimmer/interfaces";
 import {
   TestDynamicScope,
   UserHelper,
@@ -27,7 +27,7 @@ import {
   YieldSuite
 } from "@glimmer/test-helpers";
 import { BundleCompiler, CompilerDelegate, Specifier, SpecifierMap, specifierFor, LookupMap, DebugConstants } from "@glimmer/bundle-compiler";
-import { WrappedBuilder, ComponentCapabilities, VMHandle, ICompilableTemplate } from "@glimmer/opcode-compiler";
+import { WrappedBuilder, ComponentCapabilities, ICompilableTemplate } from "@glimmer/opcode-compiler";
 import { Program, RuntimeProgram, WriteOnlyProgram, RuntimeConstants } from "@glimmer/program";
 import { elementBuilder, LowLevelVM, TemplateIterator, RenderResult, Helper, Environment, WithStaticLayout, Bounds, ComponentManager, DOMTreeConstruction, DOMChanges, ComponentSpec, Invocation, getDynamicVar, Helper as GlimmerHelper, } from "@glimmer/runtime";
 import { UpdatableReference } from "@glimmer/object-reference";

--- a/packages/@glimmer/debug/lib/stack-check.ts
+++ b/packages/@glimmer/debug/lib/stack-check.ts
@@ -1,5 +1,4 @@
-import { Opaque, Option, Dict, BlockSymbolTable, ProgramSymbolTable, Simple } from "@glimmer/interfaces";
-import { VMHandle } from "@glimmer/opcode-compiler";
+import { Opaque, Option, Dict, BlockSymbolTable, ProgramSymbolTable, Simple, VMHandle } from "@glimmer/interfaces";
 
 export interface Checker<T> {
   type: T;

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -4,8 +4,7 @@
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/debug",
   "private": true,
   "dependencies": {
-    "@glimmer/interfaces": "^0.27.0",
-    "@glimmer/opcode-compiler": "^0.27.0"
+    "@glimmer/interfaces": "^0.27.0"
   },
   "devDependencies": {
     "@types/qunit": "^2.0.31",

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -1,3 +1,4 @@
+import { Unique } from './core';
 export interface Opcode {
   offset: number;
   type: number;
@@ -6,3 +7,5 @@ export interface Opcode {
   op3: number;
   size: number;
 }
+
+export type VMHandle = Unique<"Handle">;

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -1,12 +1,12 @@
 import {
   Option,
   SymbolTable,
-  ProgramSymbolTable
+  ProgramSymbolTable,
+  VMHandle
 } from '@glimmer/interfaces';
 import { Statement, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { DEBUG } from '@glimmer/local-debug-flags';
 import { debugSlice } from './debug';
-import { VMHandle } from './interfaces';
 import { CompilableTemplate as ICompilableTemplate, ParsedLayout } from './interfaces';
 import { CompileOptions, compileStatement } from './syntax';
 

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -1,8 +1,6 @@
-import { Unique, Opaque, SymbolTable, Option, BlockSymbolTable, Opcode } from "@glimmer/interfaces";
+import { VMHandle, Opaque, SymbolTable, Option, BlockSymbolTable, Opcode } from "@glimmer/interfaces";
 import { Core, SerializedTemplateBlock } from "@glimmer/wire-format";
 import { Macros } from './syntax';
-
-export type VMHandle = Unique<"Handle">;
 
 export interface CompileTimeHeap {
   push(name: /* TODO: Op */ number, op1?: number, op2?: number, op3?: number): void;

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -1,4 +1,4 @@
-import { Opaque, Option, ProgramSymbolTable, SymbolTable, Recast, BlockSymbolTable } from '@glimmer/interfaces';
+import { Opaque, Option, ProgramSymbolTable, SymbolTable, Recast, VMHandle, BlockSymbolTable } from '@glimmer/interfaces';
 import { dict, EMPTY_ARRAY, expect, fillNulls, Stack, unreachable } from '@glimmer/util';
 import { Op, Register } from '@glimmer/vm';
 import * as WireFormat from '@glimmer/wire-format';
@@ -6,7 +6,6 @@ import { SerializedInlineBlock } from "@glimmer/wire-format";
 import { PrimitiveType } from "@glimmer/program";
 
 import {
-  VMHandle as VMHandle,
   CompileTimeHeap,
   CompileTimeLazyConstants,
   Primitive,

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -1,8 +1,7 @@
 import { Register } from '@glimmer/vm';
-import { ProgramSymbolTable, BlockSymbolTable } from '@glimmer/interfaces';
+import { ProgramSymbolTable, BlockSymbolTable, VMHandle } from '@glimmer/interfaces';
 
 import {
-  VMHandle,
   ComponentArgs,
   ComponentBuilder as IComponentBuilder,
   ComponentCapabilities,

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -1,9 +1,9 @@
 
-import { Recast } from "@glimmer/interfaces";
+import { Recast, VMHandle } from "@glimmer/interfaces";
 import { DEBUG } from "@glimmer/local-debug-flags";
 import { Constants, WriteOnlyConstants, RuntimeConstants } from './constants';
 import { Opcode } from './opcode';
-import { VMHandle, CompileTimeProgram } from "@glimmer/opcode-compiler";
+import { CompileTimeProgram } from "@glimmer/opcode-compiler";
 
 enum TableSlotState {
   Allocated,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -1,4 +1,4 @@
-import { Opaque, Option, Dict, ProgramSymbolTable, Recast, RuntimeResolver } from '@glimmer/interfaces';
+import { VMHandle, Opaque, Option, Dict, ProgramSymbolTable, Recast, RuntimeResolver } from '@glimmer/interfaces';
 import {
   combineTagged,
   CONSTANT_TAG,
@@ -32,7 +32,7 @@ import { dict, assert, unreachable } from "@glimmer/util";
 import { check, expectStackChange, CheckInstanceof, CheckFunction, CheckInterface, CheckProgramSymbolTable, CheckHandle, CheckOption, CheckBlockSymbolTable, CheckOr } from '@glimmer/debug';
 import { Op, Register } from '@glimmer/vm';
 import { TemplateMeta } from "@glimmer/wire-format";
-import { ATTRS_BLOCK, VMHandle } from '@glimmer/opcode-compiler';
+import { ATTRS_BLOCK } from '@glimmer/opcode-compiler';
 import { CheckReference, CheckArguments, CheckPathReference, CheckComponentState, CheckCompilableBlock } from './-debug-strip';
 
 const ARGS = new Arguments();

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -1,5 +1,5 @@
 import { Op } from '@glimmer/vm';
-import { Opaque, Option, Recast } from '@glimmer/interfaces';
+import { Opaque, Option, Recast, VMHandle } from '@glimmer/interfaces';
 import {
   CONSTANT_TAG,
   isConst,
@@ -17,7 +17,6 @@ import { CompilableTemplate } from '../../syntax/interfaces';
 import { VM, UpdatingVM } from '../../vm';
 import { Arguments } from '../../vm/arguments';
 import { LazyConstants, PrimitiveType } from "@glimmer/program";
-import { VMHandle } from "@glimmer/opcode-compiler";
 import { CheckReference } from './-debug-strip';
 
 APPEND_OPCODES.add(Op.ChildScope, vm => vm.pushChildScope());

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -1,7 +1,7 @@
-import { Simple, Dict, Opaque, Option, RuntimeResolver, Unique, ProgramSymbolTable } from '@glimmer/interfaces';
+import { Simple, Dict, Opaque, Option, RuntimeResolver, Unique, ProgramSymbolTable, VMHandle } from '@glimmer/interfaces';
 import { Tag, VersionedPathReference } from '@glimmer/reference';
 import { Destroyable } from '@glimmer/util';
-import { ComponentCapabilities, VMHandle } from '@glimmer/opcode-compiler';
+import { ComponentCapabilities } from '@glimmer/opcode-compiler';
 import Bounds from '../bounds';
 import { ElementOperations } from '../vm/element-builder';
 import Environment, { DynamicScope } from '../environment';

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -22,9 +22,9 @@ import {
 
 import { PublicVM } from './vm/append';
 
-import { Macros, OpcodeBuilderConstructor, VMHandle, ICompilableTemplate } from "@glimmer/opcode-compiler";
+import { Macros, OpcodeBuilderConstructor, ICompilableTemplate } from "@glimmer/opcode-compiler";
 import { IArguments } from './vm/arguments';
-import { Simple, RuntimeResolver, BlockSymbolTable } from "@glimmer/interfaces";
+import { Simple, RuntimeResolver, BlockSymbolTable, VMHandle } from "@glimmer/interfaces";
 import { Component, ComponentManager } from "@glimmer/runtime/lib/internal-interfaces";
 import { Program } from "@glimmer/program";
 

--- a/packages/@glimmer/runtime/lib/partial.ts
+++ b/packages/@glimmer/runtime/lib/partial.ts
@@ -1,5 +1,4 @@
-import { ProgramSymbolTable } from '@glimmer/interfaces';
-import { VMHandle } from '@glimmer/opcode-compiler';
+import { ProgramSymbolTable, VMHandle } from '@glimmer/interfaces';
 import { Template } from './template';
 
 export class PartialDefinition {

--- a/packages/@glimmer/runtime/lib/syntax/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/syntax/interfaces.ts
@@ -2,9 +2,8 @@ import {
   BlockSymbolTable,
   ProgramSymbolTable,
   SymbolTable,
+  VMHandle
 } from '@glimmer/interfaces';
-
-import { VMHandle } from '@glimmer/opcode-compiler';
 
 export interface CompilableTemplate<S extends SymbolTable = SymbolTable> {
   symbolTable: S;

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -14,9 +14,8 @@ import {
   UpdatingOpcode
 } from '../opcodes';
 
-import { Opcode } from "@glimmer/interfaces";
+import { Opcode, VMHandle } from "@glimmer/interfaces";
 import { Heap, RuntimeProgram as Program, RuntimeConstants, RuntimeProgram } from "@glimmer/program";
-import { VMHandle as VMHandle } from "@glimmer/opcode-compiler";
 
 export interface PublicVM {
   env: Environment;

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -20,11 +20,10 @@ import {
 } from '@glimmer/reference';
 import { UpdatingOpcode, UpdatingOpSeq } from '../opcodes';
 import { DOMChanges } from '../dom/helper';
-import { Simple } from '@glimmer/interfaces';
+import { Simple, VMHandle } from '@glimmer/interfaces';
 
 import VM, { CapturedStack, EvaluationStack } from './append';
 import { RuntimeConstants as Constants, RuntimeProgram as Program } from "@glimmer/program";
-import { VMHandle } from "@glimmer/opcode-compiler";
 
 export default class UpdatingVM<Specifier = Opaque> {
   public env: Environment;

--- a/packages/@glimmer/test-helpers/lib/environment/env.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/env.ts
@@ -2,8 +2,7 @@ import { KeyFor, Iterable } from './iterable';
 
 import { Environment, DOMTreeConstruction, IDOMChanges, PrimitiveReference, ConditionalReference } from "@glimmer/runtime";
 import { dict } from "@glimmer/util";
-import { Dict, RuntimeResolver, Opaque } from "@glimmer/interfaces";
-import { VMHandle } from "@glimmer/opcode-compiler";
+import { Dict, RuntimeResolver, Opaque, VMHandle } from "@glimmer/interfaces";
 import { Program } from "@glimmer/program";
 import { Reference, isConst, OpaqueIterable } from "@glimmer/reference";
 

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -1,4 +1,4 @@
-import { Op } from "@glimmer/vm";
+import { Op } from "./opcodes";
 import { Option, Opaque, Opcode } from "@glimmer/interfaces";
 import { RuntimeConstants } from "@glimmer/program";
 import { fillNulls } from "@glimmer/util";

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -2,7 +2,12 @@
   "name": "@glimmer/vm",
   "version": "0.27.0",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/vm",
-  "dependencies": {},
+  "dependencies": {
+    "@glimmer/util": "^0.27.0",
+    "@glimmer/interfaces": "^0.27.0",
+    "@glimmer/program": "^0.27.0",
+    "@glimmer/debug": "^0.27.0"
+  },
   "devDependencies": {
     "@types/qunit": "^2.0.31",
     "typescript": "^2.2.0"


### PR DESCRIPTION
This also required removing a cycle. `VMHandle` is now in `@glimmer/interfaces`.