### PR TITLE
Guard for idempotent sets

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -210,7 +210,9 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
 
     if (candidate) {
       if (isTextNode(candidate)) {
-        candidate.nodeValue = string;
+        if (candidate.nodeValue !== string) {
+          candidate.nodeValue = string;
+        }
         this.candidate = candidate.nextSibling;
         return candidate;
       } else if (candidate && (isSeparator(candidate) || isEmpty(candidate))) {
@@ -235,8 +237,11 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
   __appendComment(string: string): Simple.Comment {
     let _candidate = this.candidate;
     if (_candidate && isComment(_candidate)) {
-      // TODO should not rehydrated a special comment
-      _candidate.nodeValue = string;
+
+      if (_candidate.nodeValue !== string) {
+        _candidate.nodeValue = string;
+      }
+
       this.candidate =_candidate.nextSibling;
       return _candidate;
     } else if (_candidate) {
@@ -270,7 +275,9 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     if (unmatched) {
       let attr = findByName(unmatched, name);
       if (attr) {
-        attr.value = value;
+        if (attr.value !== value) {
+          attr.value = value;
+        }
         unmatched.splice(unmatched.indexOf(attr), 1);
         return;
       }
@@ -285,7 +292,9 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     if (unmatched) {
       let attr = findByName(unmatched, name);
       if (attr) {
-        attr.value = value;
+        if (attr.value !== value) {
+          attr.value = value;
+        }
         unmatched.splice(unmatched.indexOf(attr), 1);
         return;
       }


### PR DESCRIPTION
In rehydration mode we should not set `nodeValue` on nodes or `value` on attributes/props if the values are the same. Without checking you will cause style recalculations / layout that really don't need to happen.
<img width="1406" alt="screen shot 2017-10-05 at 4 41 45 pm" src="https://user-images.githubusercontent.com/183799/31251558-4a534b60-a9ec-11e7-8be0-dac5f139efd6.png">
