### PR TITLE
Initialize v0 register

### DIFF
--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -87,7 +87,7 @@ export class AppendOpcodes {
 
     if (DEBUG) {
       /* tslint:disable */
-      console.log('%c -> pc: %d, ra: %d, fp: %d, sp: %d, s0: %O, s1: %O, t0: %O, t1: %O', 'color: orange', vm['pc'], vm['ra'], vm['fp'], vm['sp'], vm['s0'], vm['s1'], vm['t0'], vm['t1']);
+      console.log('%c -> pc: %d, ra: %d, fp: %d, sp: %d, s0: %O, s1: %O, t0: %O, t1: %O, v0: %O', 'color: orange', vm['pc'], vm['ra'], vm['fp'], vm['sp'], vm['s0'], vm['s1'], vm['t0'], vm['t1'], vm['v0']);
       console.log('%c -> eval stack', 'color: red', vm.stack.toArray());
       console.log('%c -> scope', 'color: green', vm.scope()['slots'].map(s => s && s['value'] ? s['value']() : s));
       console.log('%c -> elements', 'color: blue', vm.elements()['cursorStack']['stack'].map((c: any) => c.element));

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -141,6 +141,7 @@ export default class VM<Specifier> implements PublicVM {
   public s1: any = null;
   public t0: any = null;
   public t1: any = null;
+  public v0: any = null;
 
   // Fetch a value from a register onto the stack
   fetch(register: Register) {


### PR DESCRIPTION
We introduced a v0 register but did not initialize it to null in the VM. We also did not include it in the debug logging. This obfuscated cases where the register started as undefined and later incorrectly became undefined due to a programming error. This change makes it more obvious when the register switches from uninitialized to an incorrect undefined value.