### PR TITLE
Fix path lookup inside helpers

### DIFF
--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -268,10 +268,10 @@ export default class TemplateCompiler {
 
       if (expr.this) {
         this.opcode('get', expr, 0, expr.parts);
-      } else  if (symbols.has(head)) {
+      } else if (symbols.has(head)) {
         this.opcode('get', expr, symbols.get(head), expr.parts.slice(1));
       } else {
-        this.opcode('get', expr, 0, expr.parts);
+        this.opcode('maybeLocal',expr, expr.parts);
       }
     }
   }

--- a/packages/@glimmer/runtime/test/partial-test.ts
+++ b/packages/@glimmer/runtime/test/partial-test.ts
@@ -463,6 +463,19 @@ QUnit.test('dynamic partial with local reference (unknown)', () => {
   equalTokens(root, `You smaht. You loyal. `);
 });
 
+QUnit.test('partial with if statement on a local reference works as expected', () => {
+  let template = compile(`{{#each qualities key='@index' as |quality|}}{{partial name}}. {{/each}}`);
+
+  env.registerPartial('test', `{{#if quality}}You {{quality}}{{else}}No quality{{/if}}`);
+  render(template, { name: 'test', qualities: ['smaht', 'loyal', undefined] });
+
+  rerender(null, { assertStable: true });
+
+  equalTokens(root, `You smaht. You loyal. No quality. `);
+  rerender({ name: 'test', qualities: ['smaht', 'loyal', undefined] }, { assertStable: true });
+  equalTokens(root, `You smaht. You loyal. No quality. `);
+});
+
 QUnit.test('partial without arguments throws', assert => {
   assert.throws(function() {
     compile(`Before {{partial}} After`);

--- a/packages/@glimmer/runtime/test/partial-test.ts
+++ b/packages/@glimmer/runtime/test/partial-test.ts
@@ -463,7 +463,7 @@ QUnit.test('dynamic partial with local reference (unknown)', () => {
   equalTokens(root, `You smaht. You loyal. `);
 });
 
-QUnit.test('partial with if statement on a local reference works as expected', () => {
+QUnit.test('partial with if statement on a simple local reference works as expected', () => {
   let template = compile(`{{#each qualities key='@index' as |quality|}}{{partial name}}. {{/each}}`);
 
   env.registerPartial('test', `{{#if quality}}You {{quality}}{{else}}No quality{{/if}}`);
@@ -473,6 +473,19 @@ QUnit.test('partial with if statement on a local reference works as expected', (
 
   equalTokens(root, `You smaht. You loyal. No quality. `);
   rerender({ name: 'test', qualities: ['smaht', 'loyal', undefined] }, { assertStable: true });
+  equalTokens(root, `You smaht. You loyal. No quality. `);
+});
+
+QUnit.test('partial with if statement on a path local reference works as expected', () => {
+  let template = compile(`{{#each qualities key='@index' as |quality|}}{{partial name}}. {{/each}}`);
+
+  env.registerPartial('test', `{{#if quality.name}}You {{quality.name}}{{else}}No quality{{/if}}`);
+  render(template, { name: 'test', qualities: [{ name: 'smaht' }, { name: 'loyal' }, { name: undefined }] });
+
+  rerender(null, { assertStable: true });
+
+  equalTokens(root, `You smaht. You loyal. No quality. `);
+  rerender({ name: 'test', qualities: [{ name: 'smaht' }, { name: 'loyal' }, { name: undefined }] }, { assertStable: true });
   equalTokens(root, `You smaht. You loyal. No quality. `);
 });
 


### PR DESCRIPTION
Fixes #705 

MustacheExpressions generate a `get` opcode in cases where the identifier is statically found in their scope, but fall back to `maybeLocal` otherwise to disambiguate at compile time whether they are being invoked inside a partial or not.

PathExpressions however did not go through this path, always using a `get` opcode even in cases that were ambiguous. This caused any PathExpression inside a partial to fail when inheriting an identifier from the outside scope.

This PR changes the PathExpression compiler to generate a `maybeLocal` opcode in the ambiguous case instead of a `get`.