### PR TITLE
Retain opcode metadata if RETAIN_FLAGS is set

### DIFF
--- a/build/broccoli/strip-glimmer-utilities.js
+++ b/build/broccoli/strip-glimmer-utilities.js
@@ -29,6 +29,13 @@ module.exports = function(jsTree) {
         module: true
       }
     }])
+
+    glimmerUtils.push([nuke, { source: '@glimmer/debug' }])
+    glimmerUtils.push([nuke, { source: '@glimmer/vm/lib/-debug-strip' }]);
+    glimmerUtils.push([nuke, {
+      source: '@glimmer/vm',
+      delegate: removeMetaData
+    }]);
   }
 
   function removeMetaData(bindingName, path, t) {
@@ -46,12 +53,6 @@ module.exports = function(jsTree) {
     getModuleId: nameResolver,
     plugins: [
       ...glimmerUtils,
-      [nuke, { source: '@glimmer/debug' }],
-      [nuke, { source: '@glimmer/vm/lib/-debug-strip' }],
-      [nuke, {
-        source: '@glimmer/vm',
-        delegate: removeMetaData
-      }],
       [stripGlimmerUtils, { bindings: ['expect', 'unwrap'], source: '@glimmer/util' }]
     ]
   });

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -37,9 +37,11 @@ module.exports = function(_options) {
   // Glimmer includes a number of assertions and logging information that can be
   // stripped from production builds for better runtime performance.
   if (PRODUCTION) {
-    jsTree = funnel(jsTree, {
-      exclude: ['**/**/-debug-strip.js']
-    });
+    if (!process.env.RETAIN_FLAGS) {
+      jsTree = funnel(jsTree, {
+        exclude: ['**/**/-debug-strip.js']
+      });
+    }
     jsTree = stripGlimmerUtilities(jsTree);
   }
 


### PR DESCRIPTION
The recent opcode metadata work rendered the `RETAIN_FLAGS` build time flag unusable, because metadata would be stripped but the assertions checking for the metadata remained. This change retains both when the flag is set.