### PR TITLE
Add Node Bundle Compiler Tests

### DIFF
--- a/packages/@glimmer/bundle-compiler/test/ssr-node-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/ssr-node-test.ts
@@ -1,0 +1,9 @@
+import {
+  SSRSuite,
+  SSRComponentSuite,
+  rawModule,
+  NodeBundlingRenderDelegate
+} from "@glimmer/test-helpers";
+
+rawModule("[Bundle Compiler] SSR", SSRSuite, NodeBundlingRenderDelegate);
+rawModule("[Bundle Compiler] SSR Components", SSRComponentSuite, NodeBundlingRenderDelegate, { componentModule: true });

--- a/packages/@glimmer/node/test/node-dom-helper-node-test.ts
+++ b/packages/@glimmer/node/test/node-dom-helper-node-test.ts
@@ -2,174 +2,20 @@ import {
   AbstractRenderTest,
   test,
   rawModule,
-  AbstractNodeTest,
-  NodeRenderDelegate
+  NodeRenderDelegate,
+  SSRSuite,
+  SSRComponentSuite
 } from "@glimmer/test-helpers";
 import { NodeDOMTreeConstruction } from '..';
 import { precompile } from "@glimmer/compiler";
 
-class NodeTests extends AbstractNodeTest {
-
-  @test "HTML text content"() {
-    this.render('content');
-    this.assertHTML('content');
-  }
-
-  @test "HTML tags"() {
-    this.render('<h1>hello!</h1><div>content</div>');
-    this.assertHTML('<h1>hello!</h1><div>content</div>');
-  }
-
-  @test "HTML tags re-rendered"() {
-    this.render('<h1>hello!</h1><div>content</div>');
-    this.assertHTML('<h1>hello!</h1><div>content</div>');
-    this.rerender();
-    this.assertHTML('<h1>hello!</h1><div>content</div>');
-  }
-
-  @test "HTML attributes"() {
-    this.render("<div id='bar' class='foo'>content</div>");
-    this.assertHTML('<div id="bar" class="foo">content</div>');
-  }
-
-  @test "HTML tag with empty attribute"() {
-    this.render("<div class=''>content</div>");
-    this.assertHTML('<div class>content</div>');
-  }
-
-  @test "HTML boolean attribute 'disabled'"() {
-    this.render('<input disabled>');
-    this.assertHTML('<input disabled>');
-  }
-
-  @test "Quoted attribute expression is removed when null"() {
-    this.render('<input disabled="{{isDisabled}}">', { isDisabled: null });
-    this.assertHTML('<input>');
-  }
-
-  @test"Unquoted attribute expression with null value is not coerced"() {
-    this.render('<input disabled={{isDisabled}}>', { isDisabled: null });
-    this.assertHTML('<input>');
-  }
-
-  @test "Attribute expression can be followed by another attribute"() {
-    this.render('<div foo="{{funstuff}}" name="Alice"></div>', { funstuff: "oh my" });
-    this.assertHTML('<div foo="oh my" name="Alice"></div>');
-  }
-
-  @test "HTML tag with data- attribute"() {
-    this.render("<div data-some-data='foo'>content</div>");
-    this.assertHTML('<div data-some-data="foo">content</div>');
-  }
-
-  @test "The compiler can handle nesting"() {
-    this.render('<div class="foo"><p><span id="bar" data-foo="bar">hi!</span></p></div>&nbsp;More content');
-
-    // Note that the space after the closing div tag is a non-breaking space (Unicode 0xA0)
-    this.assertHTML('<div class="foo"><p><span id="bar" data-foo="bar">hi!</span></p></div> More content');
-  }
-
-  @test "The compiler can handle comments"() {
-    this.render('<div><!-- Just passing through --></div>');
-    this.assertHTML('<div><!-- Just passing through --></div>');
-  }
-
-  @test "The compiler can handle HTML comments with mustaches in them"() {
-    this.render('<div><!-- {{foo}} --></div>', { foo: 'bar' });
-    this.assertHTML('<div><!-- {{foo}} --></div>');
-  }
-
-  @test "The compiler can handle HTML comments with complex mustaches in them"() {
-    this.render('<div><!-- {{foo bar baz}} --></div>', { foo: 'bar' });
-    this.assertHTML('<div><!-- {{foo bar baz}} --></div>');
-  }
-
-  @test "The compiler can handle HTML comments with multi-line mustaches in them"() {
-    this.render('<div><!-- {{#each foo as |bar|}}\n{{bar}}\n\n{{/each}} --></div>', { foo: 'bar' });
-
-    this.assertHTML('<div><!-- {{#each foo as |bar|}}\n{{bar}}\n\n{{/each}} --></div>');
-  }
-
-  @test "The compiler can handle comments with no parent element"() {
-    this.render('<!-- {{foo}} -->', { foo: 'bar' });
-    this.assertHTML('<!-- {{foo}} -->');
-  }
-
-  @test "The compiler can handle simple handlebars"() {
-    this.render('<div>{{title}}</div>', { title: 'hello' });
-    this.assertHTML('<div>hello</div>');
-  }
-
-  @test "The compiler can handle escaping HTML"() {
-    this.render('<div>{{title}}</div>', { title: '<strong>hello</strong>' });
-    this.assertHTML('<div>&lt;strong&gt;hello&lt;/strong&gt;</div>');
-  }
-
-  @test "The compiler can handle unescaped HTML"() {
-    this.render('<div>{{{title}}}</div>', { title: '<strong>hello</strong>' });
-    this.assertHTML('<div><strong>hello</strong></div>');
-  }
-
-  @test "Unescaped helpers render correctly"() {
-    this.registerHelper('testing-unescaped', (params) => params[0]);
-    this.render('{{{testing-unescaped "<span>hi</span>"}}}');
-    this.assertHTML('<span>hi</span>');
-  }
-
-  @test 'Null literals do not have representation in DOM'() {
-    this.render('{{null}}');
-    this.assertHTML('');
-  }
-
-  @test "Attributes can be populated with helpers that generate a string"() {
-    this.registerHelper('testing', (params) => {
-      return params[0];
-    });
-
-    this.render('<a href="{{testing url}}">linky</a>', { url: 'linky.html' });
-    this.assertHTML('<a href="linky.html">linky</a>');
-  }
-
-  @test "Elements inside a yielded block"() {
-    this.render('{{#if true}}<div id="test">123</div>{{/if}}');
-    this.assertHTML('<div id="test">123</div>');
-  }
-
-  @test "A simple block helper can return text"() {
-    this.render('{{#if true}}test{{else}}not shown{{/if}}');
-    this.assertHTML('test');
-  }
-
+class DOMHelperTests extends SSRSuite {
   @test 'can instantiate NodeDOMTreeConstruction without a document'() {
     // this emulates what happens in Ember when using `App.visit('/', { shouldRender: false });`
 
     let helper = new NodeDOMTreeConstruction(null as any);
 
     this.assert.ok(!!helper, 'helper was instantiated without errors');
-  }
-
-  @test "SVG: basic element"() {
-    let template = `
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <rect x="10" y="10" height="100" width="100" style="stroke:#ff0000; fill: #0000ff"></rect>
-      </svg>
-    `;
-    this.render(template);
-    this.assertHTML(template);
-  }
-
-  @test "SVG: element with xlink:href"() {
-    let template = `
-      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-        <rect x=".01" y=".01" width="4.98" height="2.98" fill="none" stroke="blue" stroke-width=".03"></rect>
-        <a xlink:href="http://www.w3.org">
-          <ellipse cx="2.5" cy="1.5" rx="2" ry="1" fill="red"></ellipse>
-        </a>
-      </svg>
-    `;
-    this.render(template);
-
-    this.assertHTML(template);
   }
 }
 
@@ -184,5 +30,6 @@ class CompilationTests extends AbstractRenderTest {
   }
 }
 
