### PR TITLE
[BUGFIX] Path for expanding debug APIs correction

### DIFF
--- a/build/broccoli/build-packages.js
+++ b/build/broccoli/build-packages.js
@@ -161,7 +161,7 @@ function transpileCommonJS(pkgName, esVersion, tree) {
           }
         },
         debugTools: {
-          source: '@glimmer/debug'
+          source: '@glimmer/util'
         },
         externalizeHelpers: {
           module: true

--- a/build/broccoli/strip-glimmer-utilities.js
+++ b/build/broccoli/strip-glimmer-utilities.js
@@ -23,14 +23,14 @@ module.exports = function(jsTree) {
         }
       },
       debugTools: {
-        source: '@glimmer/debug'
+        source: '@glimmer/util'
       },
       externalizeHelpers: {
         module: true
       }
     }])
 
-    glimmerUtils.push([nuke, { source: '@glimmer/debug' }])
+    glimmerUtils.push([nuke, { source: '@glimmer/debug' }]);
     glimmerUtils.push([nuke, { source: '@glimmer/vm/lib/-debug-strip' }]);
     glimmerUtils.push([nuke, {
       source: '@glimmer/vm',


### PR DESCRIPTION
The `source` needs to point to where the debug utils come from e.g. `assert`, `warn`, `log` etc. This will expand these calls in a way that should get stripped by minifiers. 