### PR TITLE
BUGFIX: Don't use subarray to dump heap

### DIFF
--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -162,7 +162,7 @@ export class Heap {
 
   capture() {
     // Only called in eager mode
-    let buffer = subarray(this.heap, 0, this.offset);
+    let buffer = slice(this.heap, 0, this.offset);
     return {
       handle: this.handle,
       table: this.table,
@@ -205,9 +205,19 @@ export class Program<Specifier> extends WriteOnlyProgram {
   public constants: Constants<Specifier>;
 }
 
-function subarray(arr: Uint16Array | number[], start: number, end: number) {
+function slice(arr: Uint16Array | number[], start: number, end: number) {
   if (arr instanceof Uint16Array) {
-    return arr.subarray(start, end).buffer;
+    if (arr.slice !== undefined) {
+      return arr.slice(start, end).buffer;
+    }
+
+    let ret = new Uint16Array(end);
+
+    for (; start < end; start++) {
+      ret[start]  = arr[start];
+    }
+
+    return ret.buffer;
   }
 
   return null;

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -954,15 +954,7 @@ function assertEmberishElement(...args: any[]): void {
   equalsElement(element, tagName, fullAttrs, contents);
 }
 
-const HAS_TYPED_ARRAYS = (() => {
-  try {
-    if (typeof Uint16Array === 'undefined') return false;
-    let arr = new Uint16Array([1]);
-    return typeof arr.subarray === 'function';
-  } catch (e) {
-    return false;
-  }
-})();
+const HAS_TYPED_ARRAYS = typeof Uint16Array !== 'undefined';
 
 function shouldRunTest<T extends RenderDelegate>(Delegate: RenderDelegateConstructor<T>) {
   let isEagerDelegate = Delegate['isEager'];


### PR DESCRIPTION
Subarray is like a view of the parent typed array and thus retains the buffer from the parent. This means the gbx files that we were creating had a ton of empty space in them. Unfortunately, not all browsers implement `.slice` so in cases where it is undefined we have to copy the contents into a new typed array and return buffer.