-rawModule('Server-side rendering in Node.js', NodeTests, NodeRenderDelegate);
+rawModule('Server-side rendering in Node.js', DOMHelperTests, NodeRenderDelegate);
 rawModule('Id generation', CompilationTests, NodeRenderDelegate);
+rawModule("[Bundle Compiler] SSR Components", SSRComponentSuite, NodeRenderDelegate, { componentModule: true });

--- a/packages/@glimmer/test-helpers/lib/abstract-test-case.ts
+++ b/packages/@glimmer/test-helpers/lib/abstract-test-case.ts
@@ -29,6 +29,8 @@ export function skip(_target: Object, _name: string, descriptor: PropertyDescrip
   descriptor.value["skip"] = true;
 }
 
+const COMMENT_NODE = 8; //  Node.COMMENT_NODE
+
 export class VersionedObject implements Tagged {
   public tag: TagWrapper<DirtyableTag>;
   public value: Object;
@@ -703,7 +705,7 @@ function uniq(arr: any[]) {
 
 function isServerMarker(node: Node) {
   return (
-    node.nodeType === Node.COMMENT_NODE && node.nodeValue!.charAt(0) === '%'
+    node.nodeType === COMMENT_NODE && node.nodeValue!.charAt(0) === '%'
   );
 }
 
@@ -740,7 +742,7 @@ export function test(...args: any[]) {
 }
 
 export interface RenderDelegateConstructor<Delegate extends RenderDelegate> {
-  new(): Delegate;
+  new(env?: Environment): Delegate;
 }
 
 export interface RenderTestConstructor<D extends RenderDelegate, T extends AbstractRenderTest> {

--- a/packages/@glimmer/test-helpers/lib/environment/bundle-compiler.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/bundle-compiler.ts
@@ -3,7 +3,7 @@ import { Dict, VMHandle, ProgramSymbolTable, Opaque, Option, RuntimeResolver as 
 import { ComponentCapabilities, ICompilableTemplate, WrappedBuilder } from "@glimmer/opcode-compiler";
 import { ComponentKind, RenderDelegate, renderSync } from '../abstract-test-case';
 import { AbstractTestEnvironment, EnvironmentOptions } from './env';
-import { ComponentManager, DOMTreeConstruction, DOMChanges, ComponentSpec, getDynamicVar, Helper as GlimmerHelper, elementBuilder, TemplateIterator, RenderResult, Helper, LowLevelVM } from "@glimmer/runtime";
+import { ComponentManager, DOMTreeConstruction, DOMChanges, ComponentSpec, getDynamicVar, Helper as GlimmerHelper, elementBuilder, TemplateIterator, RenderResult, Helper, LowLevelVM, Environment } from "@glimmer/runtime";
 import { dict, assert, assign } from "@glimmer/util";
 import { Program, RuntimeProgram, RuntimeConstants, WriteOnlyProgram } from "@glimmer/program";
 import { BundlingBasicComponentManager, EMPTY_CAPABILITIES } from './components/basic';
@@ -13,6 +13,8 @@ import { HelperReference, UserHelper } from './helper';
 import { TestMacros } from './generic/macros';
 import { BundledEmberishGlimmerComponentManager, EmberishGlimmerComponent, EMBERISH_GLIMMER_CAPABILITIES } from './components/emberish-glimmer';
 import { EMBERISH_CURLY_CAPABILITIES, EmberishCurlyComponent, BundledEmberishCurlyComponentManager } from './components/emberish-curly';
+import * as SimpleDOM from 'simple-dom';
+import { NodeEnv } from './ssr-env';
 
 export interface RegisteredComponentDefinition {
   symbolTable?: boolean;
@@ -197,13 +199,14 @@ const EMBERISH_GLIMMER_COMPONENT_MANAGER = new BundledEmberishGlimmerComponentMa
 const EMBERISH_CURLY_COMPONENT_MANAGER = new BundledEmberishCurlyComponentManager();
 
 export class BundlingRenderDelegate implements RenderDelegate {
-  protected env = new BundledClientEnvironment();
+  protected env: Environment;
   protected modules = new Modules();
   protected compileTimeModules = new Modules();
   protected components = {};
   protected speficiersToSymbolTable = new LookupMap<Specifier, ProgramSymbolTable>();
 
-  constructor() {
+  constructor(env: Environment) {
+    this.env = env || new BundledClientEnvironment();
     this.registerInternalHelper("-get-dynamic-var", getDynamicVar);
   }
 
@@ -355,5 +358,11 @@ export class BundlingRenderDelegate implements RenderDelegate {
     let iterator = new TemplateIterator(vm);
 
     return renderSync(env, iterator);
+  }
+}
+
+export class NodeBundlingRenderDelegate extends BundlingRenderDelegate {
+  constructor(env = new NodeEnv({ document: new SimpleDOM.Document() })) {
+    super(env);
   }
 }

--- a/packages/@glimmer/test-helpers/lib/environment/lookup.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/lookup.ts
@@ -11,7 +11,7 @@ export class LookupResolver {
   private getComponentSpec(handle: number): ComponentSpec {
     let spec = this.resolver.resolve<Option<ComponentSpec>>(handle);
 
-    assert(!!spec, `Couldn't find a template named ${name}`);
+    assert(!!spec, `Couldn't find a template for handle ${handle}`);
 
     return spec!;
   }

--- a/packages/@glimmer/test-helpers/lib/environment/ssr-env.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/ssr-env.ts
@@ -28,7 +28,7 @@ function testOptions(options: NodeEnvironmentOptions) {
 
 }
 
-class LazyNodeEnvironment extends TestEnvironment {
+export class NodeEnv extends TestEnvironment {
   protected document: Simple.Document;
   constructor(options: NodeEnvironmentOptions) {
     super(testOptions(options));
@@ -38,7 +38,7 @@ class LazyNodeEnvironment extends TestEnvironment {
 
 export class NodeRenderDelegate extends TestEnvironmentRenderDelegate {
   constructor() {
-    super(new LazyNodeEnvironment({ document: new SimpleDOM.Document() }));
+    super(new NodeEnv({ document: new SimpleDOM.Document() }));
   }
 }
 
@@ -51,6 +51,15 @@ export class AbstractNodeTest extends AbstractRenderTest {
 
   assertHTML(html: string) {
     let serialized = this.serializer.serializeChildren(this.element);
+    this.assert.equal(serialized, html);
+  }
+
+  assertComponent(html: string) {
+    let el = this.element.firstChild! as Element;
+    this.assert.equal(el.getAttribute('class'), 'ember-view');
+    this.assert.ok(el.getAttribute('id'));
+    this.assert.ok(el.getAttribute('id')!.indexOf('ember') > -1);
+    let serialized = this.serializer.serializeChildren(this.element.firstChild!);
     this.assert.equal(serialized, html);
   }
 }

--- a/packages/@glimmer/test-helpers/lib/suites.ts
+++ b/packages/@glimmer/test-helpers/lib/suites.ts
@@ -9,3 +9,4 @@ export * from './suites/scopes';
 export * from './suites/shadowing';
 export * from './suites/with-dynamic-vars';
 export * from './suites/yield';
+export * from './suites/ssr';

--- a/packages/@glimmer/test-helpers/lib/suites/ssr.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ssr.ts
@@ -1,0 +1,198 @@
+import { test } from "../abstract-test-case";
+import { AbstractNodeTest } from '../environment/ssr-env';
+
+export class SSRSuite extends AbstractNodeTest {
+  @test "HTML text content"() {
+    this.render('content');
+    this.assertHTML('content');
+  }
+
+  @test "HTML tags"() {
+    this.render('<h1>hello!</h1><div>content</div>');
+    this.assertHTML('<h1>hello!</h1><div>content</div>');
+  }
+
+  @test "HTML tags re-rendered"() {
+    this.render('<h1>hello!</h1><div>content</div>');
+    this.assertHTML('<h1>hello!</h1><div>content</div>');
+    this.rerender();
+    this.assertHTML('<h1>hello!</h1><div>content</div>');
+  }
+
+  @test "HTML attributes"() {
+    this.render("<div id='bar' class='foo'>content</div>");
+    this.assertHTML('<div id="bar" class="foo">content</div>');
+  }
+
+  @test "HTML tag with empty attribute"() {
+    this.render("<div class=''>content</div>");
+    this.assertHTML('<div class>content</div>');
+  }
+
+  @test "HTML boolean attribute 'disabled'"() {
+    this.render('<input disabled>');
+    this.assertHTML('<input disabled>');
+  }
+
+  @test "Quoted attribute expression is removed when null"() {
+    this.render('<input disabled="{{isDisabled}}">', { isDisabled: null });
+    this.assertHTML('<input>');
+  }
+
+  @test"Unquoted attribute expression with null value is not coerced"() {
+    this.render('<input disabled={{isDisabled}}>', { isDisabled: null });
+    this.assertHTML('<input>');
+  }
+
+  @test "Attribute expression can be followed by another attribute"() {
+    this.render('<div foo="{{funstuff}}" name="Alice"></div>', { funstuff: "oh my" });
+    this.assertHTML('<div foo="oh my" name="Alice"></div>');
+  }
+
+  @test "HTML tag with data- attribute"() {
+    this.render("<div data-some-data='foo'>content</div>");
+    this.assertHTML('<div data-some-data="foo">content</div>');
+  }
+
+  @test "The compiler can handle nesting"() {
+    this.render('<div class="foo"><p><span id="bar" data-foo="bar">hi!</span></p></div>&nbsp;More content');
+
+    // Note that the space after the closing div tag is a non-breaking space (Unicode 0xA0)
+    this.assertHTML('<div class="foo"><p><span id="bar" data-foo="bar">hi!</span></p></div> More content');
+  }
+
+  @test "The compiler can handle comments"() {
+    this.render('<div><!-- Just passing through --></div>');
+    this.assertHTML('<div><!-- Just passing through --></div>');
+  }
+
+  @test "The compiler can handle HTML comments with mustaches in them"() {
+    this.render('<div><!-- {{foo}} --></div>', { foo: 'bar' });
+    this.assertHTML('<div><!-- {{foo}} --></div>');
+  }
+
+  @test "The compiler can handle HTML comments with complex mustaches in them"() {
+    this.render('<div><!-- {{foo bar baz}} --></div>', { foo: 'bar' });
+    this.assertHTML('<div><!-- {{foo bar baz}} --></div>');
+  }
+
+  @test "The compiler can handle HTML comments with multi-line mustaches in them"() {
+    this.render('<div><!-- {{#each foo as |bar|}}\n{{bar}}\n\n{{/each}} --></div>', { foo: 'bar' });
+
+    this.assertHTML('<div><!-- {{#each foo as |bar|}}\n{{bar}}\n\n{{/each}} --></div>');
+  }
+
+  @test "The compiler can handle comments with no parent element"() {
+    this.render('<!-- {{foo}} -->', { foo: 'bar' });
+    this.assertHTML('<!-- {{foo}} -->');
+  }
+
+  @test "The compiler can handle simple handlebars"() {
+    this.render('<div>{{title}}</div>', { title: 'hello' });
+    this.assertHTML('<div>hello</div>');
+  }
+
+  @test "The compiler can handle escaping HTML"() {
+    this.render('<div>{{title}}</div>', { title: '<strong>hello</strong>' });
+    this.assertHTML('<div>&lt;strong&gt;hello&lt;/strong&gt;</div>');
+  }
+
+  @test "The compiler can handle unescaped HTML"() {
+    this.render('<div>{{{title}}}</div>', { title: '<strong>hello</strong>' });
+    this.assertHTML('<div><strong>hello</strong></div>');
+  }
+
+  @test "Unescaped helpers render correctly"() {
+    this.registerHelper('testing-unescaped', (params) => params[0]);
+    this.render('{{{testing-unescaped "<span>hi</span>"}}}');
+    this.assertHTML('<span>hi</span>');
+  }
+
+  @test 'Null literals do not have representation in DOM'() {
+    this.render('{{null}}');
+    this.assertHTML('');
+  }
+
+  @test "Attributes can be populated with helpers that generate a string"() {
+    this.registerHelper('testing', (params) => {
+      return params[0];
+    });
+
+    this.render('<a href="{{testing url}}">linky</a>', { url: 'linky.html' });
+    this.assertHTML('<a href="linky.html">linky</a>');
+  }
+
+  @test "Elements inside a yielded block"() {
+    this.render('{{#if true}}<div id="test">123</div>{{/if}}');
+    this.assertHTML('<div id="test">123</div>');
+  }
+
+  @test "A simple block helper can return text"() {
+    this.render('{{#if true}}test{{else}}not shown{{/if}}');
+    this.assertHTML('test');
+  }
+
+  @test "SVG: basic element"() {
+    let template = `
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <rect x="10" y="10" height="100" width="100" style="stroke:#ff0000; fill: #0000ff"></rect>
+      </svg>
+    `;
+    this.render(template);
+    this.assertHTML(template);
+  }
+
+  @test "SVG: element with xlink:href"() {
+    let template = `
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect x=".01" y=".01" width="4.98" height="2.98" fill="none" stroke="blue" stroke-width=".03"></rect>
+        <a xlink:href="http://www.w3.org">
+          <ellipse cx="2.5" cy="1.5" rx="2" ry="1" fill="red"></ellipse>
+        </a>
+      </svg>
+    `;
+    this.render(template);
+
+    this.assertHTML(template);
+  }
+}
+
+export class SSRComponentSuite extends AbstractNodeTest {
+  @test
+  "can render components"() {
+    this.render({
+      layout: '<h1>Hello World!</h1>'
+    });
+    this.assertComponent('<h1>Hello World!</h1>');
+  }
+
+  @test
+  "can render components with yield"() {
+    this.render({
+      layout: '<h1>Hello {{yield}}!</h1>',
+      template: 'World'
+    });
+    this.assertComponent('<h1>Hello World!</h1>');
+  }
+
+  @test
+  "can render components with args"() {
+    this.render({
+      layout: '<h1>Hello {{@place}}!</h1>',
+      template: 'World',
+      args: { place: "place" }
+    }, { place: 'World' });
+    this.assertComponent('<h1>Hello World!</h1>');
+  }
+
+  @test
+  "can render components with block params"() {
+    this.render({
+      layout: '<h1>Hello {{yield @place}}!</h1>',
+      template: '{{place}}',
+      args: { place: 'place' },
+      blockParams: ['place']
+    }, { place: 'World' });
+    this.assertComponent('<h1>Hello World!</h1>');
+  }
+}


### PR DESCRIPTION
This provides the ability to run the bundle compiler in node. This PR pulls the tests that were in `@glimmer/node` into the suites directory of `@glimmer/test-helpers` so we can run them against the bundle compiler. I've also added some basic tests around components in node and are passing through both the lazy and eager environments.