### PR TITLE
Explicitly publish public packages during deploy

### DIFF
--- a/bin/publish.js
+++ b/bin/publish.js
@@ -135,7 +135,7 @@ function confirmPublish() {
     }
 
     packages.filter(pkg => !pkg.private).forEach(package => {
-      execWithSideEffects(`npm publish --tag ${distTag}`, {
+      execWithSideEffects(`npm publish --tag ${distTag} --access public`, {
         cwd: package.absolutePath
       });
     });


### PR DESCRIPTION
We publish Glimmer VM packages to the `@glimmer` scope on npm, but all scoped packages are considered private by default. Currently, any time someone adds a new package, the deploy process will fail the first time the package is published because it tries to make it private and we are on a free account which does not allow private packages.

This commit modifies the deploy script to explicitly mark each published package as public, so new packages can be published successfully.