### PR TITLE
Skip setting attributes if backing reference is not dirty

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -164,14 +164,19 @@ export class UpdateDynamicAttributeOpcode extends UpdatingOpcode {
   public type = 'patch-element';
 
   public tag: Tag;
+  public lastRevision: number;
 
   constructor(private reference: VersionedReference<Opaque>, private attribute: DynamicAttribute) {
     super();
     this.tag = reference.tag;
+    this.lastRevision = this.tag.value();
   }
 
   evaluate(vm: UpdatingVM) {
-    let { attribute, reference } = this;
-    attribute.update(reference.value(), vm.env);
+    let { attribute, reference, tag } = this;
+    if (!tag.validate(this.lastRevision)) {
+      this.lastRevision = tag.value();
+      attribute.update(reference.value(), vm.env);
+    }
   }
 }


### PR DESCRIPTION
Fixes glimmerjs/glimmer.js#9. Previously, we were always eagerly setting element attributes even in cases where the backing reference's tag had not been invalidated.

I think we didn't notice this for two reasons:

1. Most attributes sets are idempotent, and the bug is only really noticeable in cases where you're setting things like the `src` attribute of an audio tag.
2. More horrifying, it turns out that the majority of the test suite is built on top of volatile tags. I tried to change these to something a bit more reasonable but it caused hundreds of cascading failures because many tests rely on interior mutation of template context. It's hard to guess exactly how many bugs the volatility is hiding, but we should get in the habit of testing re-renders with both valid and invalid references.