### PR TITLE
Break @glimmer/interfaces circular dependency

### DIFF
--- a/packages/@glimmer/interfaces/lib/di.d.ts
+++ b/packages/@glimmer/interfaces/lib/di.d.ts
@@ -1,6 +1,6 @@
 import { TemplateMeta } from '@glimmer/wire-format';
-import { ComponentDefinition } from "@glimmer/runtime";
 
+import { ComponentDefinition } from './components';
 import { Opaque, Option, Unique } from './core';
 
 export interface RuntimeResolver<Specifier> {


### PR DESCRIPTION
The `RuntimeResolver` interface was inappropriately importing from `@glimmer/runtime` to get `ComponentDefinition`, which creates a circular dependency. Because this package already defines a `ComponentDefinition` interface, we use that instead.