### PR TITLE
Fix Memory Leaks

### DIFF
--- a/packages/@glimmer/runtime/test/attributes-test.ts
+++ b/packages/@glimmer/runtime/test/attributes-test.ts
@@ -18,7 +18,7 @@ function compile(template: string) {
 
 function commonSetup() {
   env = new TestEnvironment(); // TODO: Support SimpleDOM
-  root = document.createElement('div');
+  root = document.getElementById('qunit-fixture')!;
   root.setAttribute('debug-root', 'true');
 }
 

--- a/packages/@glimmer/runtime/test/attributes-test.ts
+++ b/packages/@glimmer/runtime/test/attributes-test.ts
@@ -18,7 +18,10 @@ function compile(template: string) {
 
 function commonSetup() {
   env = new TestEnvironment(); // TODO: Support SimpleDOM
-  root = document.getElementById('qunit-fixture')!;
+  let fixture = document.getElementById('qunit-fixture')!;
+  let div = document.createElement('div');
+  fixture.appendChild(div);
+  root = div;
   root.setAttribute('debug-root', 'true');
 }
 

--- a/packages/@glimmer/runtime/test/partial-test.ts
+++ b/packages/@glimmer/runtime/test/partial-test.ts
@@ -23,7 +23,7 @@ function compile(template: string) {
 
 function commonSetup() {
   env = new TestEnvironment();
-  root = document.createElement('div');
+  root = document.getElementById('qunit-fixture')!;
 }
 
 function render(template: Template, context={}) {

--- a/packages/@glimmer/runtime/test/style-warning-test.ts
+++ b/packages/@glimmer/runtime/test/style-warning-test.ts
@@ -14,11 +14,7 @@ function compile(template: string) {
 
 function commonSetup(customEnv = new TestEnvironment()) {
   env = customEnv; // TODO: Support SimpleDOM
-  root = rootElement();
-}
-
-function rootElement(): HTMLDivElement {
-  return env.getDOM().createElement('div') as HTMLDivElement;
+  root = document.getElementById('qunit-fixture')!;
 }
 
 function render(template: Template, self: any) {

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -20,8 +20,7 @@ function compile(template: string) {
 
 function commonSetup() {
   env = new TestEnvironment(); // TODO: Support SimpleDOM
-  root = document.createElement('div');
-  root.setAttribute('debug-root', 'true');
+  root = document.getElementById('qunit-fixture')!;
 }
 
 function assertProperty<T, K extends keyof T, V extends T[K]>(obj: T | null, key: K, value: V): void {

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -66,7 +66,6 @@ const COMPONENT_CAPABILITIES: Entries<ComponentCapabilities> = {
 };
 
 export default class EagerRenderDelegate implements RenderDelegate {
-  static isEager = true; // Used to disable tests where ArrayBuffer is undefined
   protected env: Environment;
   protected modules = new Modules();
   protected compileTimeModules = new Modules();

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
@@ -9,6 +9,8 @@ import RenderDelegate from '../../../render-delegate';
 import { TestDynamicScope } from '../../../environment';
 import { ComponentTypes, ComponentKind, registerComponent, renderTemplate } from '../../../render-test';
 
+declare const module: any;
+
 export default class LazyRenderDelegate implements RenderDelegate {
   constructor(protected env: LazyTestEnvironment = new LazyTestEnvironment()) { }
 
@@ -17,7 +19,11 @@ export default class LazyRenderDelegate implements RenderDelegate {
   }
 
   getInitialElement(): HTMLElement {
-    return this.env.getAppendOperations().createElement('div') as HTMLElement;
+    if (typeof module !== 'undefined' && module.exports) {
+      return this.env.getAppendOperations().createElement('div') as HTMLElement;
+    }
+
+    return document.getElementById('qunit-fixture')!;
   }
 
   registerComponent<K extends ComponentKind, L extends ComponentKind>(type: K, _testType: L, name: string, layout: string, Class?: ComponentTypes[K]) {

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -596,6 +596,7 @@ export class RehydrationDelegate implements RenderDelegate {
   renderTemplate(template: string, context: Dict<Opaque>, element: HTMLElement, snapshot: () => void): RenderResult {
     let serialized = this.renderServerSide(template, context, snapshot);
     element.innerHTML = serialized;
+    document.getElementById('qunit-fixture')!.appendChild(element);
     return this.renderClientSide(template, context, element);
   }
 

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -789,13 +789,14 @@ function componentModule<D extends RenderDelegate, T extends RenderTest>(name: s
     if (skip === true || test.skip === true) {
       shouldSkip = true;
     }
+
     return (type: ComponentKind, klass: RenderTestConstructor<D, T>) => {
-      let instance = new klass(new Delegate());
-      instance['testType'] = type;
       if (!shouldSkip) {
-        QUnit.test(`${type.toLowerCase()}: ${prop}`, assert =>
-          test.call(instance, assert)
-        );
+        QUnit.test(`${type.toLowerCase()}: ${prop}`, assert => {
+          let instance = new klass(new Delegate());
+          instance['testType'] = type;
+          test.call(instance, assert);
+        });
       }
     };
   }

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -877,13 +877,11 @@ function nestedComponentModules(
   Object.keys(tests).forEach(type => {
     let formattedType = `${type[0].toUpperCase() + type.slice(1)}`;
     QUnit.module(`${formattedType}`, () => {
-      tests[
-        type
-      ].forEach(
-        (
-          t: (type: string, klass: typeof RenderTest & Function) => void
-        ) => t(formattedType, klass)
-      );
+      for (let i = tests[type].length - 1; i >= 0; i--) {
+        let t = tests[type][i];
+        t(formattedType, klass);
+        tests[type].pop();
+      }
     });
   });
 }


### PR DESCRIPTION
This fixes the memory leaks that we were running into. While the test suite infra has been stable for a while we have been adding more and more tests which have actually been leaking instances of the test case for each test. It appears that in IE11 we ran into out of memory limits much sooner than the other browsers. Furthermore, this uses the `qunit-fixture` for a large majority of tests as the place we are appending to instead of doing all of the testing in an orphaned element. The only cases where we do not do this is where we are simulating SSR on the client. We should continue to try to move more of the infra to use this pattern.