### PR TITLE
Initial work towards the renderComponent API

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -8,7 +8,8 @@ import {
   Recast,
   SymbolTable,
   VMHandle,
-  ComponentCapabilities
+  ComponentCapabilities,
+  Unique
 } from "@glimmer/interfaces";
 import {
   CompilableTemplate,
@@ -18,12 +19,14 @@ import {
   CompileOptions,
   ICompilableTemplate,
   EagerOpcodeBuilder,
-  TemplateOptions
+  TemplateOptions,
+  SimpleOpcodeBuilder
 } from "@glimmer/opcode-compiler";
 import {
   WriteOnlyProgram,
   WriteOnlyConstants,
-  ConstantPool
+  ConstantPool,
+  SerializedHeap
 } from "@glimmer/program";
 
 import { Specifier } from "./specifiers";
@@ -129,6 +132,10 @@ export class BundleCompiler {
   }
 
   compile() {
+    let builder = new SimpleOpcodeBuilder();
+    builder.main();
+    let main = builder.commit(this.program.heap, 0);
+
     this.compiledBlocks.forEach((_block, specifier) => {
       this.compileSpecifier(specifier);
     });
@@ -136,7 +143,8 @@ export class BundleCompiler {
     let { heap, constants } = this.program;
 
     return {
-      heap: heap.capture(),
+      main: main as Unique<'Handle'>,
+      heap: heap.capture() as SerializedHeap,
       pool: constants.toPool()
     };
   }

--- a/packages/@glimmer/bundle-compiler/lib/specifiers.ts
+++ b/packages/@glimmer/bundle-compiler/lib/specifiers.ts
@@ -47,7 +47,7 @@ const SPECIFIERS = dict<Dict<Specifier>>();
  * @param name the export name (or 'default' for default exports)
  * @returns {Specifier}
  */
-export function specifierFor(module: ModuleName, name: NamedExport): Specifier {
+export function specifierFor(module: ModuleName, name: NamedExport = 'default'): Specifier {
   let specifiers = SPECIFIERS[module];
 
   if (!specifiers) specifiers = SPECIFIERS[module] = dict<Specifier>();

--- a/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
@@ -1,0 +1,155 @@
+import { module, test, EagerTestEnvironment } from "@glimmer/test-helpers";
+import { BundleCompiler, CompilerDelegate, specifierFor, Specifier } from "@glimmer/bundle-compiler";
+import { RuntimeResolver, ComponentCapabilities, Option } from "@glimmer/interfaces";
+import { RuntimeProgram } from "@glimmer/program";
+import { LowLevelVM, NewElementBuilder, ComponentManager, MINIMAL_CAPABILITIES, ARGS, UNDEFINED_REFERENCE, PrimitiveReference } from "@glimmer/runtime";
+import { CONSTANT_TAG, VersionedPathReference, Tag } from "@glimmer/reference";
+import { Destroyable } from "@glimmer/util";
+
+class TestCompilerDelegate implements CompilerDelegate {
+  hasComponentInScope(): boolean {
+    return false;
+  }
+
+  resolveComponentSpecifier(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  getComponentCapabilities(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  getComponentLayout(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  hasHelperInScope(): boolean {
+    return false;
+  }
+
+  resolveHelperSpecifier(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  hasModifierInScope(): boolean {
+    return false;
+  }
+
+  resolveModifierSpecifier(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  hasPartialInScope(): boolean {
+    return false;
+  }
+
+  resolvePartialSpecifier(): never {
+    throw new Error("Method not implemented.");
+  }
+}
+
+class SimpleResolver implements RuntimeResolver<Specifier> {
+  lookupComponent(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  lookupPartial(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  resolve(): never {
+    throw new Error("Method not implemented.");
+  }
+}
+
+class BasicManager implements ComponentManager<null, null> {
+  getCapabilities(): ComponentCapabilities {
+    return MINIMAL_CAPABILITIES;
+  }
+
+  prepareArgs(): never {
+    throw new Error("Method not implemented.");
+  }
+
+  create(): null {
+    return null;
+  }
+
+  getSelf(): VersionedPathReference {
+    return UNDEFINED_REFERENCE;
+  }
+
+  getTag(): Tag {
+    return CONSTANT_TAG;
+  }
+
+  didRenderLayout(): void {
+    return;
+  }
+
+  didCreate(): void {
+    return;
+  }
+
+  update(): void {
+    return;
+  }
+
+  didUpdateLayout(): void {
+    return;
+  }
+
+  didUpdate(): void {
+    return;
+  }
+
+  getDestructor(): Option<Destroyable> {
+    return null;
+  }
+}
+
+export class EntryPointTest {
+  @test "an entry point"() {
+    let compiler = new BundleCompiler(new TestCompilerDelegate());
+
+    let titleSpec = specifierFor('ui/components/Title');
+    let titleBlock = compiler.add(titleSpec, '<h1>{{@title}}</h1>');
+    let { main, heap, pool } = compiler.compile();
+    let map = compiler.getSpecifierMap();
+
+    let env = new EagerTestEnvironment();
+    let program = RuntimeProgram.hydrate(heap, pool, new SimpleResolver());
+
+    let element = document.createElement('div');
+    let builder = NewElementBuilder.forInitialRender(env, { element, nextSibling: null });
+
+    env.begin();
+
+    let vm = LowLevelVM.empty(program, env, builder);
+
+    let title = map.vmHandleBySpecifier.get(titleSpec);
+
+    vm.pushFrame();
+
+    // push three blocks onto the stack; TODO: Optimize
+    for (let i = 0; i <= 9; i++) { vm.stack.push(null); }
+
+    // @title="hello renderComponent"
+    vm.stack.push(PrimitiveReference.create('hello renderComponent'));
+    ARGS.setup(vm.stack, ['@title'], ['main', 'else', 'attrs'], 0, false);
+    vm.stack.push(ARGS);
+
+    // Setup `main()` by pushing an invocation and definition onto the stack
+    vm.stack.push({ handle: title, symbolTable: { hasEval: false, symbols: titleBlock.symbols, referrer: null } });
+    vm.stack.push({ state: null, manager: new BasicManager() });
+
+    // invoke main()
+    vm.execute(main);
+
+    env.commit();
+
+    QUnit.assert.equal(element.innerHTML, '<h1>hello renderComponent</h1>');
+  }
+}
+
+module("[bundle-compiler] entry point", EntryPointTest);

--- a/packages/@glimmer/opcode-compiler/index.ts
+++ b/packages/@glimmer/opcode-compiler/index.ts
@@ -13,7 +13,8 @@ export {
   LazyOpcodeBuilder,
   EagerOpcodeBuilder,
   OpcodeBuilder,
-  OpcodeBuilderConstructor
+  OpcodeBuilderConstructor,
+  SimpleOpcodeBuilder
 } from './lib/opcode-builder';
 
 export {

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -44,7 +44,7 @@ export default class CompilableTemplate<S extends SymbolTable, Specifier> implem
       this.statementCompiler.compile(statements[i], builder);
     }
 
-    let handle = builder.commit(program.heap);
+    let handle = builder.commit(program.heap, containingLayout.block.symbols.length);
 
     if (DEBUG) {
       let { heap } = program;

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -12,7 +12,7 @@ import {
   CompileTimeLazyConstants,
   CompileTimeHeap
 } from "@glimmer/interfaces";
-import { dict, EMPTY_ARRAY, expect, fillNulls, Stack, unreachable } from '@glimmer/util';
+import { dict, EMPTY_ARRAY, expect, Stack, unreachable } from '@glimmer/util';
 import { Op, Register } from '@glimmer/vm';
 import * as WireFormat from '@glimmer/wire-format';
 import { SerializedInlineBlock } from "@glimmer/wire-format";
@@ -97,62 +97,15 @@ export interface OpcodeBuilderConstructor {
       asPartial: boolean): OpcodeBuilder<Specifier>;
 }
 
-export abstract class OpcodeBuilder<Specifier> {
-  public constants: CompileTimeConstants;
-
-  private encoder = new InstructionEncoder([]);
-  private labelsStack = new Stack<Labels>();
-  private isComponentAttrs = false;
-  private expressionCompiler: Compilers<WireFormat.TupleExpression>;
-  public component: ComponentBuilder<Specifier> = new ComponentBuilder(this);
-
-  constructor(
-    public program: CompileTimeProgram,
-    public lookup: CompileTimeLookup<Specifier>,
-    public referrer: Specifier,
-    public macros: Macros,
-    public containingLayout: ParsedLayout,
-    public asPartial: boolean
-  ) {
-    this.constants = program.constants;
-    this.expressionCompiler = expressionCompiler();
-  }
-
-  private get pos(): number {
-    return this.encoder.typePos;
-  }
-
-  private get nextPos(): number {
-    return this.encoder.size;
-  }
-
-  expr(expression: WireFormat.Expression) {
-    if (Array.isArray(expression)) {
-      this.expressionCompiler.compile(expression, this);
-    } else {
-      this.pushPrimitiveReference(expression);
-    }
-  }
-
-  upvars<T extends [Opaque]>(count: number): T {
-    return fillNulls(count) as T;
-  }
-
-  reserve(name: Op, size = 1) {
-    let reservedOperands = [];
-    for (let i = 0; i < size; i++) {
-      reservedOperands[i] = -1;
-    }
-
-    this.push(name, ...reservedOperands);
-  }
+export class SimpleOpcodeBuilder {
+  protected encoder = new InstructionEncoder([]);
 
   push(name: Op, ...ops: number[]) {
     let { encoder } = this;
     encoder.encode(name, ...ops);
   }
 
-  commit(heap: CompileTimeHeap): VMHandle {
+  commit(heap: CompileTimeHeap, scopeSize: number): VMHandle {
     this.push(Op.Return);
 
     let { buffer } = this.encoder;
@@ -164,13 +117,196 @@ export abstract class OpcodeBuilder<Specifier> {
       heap.push(buffer[i]);
     }
 
-    heap.finishMalloc(handle, this.containingLayout.block.symbols.length);
+    heap.finishMalloc(handle, scopeSize);
 
     return handle;
   }
 
+  reserve(name: Op, size = 1) {
+    let reservedOperands = [];
+    for (let i = 0; i < size; i++) {
+      reservedOperands[i] = -1;
+    }
+
+    this.push(name, ...reservedOperands);
+  }
+
+  ///
+
+  main() {
+    this.push(Op.Main, Register.s0);
+    this.invokePreparedComponent(false);
+  }
+
+  dynamicContent(isTrusting: boolean) {
+    this.push(Op.DynamicContent, isTrusting ? 1 : 0);
+  }
+
+  beginComponentTransaction() {
+    this.push(Op.BeginComponentTransaction);
+  }
+
+  commitComponentTransaction() {
+    this.push(Op.CommitComponentTransaction);
+  }
+
+  pushDynamicScope() {
+    this.push(Op.PushDynamicScope);
+  }
+
+  popDynamicScope() {
+    this.push(Op.PopDynamicScope);
+  }
+
+  pushRemoteElement() {
+    this.push(Op.PushRemoteElement);
+  }
+
+  popRemoteElement() {
+    this.push(Op.PopRemoteElement);
+  }
+
+  pushRootScope(symbols: number, bindCallerScope: boolean) {
+    this.push(Op.RootScope, symbols, (bindCallerScope ? 1 : 0));
+  }
+
+  pushChildScope() {
+    this.push(Op.ChildScope);
+  }
+
+  popScope() {
+    this.push(Op.PopScope);
+  }
+
+  prepareArgs(state: Register) {
+    this.push(Op.PrepareArgs, state);
+  }
+
+  createComponent(state: Register, hasDefault: boolean) {
+    let flag = (hasDefault as any) | 0;
+    this.push(Op.CreateComponent, flag, state);
+  }
+
+  registerComponentDestructor(state: Register) {
+    this.push(Op.RegisterComponentDestructor, state);
+  }
+
+  putComponentOperations() {
+    this.push(Op.PutComponentOperations);
+  }
+
+  getComponentSelf(state: Register) {
+    this.push(Op.GetComponentSelf, state);
+  }
+
+  getComponentTagName(state: Register) {
+    this.push(Op.GetComponentTagName, state);
+  }
+
+  getComponentLayout(state: Register) {
+    this.push(Op.GetComponentLayout, state);
+  }
+
+  invokeComponentLayout(state: Register) {
+    this.push(Op.InvokeComponentLayout, state);
+  }
+
+  didCreateElement(state: Register) {
+    this.push(Op.DidCreateElement, state);
+  }
+
+  didRenderLayout(state: Register) {
+    this.push(Op.DidRenderLayout, state);
+  }
+
+  pushFrame() {
+    this.push(Op.PushFrame);
+  }
+
+  popFrame() {
+    this.push(Op.PopFrame);
+  }
+
+  invokeVirtual(): void {
+    this.push(Op.InvokeVirtual);
+  }
+
+  invokeYield(): void {
+    this.push(Op.InvokeYield);
+  }
+
+  toBoolean() {
+    this.push(Op.ToBoolean);
+  }
+
+  invokePreparedComponent(hasBlock: boolean, populateLayout: Option<() => void> = null) {
+    this.beginComponentTransaction();
+    this.pushDynamicScope();
+
+    this.createComponent(Register.s0, hasBlock);
+
+    // this has to run after createComponent to allow
+    // for late-bound layouts, but a caller is free
+    // to populate the layout earlier if it wants to
+    // and do nothing here.
+    if (populateLayout) populateLayout();
+
+    this.registerComponentDestructor(Register.s0);
+
+    this.getComponentSelf(Register.s0);
+
+    this.invokeComponentLayout(Register.s0);
+    this.didRenderLayout(Register.s0);
+    this.popFrame();
+
+    this.popScope();
+    this.popDynamicScope();
+    this.commitComponentTransaction();
+  }
+
+  protected get pos(): number {
+    return this.encoder.typePos;
+  }
+
+  protected get nextPos(): number {
+    return this.encoder.size;
+  }
+}
+
+export abstract class OpcodeBuilder<Specifier> extends SimpleOpcodeBuilder {
+  public constants: CompileTimeConstants;
+
+  private expressionCompiler: Compilers<WireFormat.TupleExpression> = expressionCompiler();
+  private labelsStack = new Stack<Labels>();
+  private isComponentAttrs = false;
+  public component: ComponentBuilder<Specifier> = new ComponentBuilder(this);
+
+  constructor(
+    public program: CompileTimeProgram,
+    public lookup: CompileTimeLookup<Specifier>,
+    public referrer: Specifier,
+    public macros: Macros,
+    public containingLayout: ParsedLayout,
+    public asPartial: boolean
+  ) {
+    super();
+    this.constants = program.constants;
+  }
+
+  label(name: string) {
+    this.labels.label(name, this.nextPos);
+  }
+
   setComponentAttrs(enabled: boolean): void {
     this.isComponentAttrs = enabled;
+  }
+
+  expr(expression: WireFormat.Expression) {
+    if (Array.isArray(expression)) {
+      this.expressionCompiler.compile(expression, this);
+    } else {
+      this.pushPrimitiveReference(expression);
+    }
   }
 
   // args
@@ -205,55 +341,6 @@ export abstract class OpcodeBuilder<Specifier> {
     this.push(Op.PushDynamicComponentManager, this.constants.serializable(referrer));
   }
 
-  prepareArgs(state: Register) {
-    this.push(Op.PrepareArgs, state);
-  }
-
-  createComponent(state: Register, hasDefault: boolean, hasInverse: boolean) {
-    let flag = (hasDefault === true ? 1 : 0) | ((hasInverse === true ? 1 : 0) << 1);
-    this.push(Op.CreateComponent, flag, state);
-  }
-
-  registerComponentDestructor(state: Register) {
-    this.push(Op.RegisterComponentDestructor, state);
-  }
-
-  beginComponentTransaction() {
-    this.push(Op.BeginComponentTransaction);
-  }
-
-  commitComponentTransaction() {
-    this.push(Op.CommitComponentTransaction);
-  }
-
-  putComponentOperations() {
-    this.push(Op.PutComponentOperations);
-  }
-
-  getComponentSelf(state: Register) {
-    this.push(Op.GetComponentSelf, state);
-  }
-
-  getComponentTagName(state: Register) {
-    this.push(Op.GetComponentTagName, state);
-  }
-
-  getComponentLayout(state: Register) {
-    this.push(Op.GetComponentLayout, state);
-  }
-
-  invokeComponentLayout() {
-    this.push(Op.InvokeComponentLayout);
-  }
-
-  didCreateElement(state: Register) {
-    this.push(Op.DidCreateElement, state);
-  }
-
-  didRenderLayout(state: Register) {
-    this.push(Op.DidRenderLayout, state);
-  }
-
   // partial
 
   invokePartial(referrer: Specifier, symbols: string[], evalInfo: number[]) {
@@ -272,12 +359,6 @@ export abstract class OpcodeBuilder<Specifier> {
 
   debugger(symbols: string[], evalInfo: number[]) {
     this.push(Op.Debugger, this.constants.stringArray(symbols), this.constants.array(evalInfo));
-  }
-
-  // content
-
-  dynamicContent(isTrusting: boolean) {
-    this.push(Op.DynamicContent, isTrusting ? 1 : 0);
   }
 
   // dom
@@ -416,41 +497,9 @@ export abstract class OpcodeBuilder<Specifier> {
 
   // vm
 
-  pushRemoteElement() {
-    this.push(Op.PushRemoteElement);
-  }
-
-  popRemoteElement() {
-    this.push(Op.PopRemoteElement);
-  }
-
-  label(name: string) {
-    this.labels.label(name, this.nextPos);
-  }
-
-  pushRootScope(symbols: number, bindCallerScope: boolean) {
-    this.push(Op.RootScope, symbols, (bindCallerScope ? 1 : 0));
-  }
-
-  pushChildScope() {
-    this.push(Op.ChildScope);
-  }
-
-  popScope() {
-    this.push(Op.PopScope);
-  }
-
   returnTo(label: string) {
     this.reserve(Op.ReturnTo);
     this.labels.target(this.pos, Op.ReturnTo, label);
-  }
-
-  pushDynamicScope() {
-    this.push(Op.PushDynamicScope);
-  }
-
-  popDynamicScope() {
-    this.push(Op.PopDynamicScope);
   }
 
   primitive(_primitive: Primitive) {
@@ -533,26 +582,6 @@ export abstract class OpcodeBuilder<Specifier> {
 
   return() {
     this.push(Op.Return);
-  }
-
-  pushFrame() {
-    this.push(Op.PushFrame);
-  }
-
-  popFrame() {
-    this.push(Op.PopFrame);
-  }
-
-  invokeVirtual(): void {
-    this.push(Op.InvokeVirtual);
-  }
-
-  invokeYield(): void {
-    this.push(Op.InvokeYield);
-  }
-
-  toBoolean() {
-    this.push(Op.ToBoolean);
   }
 
   jump(target: string) {
@@ -728,6 +757,10 @@ export abstract class OpcodeBuilder<Specifier> {
     this.popFrame();
   }
 
+  populateLayout(state: number) {
+    this.push(Op.PopulateLayout, state);
+  }
+
   invokeComponent(attrs: Option<CompilableBlock>, params: Option<WireFormat.Core.Params>, hash: WireFormat.Core.Hash, synthetic: boolean, block: Option<CompilableBlock>, inverse: Option<CompilableBlock> = null, layout?: ICompilableTemplate<ProgramSymbolTable>) {
     this.fetch(Register.s0);
     this.dup(Register.sp, 1);
@@ -740,28 +773,17 @@ export abstract class OpcodeBuilder<Specifier> {
     this.compileArgs(params, hash, blocks, synthetic);
     this.prepareArgs(Register.s0);
 
-    this.beginComponentTransaction();
-    this.pushDynamicScope();
-    this.createComponent(Register.s0, block !== null, inverse !== null);
-    this.registerComponentDestructor(Register.s0);
+    this.invokePreparedComponent(block !== null, () => {
+      if (layout) {
+        this.pushSymbolTable(layout.symbolTable);
+        this.pushLayout(layout);
+        this.resolveLayout();
+      } else {
+        this.getComponentLayout(Register.s0);
+      }
 
-    this.getComponentSelf(Register.s0);
-
-    if (layout) {
-      this.pushSymbolTable(layout.symbolTable);
-      this.pushLayout(layout);
-      this.resolveLayout();
-    } else {
-      this.getComponentLayout(Register.s0);
-    }
-
-    this.invokeComponentLayout();
-    this.didRenderLayout(Register.s0);
-    this.popFrame();
-
-    this.popScope();
-    this.popDynamicScope();
-    this.commitComponentTransaction();
+      this.populateLayout(Register.s0);
+    });
 
     this.load(Register.s0);
   }
@@ -791,7 +813,7 @@ export abstract class OpcodeBuilder<Specifier> {
 
     this.beginComponentTransaction();
     this.pushDynamicScope();
-    this.createComponent(Register.s0, block !== null, inverse !== null);
+    this.createComponent(Register.s0, block !== null);
 
     if (capabilities.createArgs) {
       this.popFrame();

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -101,7 +101,7 @@ export class WrappedBuilder<Specifier> implements ICompilableTemplate<ProgramSym
       b.stopLabels();
     }
 
-    let handle = b.commit(options.program.heap);
+    let handle = b.commit(options.program.heap, layout.block.symbols.length);
 
     if (DEBUG) {
       let { program, program: { heap } } = options;

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -53,6 +53,8 @@ export {
 } from './lib/partial';
 
 export {
+  DEFAULT_CAPABILITIES,
+  MINIMAL_CAPABILITIES,
   ComponentManager,
   PublicComponentDefinition as ComponentDefinition,
   WithDynamicTagName,
@@ -69,6 +71,7 @@ export {
 } from './lib/component/curried-component';
 
 export {
+  ARGS
 } from './lib/compiled/opcodes/component';
 
 export {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
@@ -1,5 +1,5 @@
 
-import { Checker, CheckInstanceof, CheckFunction, CheckInterface, CheckOpaque, CheckBlockSymbolTable, wrap } from "@glimmer/debug";
+import { Checker, CheckInstanceof, CheckFunction, CheckInterface, CheckOpaque, CheckBlockSymbolTable, CheckProgramSymbolTable, CheckHandle, wrap } from "@glimmer/debug";
 import { Tag, TagWrapper, VersionedPathReference, Reference } from "@glimmer/reference";
 import { Arguments } from '../../vm/arguments';
 import { ComponentInstance } from './component';
@@ -23,7 +23,10 @@ export const CheckComponentManager: Checker<ComponentManager> =
   CheckInterface({ getCapabilities: CheckFunction });
 
 export const CheckComponentInstance: Checker<ComponentInstance> =
-  CheckInterface({ definition: CheckOpaque, state: CheckOpaque });
+  CheckInterface({ definition: CheckOpaque, state: CheckOpaque, handle: CheckOpaque, table: CheckOpaque });
+
+export const CheckFinishedComponentInstance: Checker<ComponentInstance> =
+  CheckInterface({ definition: CheckOpaque, state: CheckOpaque, handle: CheckHandle, table: CheckProgramSymbolTable });
 
 export const CheckCompilableBlock: Checker<ICompilableTemplate<BlockSymbolTable>> =
   CheckInterface({ compile: CheckFunction, symbolTable: CheckBlockSymbolTable });

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -134,6 +134,15 @@ export const DEFAULT_CAPABILITIES: ComponentCapabilities = {
   elementHook: false
 };
 
+export const MINIMAL_CAPABILITIES: ComponentCapabilities = {
+  dynamicLayout: false,
+  dynamicTag: false,
+  prepareArgs: false,
+  createArgs: false,
+  attributeHook: false,
+  elementHook: false
+};
+
 export type BrandedComponentDefinition = CurriedComponentDefinition;
 export type InternalComponent = ComponentInstanceState;
 export type InternalComponentManager = ComponentManager<ComponentInstanceState, ComponentDefinitionState>;

--- a/packages/@glimmer/test-helpers/index.ts
+++ b/packages/@glimmer/test-helpers/index.ts
@@ -52,5 +52,6 @@ export { NodeLazyRenderDelegate, NodeEagerRenderDelegate } from './lib/environme
 export { default as EagerRenderDelegate } from './lib/environment/modes/eager/render-delegate';
 export { default as LazyRenderDelegate } from './lib/environment/modes/lazy/render-delegate';
 export { debugRehydration } from './lib/environment/modes/rehydration/debug-builder';
+export { default as EagerTestEnvironment } from './lib/environment/modes/eager/environment';
 
 export * from './lib/environment/components';

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -736,11 +736,11 @@ export interface RenderDelegateConstructor<Delegate extends RenderDelegate> {
   new(env?: Environment): Delegate;
 }
 
-export interface RenderTestConstructor<D extends RenderDelegate, T extends RenderTest> {
+export interface RenderTestConstructor<D extends RenderDelegate, T> {
   new(delegate: D): T;
 }
 
-export function module<T extends RenderTest> (
+export function module<T> (
   name: string,
   klass: RenderTestConstructor<RenderDelegate, T>,
   options = { componentModule: false }
@@ -748,7 +748,7 @@ export function module<T extends RenderTest> (
   return rawModule(name, klass, LazyRenderDelegate, options);
 }
 
-export function rawModule<D extends RenderDelegate, T extends RenderTest> (
+export function rawModule<D extends RenderDelegate, T> (
   name: string,
   klass: RenderTestConstructor<D, T>,
   Delegate: RenderDelegateConstructor<D>,
@@ -756,7 +756,7 @@ export function rawModule<D extends RenderDelegate, T extends RenderTest> (
 ): void {
   if (options.componentModule) {
     if (shouldRunTest<D>(Delegate)) {
-      componentModule(name, klass, Delegate);
+      componentModule(name, klass as any as RenderTestConstructor<D, RenderTest>, Delegate);
     }
   } else {
     QUnit.module(`[NEW] ${name}`);

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -363,7 +363,21 @@ OPCODE_METADATA(Op.GetComponentLayout, {
 
 OPCODE_METADATA(Op.InvokeComponentLayout, {
   name: 'InvokeComponentLayout',
-  stackChange: -4
+  stackChange: -2
+});
+
+OPCODE_METADATA(Op.PopulateLayout, {
+  name: 'PopulateLayout',
+  ops: [Register('state')],
+  operands: 1,
+  stackChange: -2
+});
+
+OPCODE_METADATA(Op.Main, {
+  name: 'Main',
+  ops: [Register('state')],
+  operands: 1,
+  stackChange: -2
 });
 
 OPCODE_METADATA(Op.BeginComponentTransaction, {

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -656,6 +656,17 @@ export const enum Op {
    * Operation: Test whether a reference contains a component definition.
    *
    * Format:
+   *   (Main state:register)
+   * Operand Stack:
+   *   ..., Invocation, ComponentDefinition →
+   *   ...
+   */
+  Main,
+
+  /**
+   * Operation: Test whether a reference contains a component definition.
+   *
+   * Format:
    *   (IsComponent)
    * Operand Stack:
    *   ..., VersionedPathReference<Opaque> →
@@ -738,7 +749,7 @@ export const enum Op {
   /**
    * Operation: ...
    * Format:
-   *   (PrepareArgs state:u32)
+   *   (PrepareArgs state:register)
    * Operand Stack:
    *   ... →
    *   ...
@@ -748,7 +759,7 @@ export const enum Op {
   /**
    * Operation: Create the component and push it onto the stack.
    * Format:
-   *   (CreateComponent flags:u32 state:u32)
+   *   (CreateComponent flags:u32 state:register)
    *   ... →
    *   ...
    * Description:
@@ -764,7 +775,7 @@ export const enum Op {
    * Operation: Register a destructor for the current component
    *
    * Format:
-   *   (RegisterComponentDestructor state:u32)
+   *   (RegisterComponentDestructor state:register)
    * Operand Stack:
    *   ... →
    *   ...
@@ -786,7 +797,7 @@ export const enum Op {
    * Operation: Push the component's `self` onto the stack.
    *
    * Format:
-   *   (GetComponentSelf state:u32)
+   *   (GetComponentSelf state:register)
    * Operand Stack:
    *   ... →
    *   ..., VersionedPathReference
@@ -797,7 +808,7 @@ export const enum Op {
    * Operation: Push the component's `self` onto the stack.
    *
    * Format:
-   *   (GetComponentTagName state:u32)
+   *   (GetComponentTagName state:register)
    * Operand Stack:
    *   ... →
    *   ..., Option<string>
@@ -808,7 +819,7 @@ export const enum Op {
    * Operation: Get the component layout from the manager.
    *
    * Format:
-   *   (GetComponentLayout state:u32)
+   *   (GetComponentLayout state:register)
    * Operand Stack:
    *   ... →
    *   ..., ProgramSymbolTable, Handle
@@ -816,12 +827,25 @@ export const enum Op {
   GetComponentLayout,
 
   /**
+   * Operation:
+   *   Populate the state register with the layout currently
+   *   on the stack.
+   *
+   * Format:
+   *   (PopulateLayout state:register)
+   * Operand Stack:
+   *   ..., ProgramSymbolTable, Handle →
+   *   ...
+   */
+  PopulateLayout,
+
+  /**
    * Operation: Invoke the layout returned by the manager.
    *
    * Format:
-   *   (InvokeComponentLayout)
+   *   (InvokeComponentLayout state:register)
    * Operand Stack:
-   *   ..., ProgramSymbolTable, Handle →
+   *   ... →
    *   ...
    */
   InvokeComponentLayout,
@@ -852,7 +876,7 @@ export const enum Op {
    * Operation: Invoke didCreateElement on the current component manager
    *
    * Format:
-   *   (DidCreateElement state:u32)
+   *   (DidCreateElement state:register)
    * Operand Stack:
    *   ... →
    *   ...
@@ -863,7 +887,7 @@ export const enum Op {
    * Operation: Invoke didRenderLayout on the current component manager
    *
    * Format:
-   *   (DidRenderLayout state:u32)
+   *   (DidRenderLayout state:register)
    * Operand Stack:
    *   ..., →
    *   ...


### PR DESCRIPTION
This introduces the initial work to pass args directly to the top level component. While this implementation is somewhat crude, it exposes all of the primitives need to synthetically create args for the the top level component. For example in Glimmer.js the user facing API for this would be:

```
renderComponent('MyApp', document.body, { name: 'Chad' });
```

Internally we would synthetically turn `{ name: 'Chad' }` into args and thus virtualize the invocation like so:

```
<MyApp @name="Chad" />
```

In the layout you could then refer to the name argument as `@name`.