### PR TITLE
Cleanup some of the rehydration code

### DIFF
--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -90,7 +90,7 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
   pushRemoteElement(element: Simple.Element, cursorId: string,  nextSibling: Option<Simple.Node> = null) {
     let { dom } = this;
     let script = dom.createElement('script');
-    script.setAttribute('id', cursorId);
+    script.setAttribute('glmr', cursorId);
     dom.insertBefore(element, script, nextSibling);
     super.pushRemoteElement(element, cursorId, nextSibling);
   }

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -244,9 +244,12 @@ export class NewElementBuilder implements ElementBuilder {
     this.popElement();
   }
 
-  pushRemoteElement(element: Simple.Element, _guid: string, nextSibling: Option<Simple.Node> = null) {
-    this.pushElement(element, nextSibling);
+  pushRemoteElement(element: Simple.Element, guid: string, nextSibling: Option<Simple.Node> = null) {
+    this.__pushRemoteElement(element, guid, nextSibling);
+  }
 
+  __pushRemoteElement(element: Simple.Element, _guid: string, nextSibling: Option<Simple.Node>) {
+    this.pushElement(element, nextSibling);
     let tracker = new RemoteBlockTracker(element);
     this.pushBlockTracker(tracker, true);
   }

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -84,7 +84,6 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
         }
         assert(current !== null, 'should have found closing block');
       } else {
-        // assert current.parentNode === lastMatched
         while (current !== null) {
           current = this.remove(current);
         }
@@ -115,13 +114,6 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       this.clearMismatch(candidate);
     }
   }
-
-  // <el>
-  //  null
-  //  open block set
-  //    open block  incr
-  //    close block dcr
-  //  close unset
 
   __closeBlock(): void {
     let { currentCursor } = this;
@@ -334,23 +326,23 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     super.willCloseElement();
   }
 
-  getMarker(element: Simple.Element, guid: string): Simple.Node {
-    let marker = element.firstChild;
-    if (marker && marker['id'] === guid) {
+  getMarker(element: HTMLElement, guid: string): Simple.Node {
+    let marker = element.querySelector(`script[glmr="${guid}"]`);
+    if (marker) {
       return marker;
     }
 
     throw new Error('Cannot find serialized cursor for `in-element`');
   }
 
-  pushRemoteElement(element: Simple.Element, cursorId: string, _nextSibling: Option<Simple.Node> = null) {
-    let marker = this.getMarker(element, cursorId);
+  __pushRemoteElement(element: Simple.Element, cursorId: string, nextSibling: Option<Simple.Node> = null) {
+    let marker = this.getMarker(element as HTMLElement, cursorId);
 
     if (marker.parentNode === element) {
       let currentCursor = this.currentCursor;
       let candidate = currentCursor!.candidate;
 
-      this.pushElement(element, _nextSibling);
+      this.pushElement(element, nextSibling);
 
       currentCursor!.candidate = candidate;
       this.candidate = this.remove(marker);
@@ -367,11 +359,6 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       this.candidate = last && last.nextSibling;
     }
     return bounds;
-  }
-
-  didOpenElement(element: Simple.Element): Simple.Element {
-    super.didOpenElement(element);
-    return element;
   }
 }
 

--- a/packages/@glimmer/test-helpers/lib/environment/modes/rehydration/debug-builder.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/rehydration/debug-builder.ts
@@ -6,10 +6,19 @@ export class DebugRehydrationBuilder extends RehydrateBuilder {
 
   remove(node: Simple.Node) {
     let next = super.remove(node);
+    let el = node as Element;
+
     if (node.nodeType !== 8) {
-      // Only push nodes that effect the UI
-      this.clearedNodes.push(node);
+      if (el.nodeType === 1) {
+        // don't stat serialized cursor positions
+        if (el.tagName !== 'SCRIPT' && !el.getAttribute('gmlr')) {
+          this.clearedNodes.push(node);
+        }
+      } else {
+        this.clearedNodes.push(node);
+      }
     }
+
     return next;
   }
 }


### PR DESCRIPTION
Cleans up some things from #690. For rehydrating `{{in-element}}` the remote may have existing content in it so we have to query to the point where to start rehydration. Also I believe the pattern here is that dunderscores e.g. `__` are suppose to be extension points until we have done more rationalization. The implementation of `pushRemoteElement` is very different in rehydration mode instead of append so I added `__pushRemoteElement` on both sides.