### PR TITLE
Use an ArrayBuffer for storing the heap

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -130,7 +130,7 @@ export class BundleCompiler {
     let { heap, constants } = this.program;
 
     return {
-      heap: heap.toArray(),
+      heap: heap.capture(),
       pool: constants.toPool()
     };
   }

--- a/packages/@glimmer/bundle-compiler/test/ssr-node-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/ssr-node-test.ts
@@ -2,8 +2,8 @@ import {
   SSRSuite,
   SSRComponentSuite,
   rawModule,
-  NodeRenderDelegate
+  NodeEagerRenderDelegate
 } from "@glimmer/test-helpers";
 
-rawModule("[Bundle Compiler] SSR", SSRSuite, NodeRenderDelegate);
-rawModule("[Bundle Compiler] SSR Components", SSRComponentSuite, NodeRenderDelegate, { componentModule: true });
+rawModule("[Bundle Compiler] SSR", SSRSuite, NodeEagerRenderDelegate);
+rawModule("[Bundle Compiler] SSR Components", SSRComponentSuite, NodeEagerRenderDelegate, { componentModule: true });

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -1,4 +1,6 @@
-import { Unique } from './core';
+import { Opaque, Unique } from './core';
+import { SymbolTable } from './tier1/symbol-table';
+
 export interface Opcode {
   offset: number;
   type: number;
@@ -9,3 +11,37 @@ export interface Opcode {
 }
 
 export type VMHandle = Unique<"Handle">;
+
+export interface CompileTimeHeap {
+  push(name: /* TODO: Op */ number, op1?: number, op2?: number, op3?: number): void;
+  malloc(): VMHandle;
+  finishMalloc(handle: VMHandle, scopeSize: number): void;
+
+  // for debugging
+  getaddr(handle: VMHandle): number;
+  sizeof(handle: VMHandle): number;
+}
+
+export interface CompileTimeProgram {
+  [key: number]: never;
+
+  constants: CompileTimeConstants;
+  heap: CompileTimeHeap;
+
+  opcode(offset: number): Opcode;
+}
+
+export interface CompileTimeConstants {
+  string(value: string): number;
+  stringArray(strings: string[]): number;
+  array(values: number[]): number;
+  table(t: SymbolTable): number;
+  handle(specifier: Opaque): number;
+  serializable(value: Opaque): number;
+  float(value: number): number;
+  negative(value: number): number;
+}
+
+export interface CompileTimeLazyConstants extends CompileTimeConstants {
+  other(value: Opaque): number;
+}

--- a/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
+++ b/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
@@ -1,6 +1,5 @@
-import { Option, Dict } from '../core';
+import { Opaque, Option, Dict } from '../core';
 import { TemplateMeta } from '@glimmer/wire-format';
-import { Opaque } from "@glimmer/interfaces";
 
 export interface Symbols {
 }

--- a/packages/@glimmer/node/test/node-dom-helper-node-test.ts
+++ b/packages/@glimmer/node/test/node-dom-helper-node-test.ts
@@ -2,7 +2,7 @@ import {
   RenderTest,
   test,
   rawModule,
-  NodeRenderDelegate,
+  NodeLazyRenderDelegate,
   SSRSuite,
   SSRComponentSuite
 } from "@glimmer/test-helpers";
@@ -30,6 +30,6 @@ class CompilationTests extends RenderTest {
   }
 }
 
-rawModule('Server-side rendering in Node.js', DOMHelperTests, NodeRenderDelegate);
-rawModule('Id generation', CompilationTests, NodeRenderDelegate);
-rawModule("[Bundle Compiler] SSR Components", SSRComponentSuite, NodeRenderDelegate, { componentModule: true });
+rawModule('Server-side rendering in Node.js', DOMHelperTests, NodeLazyRenderDelegate);
+rawModule('Id generation', CompilationTests, NodeLazyRenderDelegate);
+rawModule("[Bundle Compiler] SSR Components", SSRComponentSuite, NodeLazyRenderDelegate, { componentModule: true });

--- a/packages/@glimmer/object-reference/lib/meta.ts
+++ b/packages/@glimmer/object-reference/lib/meta.ts
@@ -2,7 +2,7 @@ import { PropertyReference } from './references/descriptors';
 import RootReference from './references/root';
 import { MetaOptions } from './types';
 
