### PR TITLE
[BUGFIX] Fix metamorphs during rehydration

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -79,5 +79,5 @@ export {
 export { default as DOMChanges, SVG_NAMESPACE, DOMChanges as IDOMChanges, DOMTreeConstruction, isWhitespace, insertHTMLBefore } from './lib/dom/helper';
 export { normalizeProperty } from './lib/dom/props';
 export { ElementBuilder, NewElementBuilder, ElementOperations, clientBuilder } from './lib/vm/element-builder';
-export { rehydrationBuilder } from './lib/vm/rehydrate-builder';
+export { rehydrationBuilder, RehydrateBuilder } from './lib/vm/rehydrate-builder';
 export { default as Bounds, ConcreteBounds, Cursor } from './lib/bounds';

--- a/packages/@glimmer/test-helpers/index.ts
+++ b/packages/@glimmer/test-helpers/index.ts
@@ -50,5 +50,6 @@ export { NodeLazyRenderDelegate, NodeEagerRenderDelegate } from './lib/environme
 
 export { default as EagerRenderDelegate } from './lib/environment/modes/eager/render-delegate';
 export { default as LazyRenderDelegate } from './lib/environment/modes/lazy/render-delegate';
+export { debugRehydration } from './lib/environment/modes/rehydration/debug-builder';
 
 export * from './lib/environment/components';

--- a/packages/@glimmer/test-helpers/lib/environment/modes/rehydration/debug-builder.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/rehydration/debug-builder.ts
@@ -1,0 +1,24 @@
+import { RehydrateBuilder, ElementBuilder, Environment, Cursor } from '@glimmer/runtime';
+import { Simple } from '@glimmer/interfaces';
+
+export class DebugRehydrationBuilder extends RehydrateBuilder {
+  clearedBlocks: string[] = [];
+  clearedNodes: Simple.Node[] = [];
+  clearBlock(count: number) {
+    this.clearedBlocks.push(`block:${count}`);
+    super.clearBlock(count);
+  }
+
+  remove(node: Simple.Node) {
+    let next = super.remove(node);
+    if (node.nodeType !== 8) {
+      // Only push nodes that effect the UI
+      this.clearedNodes.push(node);
+    }
+    return next;
+  }
+}
+
+export function debugRehydration(env: Environment, cursor: Cursor): ElementBuilder {
+  return DebugRehydrationBuilder.forInitialRender(env, cursor);
+}


### PR DESCRIPTION
Prior to this PR we were not doing a very good job at ensuring the
integrity of the rehydration process. Unsurprisingly we had bugs, specifically parsing the depth out of the block metamorphs was not correct as it was looking for `%bounds:int%` instead of `%block:int%`. This meant that things were accidently working. To ensure we do not regress on this in the future I have added a `DebugRehydrationBuilder` that collects stats for when clearing blocks and removing nodes occurs.