### PR TITLE
Cleanup bundle compiler

### DIFF
--- a/bin/run-types-tests.js
+++ b/bin/run-types-tests.js
@@ -12,7 +12,7 @@ try {
   console.log('TAP version 13');
   console.log('1..1');
   console.log('# Smoke testing types');
-  execa.sync('tsc', ['--noEmit', '--module', 'commonjs', 'dist/types-smoke-test.ts']);
+  execa.sync('tsc', ['--noEmit', '--target', 'ES2015', '--module', 'commonjs', 'dist/types-smoke-test.ts']);
   console.log('ok 1 - types passed smoke test');
 } catch (err) {
   let { message } = err;

--- a/packages/@glimmer/bundle-compiler/index.ts
+++ b/packages/@glimmer/bundle-compiler/index.ts
@@ -16,6 +16,5 @@ export {
 } from './lib/specifiers';
 
 export {
-  SpecifierMap,
-  LookupMap
+  SpecifierMap
 } from './lib/specifier-map';

--- a/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
+++ b/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
@@ -1,7 +1,8 @@
 import { ProgramSymbolTable, ComponentCapabilities } from "@glimmer/interfaces";
-import { ICompilableTemplate } from "@glimmer/opcode-compiler";
+import { ICompilableTemplate, CompileOptions } from "@glimmer/opcode-compiler";
 
 import { Specifier } from "./specifiers";
+import { SerializedTemplateBlock } from "@glimmer/wire-format";
 
 /**
  * A CompilerDelegate helps the BundleCompiler map external references it finds
@@ -60,7 +61,7 @@ export interface CompilerDelegate {
    * and it should return a compilable template that the compiler adds to the
    * set of templates to compile for the bundle.
    */
-  getComponentLayout(specifier: Specifier): ICompilableTemplate<ProgramSymbolTable>;
+  getComponentLayout(specifier: Specifier, block: SerializedTemplateBlock, options: CompileOptions<Specifier>): ICompilableTemplate<ProgramSymbolTable>;
 
   /**
    * During compilation, the compiler will ask the delegate about each possible

--- a/packages/@glimmer/bundle-compiler/lib/specifier-map.ts
+++ b/packages/@glimmer/bundle-compiler/lib/specifier-map.ts
@@ -1,5 +1,3 @@
-import { Opaque } from "@glimmer/util";
-
 import { Specifier } from "./specifiers";
 
 /**
@@ -8,50 +6,9 @@ import { Specifier } from "./specifiers";
  * build a data structure for converting handles into actual module values.
  */
 export class SpecifierMap {
-  public bySpecifier = new LookupMap<Specifier, number>();
-  public byHandle = new LookupMap<number, Specifier>();
+  public bySpecifier = new Map<Specifier, number>();
+  public byHandle = new Map<number, Specifier>();
 
-  public byVMHandle = new LookupMap<number, Specifier>();
-  public vmHandleBySpecifier = new LookupMap<Specifier, number>();
-}
-
-export interface Mapping {
-  get(key: Opaque): Opaque;
-  set(key: Opaque, value: Opaque): void;
-  forEach(cb: (value: Opaque, key: Opaque) => void): void;
-}
-
-export class LookupMap<K, V> implements Mapping {
-  private pairs: Opaque[];
-  size = 0;
-  constructor() {
-    this.pairs = [];
-  }
-
-  set(key: K, value: V) {
-    let idx = this.pairs.indexOf(key);
-    if (idx === -1) {
-      this.pairs.push(key, value);
-      this.size++;
-    } else {
-      this.pairs[idx + 1] = value;
-    }
-  }
-
-  get(key: K): V | undefined {
-    let idx = this.pairs.indexOf(key);
-    if (idx > -1) {
-      return this.pairs[idx + 1] as V;
-    }
-
-    return undefined;
-  }
-
-  forEach(cb: (value: V, key: K) => void) {
-    for (let i = 0; i < this.pairs.length; i += 2) {
-      let value = this.pairs[i + 1];
-      let key = this.pairs[i];
-      cb(value as V, key as K);
-    }
-  }
+  public byVMHandle = new Map<number, Specifier>();
+  public vmHandleBySpecifier = new Map<Specifier, number>();
 }

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -134,9 +134,7 @@ export default class EagerRenderDelegate implements RenderDelegate {
 
   renderTemplate(template: string, context: Dict<Opaque>, element: HTMLElement): RenderResult {
     let macros = new TestMacros();
-    let delegate: EagerCompilerDelegate = new EagerCompilerDelegate(this.components, this.modules, this.compileTimeModules, specifier => {
-      return compiler.compileSpecifier(specifier);
-    });
+    let delegate: EagerCompilerDelegate = new EagerCompilerDelegate(this.components, this.modules);
     let program = new WriteOnlyProgram(new DebugConstants());
     let compiler = new BundleCompiler(delegate, { macros, program });
 

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -12,7 +12,7 @@ import {
   ElementBuilder,
   Cursor
 } from '@glimmer/runtime';
-import { LookupMap, specifierFor, DebugConstants, BundleCompiler, Specifier } from '@glimmer/bundle-compiler';
+import { specifierFor, DebugConstants, BundleCompiler, Specifier } from '@glimmer/bundle-compiler';
 import { Opaque, assert, Dict, assign, expect, Option } from '@glimmer/util';
 import { WriteOnlyProgram, RuntimeProgram, RuntimeConstants, Heap } from '@glimmer/program';
 import { ProgramSymbolTable, Recast, VMHandle, ComponentCapabilities } from '@glimmer/interfaces';
@@ -71,7 +71,7 @@ export default class EagerRenderDelegate implements RenderDelegate {
   protected modules = new Modules();
   protected compileTimeModules = new Modules();
   protected components: Dict<ComponentDefinition<TestComponentDefinitionState>> = {};
-  protected specifiersToSymbolTable = new LookupMap<Specifier, ProgramSymbolTable>();
+  protected specifiersToSymbolTable = new Map<Specifier, ProgramSymbolTable>();
 
   constructor(env: Environment) {
     this.env = env || new EagerTestEnvironment();

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/runtime-resolver.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/runtime-resolver.ts
@@ -1,5 +1,5 @@
 import { RuntimeResolver, ComponentDefinition, VMHandle, Recast, ProgramSymbolTable } from '@glimmer/interfaces';
-import { Specifier, SpecifierMap, LookupMap } from '@glimmer/bundle-compiler';
+import { Specifier, SpecifierMap } from '@glimmer/bundle-compiler';
 import { Opaque, Option, expect } from '@glimmer/util';
 import { Invocation } from "@glimmer/runtime";
 
@@ -9,7 +9,7 @@ export default class EagerRuntimeResolver implements RuntimeResolver<Specifier> 
   constructor(
     private map: SpecifierMap,
     private modules: Modules,
-    public symbolTables: LookupMap<Specifier, ProgramSymbolTable>
+    public symbolTables: Map<Specifier, ProgramSymbolTable>
   ) {}
 
   lookupHelper(_name: string, _meta: Opaque): Option<number> {


### PR DESCRIPTION
Prior to this change the compiler delegate needed shared state from the BundleCompiler and BundleCompilerLookup to work backwards into a CompilableTemplate. This meant that we had to pass in a `compile` function that closed over the BundleCompiler so that the delegate could compile a specifier. All of this is not neccessary as the lookup can simply pass all the information directly to the delegate, in the event it cannot find a compilable template. By default the delegate can just return an instance of `CompilableTemplate` because everything is now in scope.
ea99e76