### PR TITLE
Move In-Element Specific Transform Into Visitor

### DIFF
--- a/packages/@glimmer/bundle-compiler/test/in-element-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/in-element-test.ts
@@ -1,3 +1,14 @@
-import { rawModule, EagerRenderDelegate, InElementSuite } from "@glimmer/test-helpers";
+import { rawModule, EagerRenderDelegate, InElementSuite, test } from "@glimmer/test-helpers";
 
-rawModule('[Bundle Compiler] In-Element Tests', InElementSuite, EagerRenderDelegate);
+class BundleCompiledInElement extends InElementSuite {
+  @test
+  "Top level in-element components"() {
+    this.registerComponent('Glimmer', 'A', '{{#in-element @element}}Hello{{/in-element}}');
+    let element = document.createElement('div');
+    this.render('<A @element={{element}} />', { element });
+    this.assertHTML('<!---->');
+    this.assert.equal('Hello', element.textContent);
+  }
+}
+
+rawModule('[Bundle Compiler] In-Element Tests', BundleCompiledInElement, EagerRenderDelegate);

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -16,7 +16,8 @@ import {
   blockStack,
   ComponentBlueprint,
   GLIMMER_TEST_COMPONENT,
-  assertEmberishElement
+  assertEmberishElement,
+  assertSerializedInElement
 } from "@glimmer/test-helpers";
 import { expect } from "@glimmer/util";
 
@@ -145,10 +146,13 @@ class Rehydration extends AbstractRehydrationTests {
 
     this.renderServerSide(template, { remote });
     let serializedRemote = this.delegate.serialize(remote);
-    this.assert.equal(serializedRemote, strip`
-      <script glmr="%cursor:0%"></script>
-      <!--%+block:2%--><inner>Wat Wat</inner><!--%-block:2%-->
+    let b = blockStack();
+    assertSerializedInElement(serializedRemote, strip`
+      ${b(2)}
+      <inner>Wat Wat</inner>
+      ${b(2)}
     `);
+
     env = this.delegate.clientEnv;
     let clientRemote = remote = env.getDOM().createElement('remote') as HTMLElement;
     let host = env.getDOM().createElement('div') as HTMLElement;
@@ -178,16 +182,14 @@ class Rehydration extends AbstractRehydrationTests {
     let serializedParentRemote = this.delegate.serialize(remoteParent);
     let serializedRemoteChild = this.delegate.serialize(remoteChild);
     let b = blockStack();
-    this.assert.equal(serializedParentRemote, strip`
-      <script glmr="%cursor:0%"></script>
+    assertSerializedInElement(serializedParentRemote, strip`
       ${b(2)}
         <inner>
           ${b(3)}<!---->${b(3)}
         </inner>
       ${b(2)}
     `, 'Serialized parent remote');
-    this.assert.equal(serializedRemoteChild, strip`
-      <script glmr="%cursor:1%"></script>
+    assertSerializedInElement(serializedRemoteChild, strip`
       ${b(4)}Wat Wat${b(4)}
     `, 'Serilaized nested remote');
     env = this.delegate.clientEnv;

--- a/packages/@glimmer/test-helpers/index.ts
+++ b/packages/@glimmer/test-helpers/index.ts
@@ -14,7 +14,8 @@ export {
   strip,
   stripTight,
   trimLines,
-  blockStack
+  blockStack,
+  assertSerializedInElement
 } from './lib/helpers';
 
 export {

--- a/packages/@glimmer/test-helpers/lib/helpers.ts
+++ b/packages/@glimmer/test-helpers/lib/helpers.ts
@@ -271,6 +271,18 @@ export function assertNodeProperty<T extends keyof ElementTagNameMap, P extends 
   }
 }
 
+export function assertSerializedInElement(result: string, expected: string, message?: string) {
+  let matched = result.match(/<script glmr="%cursor:[0-9]*.%"><\/script>/);
+
+  if (matched) {
+    QUnit.assert.ok(true, `has cursor ${matched[0]}`);
+    let [, trimmed] = result.split(matched![0]);
+    QUnit.assert.equal(trimmed, expected, message);
+  } else {
+    QUnit.assert.ok(false, `does not have a cursor`);
+  }
+}
+
 export function blockStack() {
   let stack: number[] = [];
 


### PR DESCRIPTION
Instead of relying on a plugin to add the `guid` to each `in-element` we should just bake this into the visitor.