-import { Dict, DictSet, HasGuid, Set, dict } from '@glimmer/util';
+import { Option, Dict, DictSet, HasGuid, Set, dict } from '@glimmer/util';
 
 import {
   RootReferenceFactory,
@@ -14,7 +14,6 @@ import {
 import { PathReference as IPathReference, VOLATILE_TAG } from '@glimmer/reference';
 
 import { InnerReferenceFactory } from './references/descriptors';
-import { Option } from "@glimmer/interfaces";
 
 const NOOP_DESTROY = { destroy() {} };
 

--- a/packages/@glimmer/object-reference/lib/references/root.ts
+++ b/packages/@glimmer/object-reference/lib/references/root.ts
@@ -1,8 +1,7 @@
-import { Opaque, dict } from '@glimmer/util';
+import { Option, Opaque, dict } from '@glimmer/util';
 import { PathReference } from './path';
 import { RootReference as IRootReference } from '../types';
 import { VOLATILE_TAG, PathReference as IPathReference, Tag } from '@glimmer/reference';
-import { Option } from "@glimmer/interfaces";
 
 export default class RootReference<T> implements IRootReference<T>, IPathReference<T> {
   private object: T;

--- a/packages/@glimmer/object-reference/lib/types.ts
+++ b/packages/@glimmer/object-reference/lib/types.ts
@@ -1,5 +1,6 @@
-import { Opaque, Dict, Set } from '@glimmer/util';
+import { Option, Opaque, Dict, Set } from '@glimmer/util';
 import { Reference, PathReference } from '@glimmer/reference';
+import { InnerReferenceFactory } from './references/descriptors';
 
 export interface NotifiableReference<T> extends Reference<T> {
   // notify();
@@ -22,9 +23,6 @@ export interface RootReference<T> extends PathReference<T> {
   referenceFromParts(parts: string[]): PathReference<Opaque>;
   chainFor(prop: string): Option<PathReference<T>>;
 }
-
-import { InnerReferenceFactory } from './references/descriptors';
-import { Option } from "@glimmer/interfaces";
 
 export interface MetaOptions {
   RootReferenceFactory?: RootReferenceFactory<any>;

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -1,5 +1,11 @@
-import { CompileTimeProgram, CompileTimeConstants } from './interfaces';
-import { Option, Opaque, SymbolTable, Recast } from '@glimmer/interfaces';
+import {
+  CompileTimeProgram,
+  CompileTimeConstants,
+  Option,
+  Opaque,
+  SymbolTable,
+  Recast
+} from '@glimmer/interfaces';
 import { METADATA, Op, Register } from '@glimmer/vm';
 import { DEBUG } from '@glimmer/local-debug-flags';
 import { unreachable, dict } from "@glimmer/util";

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -8,6 +8,7 @@ import { PrimitiveType } from "@glimmer/program";
 
 export interface DebugConstants {
   getFloat(value: number): number;
+  getNegative(value: number): number;
   getString(value: number): string;
   getStringArray(value: number): string[];
   getArray(value: number): number[];
@@ -157,6 +158,8 @@ function decodePrimitive(primitive: number, constants: DebugConstants): Primitiv
         case 2: return null;
         case 3: return undefined;
       }
+    case PrimitiveType.NEGATIVE:
+      return constants.getNegative(value);
     default:
       throw unreachable();
   }

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -56,6 +56,7 @@ export interface CompileTimeConstants {
   handle(specifier: Opaque): number;
   serializable(value: Opaque): number;
   float(value: number): number;
+  negative(value: number): number;
 }
 
 export interface CompileTimeLazyConstants extends CompileTimeConstants {

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -4,21 +4,11 @@ import {
   SymbolTable,
   Option,
   BlockSymbolTable,
-  Opcode,
-  ComponentCapabilities
+  ComponentCapabilities,
+  CompileTimeProgram
 } from '@glimmer/interfaces';
 import { Core, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { Macros } from './syntax';
-
-export interface CompileTimeHeap {
-  push(name: /* TODO: Op */ number, op1?: number, op2?: number, op3?: number): void;
-  malloc(): VMHandle;
-  finishMalloc(handle: VMHandle, scopeSize: number): void;
-
-  // for debugging
-  getaddr(handle: VMHandle): number;
-  sizeof(handle: VMHandle): number;
-}
 
 export interface EagerResolver<Specifier> {
   getCapabilities(specifier: Specifier): ComponentCapabilities;
@@ -37,31 +27,7 @@ export interface CompilableTemplate<S extends SymbolTable> {
 
 export type CompilableBlock = CompilableTemplate<BlockSymbolTable>;
 
-export interface CompileTimeProgram {
-  [key: number]: never;
-
-  constants: CompileTimeConstants;
-  heap: CompileTimeHeap;
-
-  opcode(offset: number): Opcode;
-}
-
 export type Primitive = undefined | null | boolean | number | string;
-
-export interface CompileTimeConstants {
-  string(value: string): number;
-  stringArray(strings: string[]): number;
-  array(values: number[]): number;
-  table(t: SymbolTable): number;
-  handle(specifier: Opaque): number;
-  serializable(value: Opaque): number;
-  float(value: number): number;
-  negative(value: number): number;
-}
-
-export interface CompileTimeLazyConstants extends CompileTimeConstants {
-  other(value: Opaque): number;
-}
 
 export type ComponentArgs = [Core.Params, Core.Hash, Option<CompilableBlock>, Option<CompilableBlock>];
 export type Specifier = Opaque;

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -1,4 +1,17 @@
-import { Opaque, Option, ProgramSymbolTable, SymbolTable, Recast, VMHandle, BlockSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
+import {
+  Opaque,
+  Option,
+  ProgramSymbolTable,
+  SymbolTable,
+  Recast,
+  VMHandle,
+  BlockSymbolTable,
+  ComponentCapabilities,
+  CompileTimeConstants,
+  CompileTimeProgram,
+  CompileTimeLazyConstants,
+  CompileTimeHeap
+} from "@glimmer/interfaces";
 import { dict, EMPTY_ARRAY, expect, fillNulls, Stack, unreachable } from '@glimmer/util';
 import { Op, Register } from '@glimmer/vm';
 import * as WireFormat from '@glimmer/wire-format';
@@ -6,12 +19,8 @@ import { SerializedInlineBlock } from "@glimmer/wire-format";
 import { PrimitiveType } from "@glimmer/program";
 
 import {
-  CompileTimeHeap,
-  CompileTimeLazyConstants,
   Primitive,
   CompilableBlock,
-  CompileTimeConstants,
-  CompileTimeProgram,
   ParsedLayout
 } from './interfaces';
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -434,7 +434,12 @@ export abstract class OpcodeBuilder<Specifier> {
     switch (typeof _primitive) {
       case 'number':
         if (_primitive as number % 1 === 0) {
-          primitive = _primitive as number;
+          if (_primitive as number > -1) {
+            primitive = _primitive as number;
+          } else {
+            primitive = this.negative(_primitive as number);
+            type = PrimitiveType.NEGATIVE;
+          }
         } else {
           primitive = this.float(_primitive as number);
           type = PrimitiveType.FLOAT;
@@ -466,6 +471,10 @@ export abstract class OpcodeBuilder<Specifier> {
 
   float(num: number): number {
     return this.constants.float(num);
+  }
+
+  negative(num: number): number {
+    return this.constants.negative(num);
   }
 
   pushPrimitiveReference(primitive: Primitive) {

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -1,10 +1,10 @@
-import { Option, Opaque } from '@glimmer/interfaces';
+import { CompileTimeProgram, Option, Opaque } from '@glimmer/interfaces';
 import { assert, dict, unwrap, EMPTY_ARRAY } from '@glimmer/util';
 import { Register } from '@glimmer/vm';
 import * as WireFormat from '@glimmer/wire-format';
 import * as ClientSide from './client-side';
 import OpcodeBuilder, { CompileTimeLookup, OpcodeBuilderConstructor } from "./opcode-builder";
-import { CompilableBlock, CompileTimeProgram } from './interfaces';
+import { CompilableBlock } from './interfaces';
 
 import Ops = WireFormat.Ops;
 

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -1,5 +1,4 @@
-import { Opaque, SymbolTable, RuntimeResolver } from "@glimmer/interfaces";
-import { CompileTimeConstants } from "@glimmer/opcode-compiler";
+import { Opaque, SymbolTable, RuntimeResolver, CompileTimeConstants } from "@glimmer/interfaces";
 
 const UNRESOLVED = {};
 

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -10,13 +10,15 @@ export interface ConstantPool {
   handles: number[];
   serializables: Opaque[];
   floats: number[];
+  negatives: number[];
 }
 
 export const enum PrimitiveType {
-  NUMBER          = 0b00,
-  FLOAT           = 0b01,
-  STRING          = 0b10,
-  BOOLEAN_OR_VOID = 0b11
+  NUMBER          = 0b000,
+  FLOAT           = 0b001,
+  STRING          = 0b010,
+  BOOLEAN_OR_VOID = 0b011,
+  NEGATIVE        = 0b100
 }
 
 export class WriteOnlyConstants implements CompileTimeConstants {
@@ -29,6 +31,7 @@ export class WriteOnlyConstants implements CompileTimeConstants {
   protected serializables: Opaque[] = [];
   protected resolved: Opaque[] = [];
   protected floats: number[] = [];
+  protected negatives: number[] = [];
 
   float(float: number) {
     let index = this.floats.indexOf(float);
@@ -38,6 +41,10 @@ export class WriteOnlyConstants implements CompileTimeConstants {
     }
 
     return this.floats.push(float) - 1;
+  }
+
+  negative(negative: number) {
+    return this.negatives.push(negative);
   }
 
   string(value: string): number {
@@ -102,7 +109,8 @@ export class WriteOnlyConstants implements CompileTimeConstants {
       tables: this.tables,
       handles: this.handles,
       serializables: this.serializables,
-      floats: this.floats
+      floats: this.floats,
+      negatives: this.negatives
     };
   }
 }
@@ -115,6 +123,7 @@ export class RuntimeConstants<Specifier> {
   protected serializables: Opaque[];
   protected resolved: Opaque[];
   protected floats: number[];
+  protected negatives: number[];
 
   constructor(public resolver: RuntimeResolver<Specifier>, pool: ConstantPool) {
     this.strings = pool.strings;
@@ -123,6 +132,7 @@ export class RuntimeConstants<Specifier> {
     this.handles = pool.handles;
     this.serializables = pool.serializables;
     this.floats = pool.floats;
+    this.negatives = pool.negatives;
     this.resolved = this.handles.map(() => UNRESOLVED);
   }
 
@@ -130,6 +140,10 @@ export class RuntimeConstants<Specifier> {
 
   getFloat(value: number): number {
     return this.floats[value];
+  }
+
+  getNegative(value: number): number {
+    return this.negatives[value - 1];
   }
 
   getString(value: number): string {
@@ -183,11 +197,20 @@ export class Constants<Specifier> extends WriteOnlyConstants {
       this.tables = pool.tables;
       this.handles = pool.handles;
       this.serializables = pool.serializables;
+      this.floats = pool.floats;
+      this.negatives = pool.negatives;
       this.resolved = this.handles.map(() => UNRESOLVED);
     }
   }
 
   // `0` means NULL
+  getFloat(value: number): number {
+    return this.floats[value - 1];
+  }
+
+  getNegative(value: number): number {
+    return this.negatives[value - 1];
+  }
 
   getString(value: number): string {
     return this.strings[value];

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -1,9 +1,8 @@
 
-import { Recast, VMHandle } from "@glimmer/interfaces";
+import { CompileTimeProgram, Recast, VMHandle } from "@glimmer/interfaces";
 import { DEBUG } from "@glimmer/local-debug-flags";
 import { Constants, WriteOnlyConstants, RuntimeConstants } from './constants';
 import { Opcode } from './opcode';
-import { CompileTimeProgram } from "@glimmer/opcode-compiler";
 
 enum TableSlotState {
   Allocated,

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -157,11 +157,11 @@ export class Heap {
   }
 
   capture() {
-    let o = this.heap.slice(0, this.offset);
+    let heap = this.heap.slice(0, this.offset);
     return {
       handle: this.handle,
       table: this.table,
-      buffer: o.buffer as ArrayBuffer
+      buffer: heap.buffer as ArrayBuffer
     };
   }
 }

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -57,8 +57,6 @@ export class Heap {
       this.heap = new Uint16Array(0x100000);
       this.table = [];
     }
-    this.heap = serializedHeap ? new Uint16Array(serializedHeap.buffer) : new Uint16Array(0x100000);
-    this.table = serializedHeap ? serializedHeap.table : [];
   }
 
   push(item: number): void {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -55,6 +55,9 @@ APPEND_OPCODES.add(Op.Primitive, (vm, { op1: primitive }) => {
         case 3: stack.push(undefined); break;
       }
       break;
+    case PrimitiveType.NEGATIVE:
+      stack.push(vm.constants.getNegative(value));
+      break;
   }
 });
 

--- a/packages/@glimmer/test-helpers/index.ts
+++ b/packages/@glimmer/test-helpers/index.ts
@@ -45,7 +45,7 @@ export {
 export * from './lib/environment/modifier';
 
 export { default as LazyTestEnvironment, default as TestEnvironment } from './lib/environment/modes/lazy/environment';
-export { NodeRenderDelegate } from './lib/environment/modes/ssr/environment';
+export { NodeLazyRenderDelegate, NodeEagerRenderDelegate } from './lib/environment/modes/ssr/environment';
 
 export { default as EagerRenderDelegate } from './lib/environment/modes/eager/render-delegate';
 export { default as LazyRenderDelegate } from './lib/environment/modes/lazy/render-delegate';

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -64,6 +64,7 @@ const COMPONENT_CAPABILITIES: Entries<ComponentCapabilities> = {
 };
 
 export default class EagerRenderDelegate implements RenderDelegate {
+  static isEager = true; // Used to disable tests where ArrayBuffer is undefined
   protected env: Environment;
   protected modules = new Modules();
   protected compileTimeModules = new Modules();

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -1,3 +1,4 @@
+import * as SimpleDOM from 'simple-dom';
 import {
   Environment,
   ComponentDefinition,
@@ -11,6 +12,9 @@ import {
 } from '@glimmer/runtime';
 import { LookupMap, specifierFor, DebugConstants, BundleCompiler, Specifier } from '@glimmer/bundle-compiler';
 import { Opaque, assert, Dict, assign, expect, Option } from '@glimmer/util';
+import { WriteOnlyProgram, RuntimeProgram, RuntimeConstants, Heap } from '@glimmer/program';
+import { ProgramSymbolTable, Recast, VMHandle, ComponentCapabilities } from '@glimmer/interfaces';
+import { UpdatableReference } from '@glimmer/object-reference';
 
 import RenderDelegate from '../../../render-delegate';
 import EagerCompilerDelegate from './compiler-delegate';
@@ -27,12 +31,8 @@ import EagerRuntimeResolver from './runtime-resolver';
 
 import { Modules } from './modules';
 import { TestDynamicScope } from '../../../environment';
-import { WriteOnlyProgram, RuntimeProgram, RuntimeConstants } from '@glimmer/program';
 import { WrappedBuilder } from '@glimmer/opcode-compiler';
-import { ProgramSymbolTable, Recast, VMHandle, ComponentCapabilities } from '@glimmer/interfaces';
-import { UpdatableReference } from '@glimmer/object-reference';
 import { NodeEnv } from '../ssr/environment';
-import * as SimpleDOM from 'simple-dom';
 import { TestComponentDefinitionState } from '../../component-definition';
 
 export type RenderDelegateComponentDefinition = ComponentDefinition<TestComponentDefinitionState>;
@@ -192,7 +192,7 @@ export default class EagerRenderDelegate implements RenderDelegate {
       }
     });
 
-    compiler.compile();
+    let { heap, pool } = compiler.compile();
 
     let handle = compiler.getSpecifierMap().vmHandleBySpecifier.get(spec)! as Recast<number, VMHandle>;
     let { env } = this;
@@ -202,8 +202,8 @@ export default class EagerRenderDelegate implements RenderDelegate {
     let self = new UpdatableReference(context);
     let dynamicScope = new TestDynamicScope();
     let resolver = new EagerRuntimeResolver(compiler.getSpecifierMap(), this.modules, this.specifiersToSymbolTable);
-    let pool = program.constants.toPool();
-    let runtimeProgram = new RuntimeProgram(new RuntimeConstants(resolver, pool), program.heap);
+    let runtimeHeap = new Heap(heap);
+    let runtimeProgram = new RuntimeProgram(new RuntimeConstants(resolver, pool), runtimeHeap);
 
     let vm = LowLevelVM.initial(runtimeProgram, env, self, null, dynamicScope, builder, handle);
     let iterator = new TemplateIterator(vm);

--- a/packages/@glimmer/test-helpers/lib/environment/modes/ssr/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/ssr/environment.ts
@@ -5,6 +5,7 @@ import * as SimpleDOM from 'simple-dom';
 
 import LazyTestEnvironment from '../lazy/environment';
 import LazyRenderDelegate from '../lazy/render-delegate';
+import EagerRenderDelegate from '../eager/render-delegate';
 import RenderDelegate from '../../../render-delegate';
 import { RenderTest } from '../../../render-test';
 
@@ -39,7 +40,13 @@ export class NodeEnv extends LazyTestEnvironment {
   }
 }
 
-export class NodeRenderDelegate extends LazyRenderDelegate {
+export class NodeLazyRenderDelegate extends LazyRenderDelegate {
+  constructor() {
+    super(new NodeEnv({ document: new SimpleDOM.Document() }));
+  }
+}
+
+export class NodeEagerRenderDelegate extends EagerRenderDelegate {
   constructor() {
     super(new NodeEnv({ document: new SimpleDOM.Document() }));
   }

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -958,8 +958,7 @@ const HAS_TYPED_ARRAYS = (() => {
   try {
     if (typeof Uint16Array === 'undefined') return false;
     let arr = new Uint16Array([1]);
-    arr.slice(0, 1);
-    return true;
+    return typeof arr.subarray === 'function';
   } catch (e) {
     return false;
   }

--- a/packages/@glimmer/util/index.ts
+++ b/packages/@glimmer/util/index.ts
@@ -10,7 +10,7 @@ export { ensureGuid, initializeGuid, HasGuid } from './lib/guid';
 
 export { Stack, Dict, Set, DictSet, dict } from './lib/collections';
 export { EMPTY_SLICE, LinkedList, LinkedListNode, ListNode, CloneableListNode, ListSlice, Slice } from './lib/list-utils';
-export { default as A, EMPTY_ARRAY } from './lib/array-utils';
+export { EMPTY_ARRAY } from './lib/array-utils';
 export { HAS_NATIVE_WEAKMAP } from './lib/weakmap';
 
 export type TSISSUE<T, S extends string> = T;

--- a/packages/@glimmer/util/lib/array-utils.ts
+++ b/packages/@glimmer/util/lib/array-utils.ts
@@ -1,15 +1,3 @@
 import { HAS_NATIVE_WEAKMAP } from './weakmap';
 
-const HAS_TYPED_ARRAYS = typeof Uint32Array !== 'undefined';
-
-let A;
-
-if (HAS_TYPED_ARRAYS) {
-  A = Uint32Array;
-} else {
-  A = Array;
-}
-
-export default A;
-
 export const EMPTY_ARRAY: any[] = (HAS_NATIVE_WEAKMAP ? Object.freeze([]) : []) as any;

--- a/testem-sauce.js
+++ b/testem-sauce.js
@@ -4,7 +4,7 @@ module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
-  "timeout": 540,
+  "timeout": 600,
   "parallel": 2,
   "launchers":
     {
@@ -29,7 +29,7 @@ module.exports = {
         "protocol": "tap"
       },
       "SL_Safari_Current": {
-        "command": "ember sauce:launch -b safari -v 9 --no-ct -u '<url>'",
+        "command": "ember sauce:launch -b safari -v 10 --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_Safari_Last": {


### PR DESCRIPTION
Prior to this commit we were directly passing the populated `Heap` instance directly into the VM. This is not reflective of how eager mode will work. Instead eager mode will read directly from an `ArrayBuffer` that was precomputed on the server. At runtime this `ArrayBuffer` is placed into a `Uint16Array` view and is decoded as we execute. Decoding is merely shifting off some bits and can be seen in #643. 

Because we are not using signed integers we have to place negative numbers into the constant pool. In the future we may revisit this but at this time numeric literals in the template are not represented of the common case e.g. strings.