### PR TITLE
[Breaking] Pass Instances Of Element Builders

### DIFF
--- a/packages/@glimmer/node/index.ts
+++ b/packages/@glimmer/node/index.ts
@@ -1,1 +1,2 @@
 export { default as NodeDOMTreeConstruction } from './lib/node-dom-helper';
+export { serializeBuilder } from './lib/serialize-builder';

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -1,6 +1,6 @@
 import './lib/bootstrap';
 
-export { default as templateFactory, ScannableTemplate, TemplateFactory, Template, TemplateIterator, RenderLayoutOptions, clientBuilder, rehydrationBuilder, serializeBuilder } from './lib/template';
+export { default as templateFactory, ScannableTemplate, TemplateFactory, Template, TemplateIterator, RenderLayoutOptions, clientBuilder, rehydrationBuilder } from './lib/template';
 
 export { NULL_REFERENCE, UNDEFINED_REFERENCE, PrimitiveReference, ConditionalReference } from './lib/references';
 

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -1,6 +1,6 @@
 import './lib/bootstrap';
 
-export { default as templateFactory, ScannableTemplate, TemplateFactory, Template, TemplateIterator, RenderLayoutOptions, elementBuilder } from './lib/template';
+export { default as templateFactory, ScannableTemplate, TemplateFactory, Template, TemplateIterator, RenderLayoutOptions, clientBuilder, rehydrationBuilder, serializeBuilder } from './lib/template';
 
 export { NULL_REFERENCE, UNDEFINED_REFERENCE, PrimitiveReference, ConditionalReference } from './lib/references';
 

--- a/packages/@glimmer/runtime/lib/bounds.ts
+++ b/packages/@glimmer/runtime/lib/bounds.ts
@@ -12,16 +12,6 @@ export class Cursor {
   constructor(public element: Simple.Element, public nextSibling: Option<Simple.Node>) {}
 }
 
-export function currentNode(cursor: Cursor): Option<Simple.Node> {
-  let { element, nextSibling } = cursor;
-
-  if (nextSibling === null) {
-    return element.lastChild;
-  } else {
-    return nextSibling.previousSibling;
-  }
-}
-
 export default Bounds;
 
 export interface DestroyableBounds extends Bounds, Destroyable {}

--- a/packages/@glimmer/runtime/lib/template.ts
+++ b/packages/@glimmer/runtime/lib/template.ts
@@ -24,7 +24,6 @@ export interface RenderLayoutOptions {
   env: Environment;
   self: PathReference<Opaque>;
   args?: ICapturedArguments;
-  cursor: Cursor;
   dynamicScope: DynamicScope;
   builder: ElementBuilder;
 }

--- a/packages/@glimmer/runtime/lib/template.ts
+++ b/packages/@glimmer/runtime/lib/template.ts
@@ -9,7 +9,6 @@ import {
 } from '@glimmer/wire-format';
 import { NewElementBuilder, ElementBuilder } from './vm/element-builder';
 import { RehydrateBuilder } from './vm/rehydrate-builder';
-import { SerializeBuilder } from './vm/serialize-builder';
 import { DynamicScope, Environment } from './environment';
 import { TopLevelSyntax } from './syntax/interfaces';
 import { IteratorResult, RenderResult, VM } from './vm';
@@ -170,8 +169,4 @@ export function clientBuilder(env: Environment, cursor: Cursor) {
 
 export function rehydrationBuilder(env: Environment, cursor: Cursor) {
   return RehydrateBuilder.forInitialRender(env, cursor);
-}
-
-export function serializeBuilder(env: Environment, cursor: Cursor) {
-  return SerializeBuilder.forInitialRender(env, cursor);
 }

--- a/packages/@glimmer/runtime/test/attributes-test.ts
+++ b/packages/@glimmer/runtime/test/attributes-test.ts
@@ -42,7 +42,6 @@ function render(template: Template, context = {}) {
   let templateIterator = template.renderLayout({
     env,
     self,
-    cursor,
     builder: clientBuilder(env, cursor),
     dynamicScope: new TestDynamicScope()
   });

--- a/packages/@glimmer/runtime/test/attributes-test.ts
+++ b/packages/@glimmer/runtime/test/attributes-test.ts
@@ -1,7 +1,7 @@
 import { UpdatableReference } from "@glimmer/object-reference";
 import { IteratorResult } from '@glimmer/runtime';
 import { equalTokens, TestDynamicScope, TestEnvironment } from "@glimmer/test-helpers";
-import { SVG_NAMESPACE, RenderResult, Template, normalizeProperty } from "@glimmer/runtime";
+import { SVG_NAMESPACE, RenderResult, Template, normalizeProperty, clientBuilder } from "@glimmer/runtime";
 
 const { assert, test } = QUnit;
 
@@ -39,7 +39,13 @@ function render(template: Template, context = {}) {
   self = new UpdatableReference(context);
   env.begin();
   let cursor = { element: root, nextSibling: null };
-  let templateIterator = template.renderLayout({ env, self, cursor, dynamicScope: new TestDynamicScope() });
+  let templateIterator = template.renderLayout({
+    env,
+    self,
+    cursor,
+    builder: clientBuilder(env, cursor),
+    dynamicScope: new TestDynamicScope()
+  });
   let iteratorResult: IteratorResult<RenderResult>;
   do {
     iteratorResult = templateIterator.next();

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -41,7 +41,6 @@ export class EmberishRootView extends EmberObject {
     let templateIterator = this.template.renderLayout({
       env: this.env,
       self,
-      cursor,
       builder: clientBuilder(env, cursor),
       dynamicScope: new TestDynamicScope()
     });

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -14,7 +14,7 @@ import {
   TestEnvironment,
 } from "@glimmer/test-helpers";
 import { assign } from "@glimmer/util";
-import { RenderResult, Template } from '../index';
+import { RenderResult, Template, clientBuilder } from '@glimmer/runtime';
 import { assert } from './support';
 
 export class EmberishRootView extends EmberObject {
@@ -37,7 +37,14 @@ export class EmberishRootView extends EmberObject {
   appendTo(selector: string) {
     let element = this.parent = document.querySelector(selector)!;
     let self = new UpdatableReference(this);
-    let templateIterator = this.template.renderLayout({ env: this.env, self, cursor: { element, nextSibling: null }, dynamicScope: new TestDynamicScope() });
+    let cursor =  { element, nextSibling: null };
+    let templateIterator = this.template.renderLayout({
+      env: this.env,
+      self,
+      cursor,
+      builder: clientBuilder(env, cursor),
+      dynamicScope: new TestDynamicScope()
+    });
 
     let result;
     do {

--- a/packages/@glimmer/runtime/test/partial-test.ts
+++ b/packages/@glimmer/runtime/test/partial-test.ts
@@ -33,7 +33,6 @@ function render(template: Template, context={}) {
   let templateIterator = template.renderLayout({
     env,
     self,
-    cursor,
     builder: clientBuilder(env, cursor),
     dynamicScope: new TestDynamicScope()
   });

--- a/packages/@glimmer/runtime/test/partial-test.ts
+++ b/packages/@glimmer/runtime/test/partial-test.ts
@@ -1,4 +1,4 @@
-import { Template, RenderResult, IteratorResult } from "@glimmer/runtime";
+import { Template, RenderResult, IteratorResult, clientBuilder } from "@glimmer/runtime";
 import {
   BasicComponent,
   EmberishCurlyComponent,
@@ -29,7 +29,14 @@ function commonSetup() {
 function render(template: Template, context={}) {
   self = new UpdatableReference(context);
   env.begin();
-  let templateIterator = template.renderLayout({ env, self, cursor: { element: root, nextSibling: null }, dynamicScope: new TestDynamicScope() });
+  let cursor = { element: root, nextSibling: null };
+  let templateIterator = template.renderLayout({
+    env,
+    self,
+    cursor,
+    builder: clientBuilder(env, cursor),
+    dynamicScope: new TestDynamicScope()
+  });
   let iteratorResult: IteratorResult<RenderResult>;
   do {
     iteratorResult = templateIterator.next();

--- a/packages/@glimmer/runtime/test/style-warning-test.ts
+++ b/packages/@glimmer/runtime/test/style-warning-test.ts
@@ -28,7 +28,6 @@ function render(template: Template, self: any) {
   let templateIterator = template.renderLayout({
     env,
     self: new UpdatableReference(self),
-    cursor,
     builder: clientBuilder(env, cursor),
     dynamicScope: new TestDynamicScope()
   });

--- a/packages/@glimmer/runtime/test/style-warning-test.ts
+++ b/packages/@glimmer/runtime/test/style-warning-test.ts
@@ -1,6 +1,6 @@
 import { TestEnvironment, equalTokens, TestDynamicScope } from "@glimmer/test-helpers";
 import { test, module } from "@glimmer/runtime/test/support";
-import { Template, RenderResult, DynamicAttributeFactory, SimpleDynamicAttribute, ElementBuilder } from "@glimmer/runtime";
+import { Template, RenderResult, DynamicAttributeFactory, SimpleDynamicAttribute, ElementBuilder, clientBuilder } from "@glimmer/runtime";
 import { UpdatableReference } from "@glimmer/object-reference";
 import { Option, Simple, Opaque } from "@glimmer/interfaces";
 
@@ -24,7 +24,14 @@ function rootElement(): HTMLDivElement {
 function render(template: Template, self: any) {
   let result: RenderResult;
   env.begin();
-  let templateIterator = template.renderLayout({ env, self: new UpdatableReference(self), cursor: { element: root, nextSibling: null }, dynamicScope: new TestDynamicScope() });
+  let cursor = { element: root, nextSibling: null };
+  let templateIterator = template.renderLayout({
+    env,
+    self: new UpdatableReference(self),
+    cursor,
+    builder: clientBuilder(env, cursor),
+    dynamicScope: new TestDynamicScope()
+  });
   let iteratorResult: IteratorResult<RenderResult>;
   do {
     iteratorResult = templateIterator.next() as IteratorResult<RenderResult>;

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -50,7 +50,6 @@ function render(template: Template, context = {}) {
   let templateIterator = template.renderLayout({
     env,
     self,
-    cursor,
     builder: clientBuilder(env, cursor),
     dynamicScope: new TestDynamicScope()
   });

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -1,4 +1,4 @@
-import { UNDEFINED_REFERENCE, Template, RenderResult, SafeString, PrimitiveReference, VM, IteratorResult } from "@glimmer/runtime";
+import { UNDEFINED_REFERENCE, Template, RenderResult, SafeString, PrimitiveReference, VM, IteratorResult, clientBuilder } from "@glimmer/runtime";
 import { assertNodeTagName, BasicComponent, TestEnvironment, TestDynamicScope, TestModifierManager, equalTokens, stripTight, trimLines } from "@glimmer/test-helpers";
 import { ConstReference } from "@glimmer/reference";
 import { UpdatableReference } from "@glimmer/object-reference";
@@ -46,7 +46,14 @@ function assertProperty<T, K extends keyof T, V extends T[K]>(obj: T | null, key
 function render(template: Template, context = {}) {
   self = new UpdatableReference(context);
   env.begin();
-  let templateIterator = template.renderLayout({ env, self, cursor: { element: root, nextSibling: null }, dynamicScope: new TestDynamicScope() });
+  let cursor = { element: root, nextSibling: null };
+  let templateIterator = template.renderLayout({
+    env,
+    self,
+    cursor,
+    builder: clientBuilder(env, cursor),
+    dynamicScope: new TestDynamicScope()
+  });
   let iteratorResult: IteratorResult<RenderResult>;
   do {
     iteratorResult = templateIterator.next();

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -5,10 +5,10 @@ import {
   getDynamicVar,
   Helper as GlimmerHelper,
   RenderResult,
-  elementBuilder,
   LowLevelVM,
   TemplateIterator,
-  ComponentManager
+  ComponentManager,
+  clientBuilder
 } from '@glimmer/runtime';
 import { LookupMap, specifierFor, DebugConstants, BundleCompiler, Specifier } from '@glimmer/bundle-compiler';
 import { Opaque, assert, Dict, assign, expect, Option } from '@glimmer/util';
@@ -199,7 +199,7 @@ export default class EagerRenderDelegate implements RenderDelegate {
     let { env } = this;
 
     let cursor = { element, nextSibling: null };
-    let builder = elementBuilder({ mode: 'client', env, cursor });
+    let builder = clientBuilder(env, cursor);
     let self = new UpdatableReference(context);
     let dynamicScope = new TestDynamicScope();
     let resolver = new EagerRuntimeResolver(compiler.getSpecifierMap(), this.modules, this.specifiersToSymbolTable);

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
@@ -34,7 +34,6 @@ export default class LazyRenderDelegate implements RenderDelegate {
     return renderTemplate(template, {
       env,
       self: new UpdatableReference(context),
-      cursor,
       builder: clientBuilder(env, cursor),
       dynamicScope: new TestDynamicScope()
     });

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
@@ -1,6 +1,6 @@
 import { Dict, Opaque } from '@glimmer/util';
 import { Simple } from '@glimmer/interfaces';
-import { RenderResult } from '@glimmer/runtime';
+import { RenderResult, clientBuilder } from '@glimmer/runtime';
 import { UpdatableReference } from '@glimmer/object-reference';
 
 import LazyTestEnvironment from './environment';
@@ -30,10 +30,12 @@ export default class LazyRenderDelegate implements RenderDelegate {
 
   renderTemplate(template: string, context: Dict<Opaque>, element: Simple.Element): RenderResult {
     let { env } = this;
+    let cursor = { element, nextSibling: null };
     return renderTemplate(template, {
       env,
       self: new UpdatableReference(context),
-      cursor: { element, nextSibling: null },
+      cursor,
+      builder: clientBuilder(env, cursor),
       dynamicScope: new TestDynamicScope()
     });
   }

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -1,7 +1,7 @@
 import { PathReference, Tagged, TagWrapper, RevisionTag, DirtyableTag, Tag } from "@glimmer/reference";
-import { RenderResult, RenderLayoutOptions, TemplateIterator, Environment, rehydrationBuilder, serializeBuilder } from "@glimmer/runtime";
+import { RenderResult, RenderLayoutOptions, TemplateIterator, Environment, rehydrationBuilder } from "@glimmer/runtime";
 import { Opaque, Dict, dict, expect } from "@glimmer/util";
-import { NodeDOMTreeConstruction } from "@glimmer/node";
+import { NodeDOMTreeConstruction, serializeBuilder } from "@glimmer/node";
 import { Option } from "@glimmer/interfaces";
 import { UpdatableReference } from "@glimmer/object-reference";
 import * as SimpleDOM from "simple-dom";

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -547,7 +547,6 @@ export class RehydrationDelegate implements RenderDelegate {
     renderTemplate(template, {
       env,
       self: new UpdatableReference(context),
-      cursor,
       dynamicScope: new TestDynamicScope(),
       builder: serializeBuilder(env, cursor)
     });
@@ -569,7 +568,6 @@ export class RehydrationDelegate implements RenderDelegate {
     return renderTemplate(template, {
       env,
       self: new UpdatableReference(context),
-      cursor,
       dynamicScope: new TestDynamicScope(),
       builder: rehydrationBuilder(env, cursor)
     });


### PR DESCRIPTION
Instead of using a `mode` string to pick the element builder we should provide factory functions for producing the correct element builder. This will allow for tooling that does tree shaking to properly remove the element builders that are not used.

### What Changed

Instead of rendering a layout like so:

```
template.renderLayout({
  env,
  self: new UpdatableReference(self),
  cursor: { element: root, nextSibling: null },
  dynamicScope: new TestDynamicScope(),
  mode: 'client' | 'rehydrate' | 'serialize'
});
```

You now render as follows:

```
import { clientBuilder, rehydrationBuilder } from '@glimmer/runtime';
import { serializeBuilder } from '@glimmer/node';

let cursor = { element: root, nextSibling: null };
template.renderLayout({
  env,
  self: new UpdatableReference(self),
  dynamicScope: new TestDynamicScope(),
  builder: clientBuilder(env, cursor) | rehydrationBuilder(env, cursor) | serializeBuilder(env, cursor)
});
```

Also there is a larger refactor that should be done (attempted in #610) to decouple the DOM from the environment and make the element builder the object in which the document comes from. This PR is a toned down version of #610. These changes should be absorbed by Glimmer.js and Ember.