### PR TITLE
Document capabilities

### DIFF
--- a/packages/@glimmer/interfaces/lib/component-capabilities.d.ts
+++ b/packages/@glimmer/interfaces/lib/component-capabilities.d.ts
@@ -1,5 +1,4 @@
 export default interface ComponentCapabilities {
-  staticDefinitions: boolean;
   dynamicLayout: boolean;
   dynamicTag: boolean;
   prepareArgs: boolean;

--- a/packages/@glimmer/interfaces/lib/component-capabilities.d.ts
+++ b/packages/@glimmer/interfaces/lib/component-capabilities.d.ts
@@ -1,8 +1,59 @@
+/**
+ * Describes the capabilities of a particular component. The capabilities are
+ * provided to the Glimmer compiler and VM via the ComponentDefinition, which
+ * includes a ComponentCapabilities record.
+ *
+ * Certain features in the VM come with some overhead, so the compiler and
+ * runtime use this information to skip unnecessary work for component types
+ * that don't need it.
+ *
+ * For example, a component that is template-only (i.e., it does not have an
+ * associated JavaScript class to instantiate) can skip invoking component
+ * manager hooks related to lifecycle events by setting the `elementHook`
+ * capability to `false`.
+ */
 export default interface ComponentCapabilities {
+  /**
+   * Whether a component's template is static across all instances of that
+   * component, or can vary per instance. This should usually be `false` except
+   * for cases of backwards-compatibility.
+   */
   dynamicLayout: boolean;
+
+  /**
+   * Whether a "wrapped" component's root element can change after being
+   * rendered. This flag is only used by the WrappedBuilder and should be
+   * `false` except for cases of backwards-compatibility.
+   */
   dynamicTag: boolean;
+
+  /**
+   * Setting the `prepareArgs` flag to true enables the `prepareArgs` hook on
+   * the component manager, which would otherwise not be called.
+   *
+   * The component manager's `prepareArgs` hook allows it to programmatically
+   * add or remove positional and named arguments for a component before the
+   * component is invoked. This flag should usually be `false` except for cases
+   * of backwards-compatibility.
+   */
   prepareArgs: boolean;
+
+  /**
+   * Whether a reified `Arguments` object will get passed to the component
+   * manager's `create` hook. If a particular component does not access passed
+   * arguments from JavaScript (via the `this.args` property in Glimmer.js, for
+   * example), this flag can be set to `false` to avoid the work of
+   * instantiating extra data structures to expose the arguments to JavaScript.
+   */
   createArgs: boolean;
+
+  /**
+   * Whether to call the `didSplatAttributes` hook on the component manager.
+   */
   attributeHook: boolean;
+
+  /**
+   * Whether to call the `didCreateElement` hook on the component manager.
+   */
   elementHook: boolean;
 }

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -125,17 +125,7 @@ export function hasDynamicLayout<D extends ComponentDefinitionState, I extends C
   return manager.getCapabilities(state).dynamicLayout === true;
 }
 
-export interface WithStaticDefinitions<ComponentDefinition> extends ComponentManager<Opaque, ComponentDefinition> {
-  getComponentDefinition(definition: ComponentDefinition, handle: VMHandle): ComponentDefinition;
-}
-
-/** @internal */
-export function hasStaticDefinitions<D extends ComponentDefinitionState>(state: D, manager: ComponentManager<Opaque, D>): manager is WithStaticDefinitions<D> {
-  return manager.getCapabilities(state).staticDefinitions === true;
-}
-
 export const DEFAULT_CAPABILITIES: ComponentCapabilities = {
-  staticDefinitions: false,
   dynamicLayout: true,
   dynamicTag: true,
   prepareArgs: true,

--- a/packages/@glimmer/test-helpers/lib/environment/components/basic.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/basic.ts
@@ -22,7 +22,6 @@ export interface BasicComponentFactory {
 }
 
 export const BASIC_CAPABILITIES: ComponentCapabilities = {
-  staticDefinitions: true,
   dynamicLayout: false,
   dynamicTag: false,
   prepareArgs: false,

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
@@ -54,7 +54,6 @@ export interface EmberishCurlyComponentFactory {
 }
 
 export const CURLY_CAPABILITIES: ComponentCapabilities = {
-  staticDefinitions: false,
   dynamicLayout: true,
   dynamicTag: true,
   prepareArgs: true,
@@ -63,9 +62,8 @@ export const CURLY_CAPABILITIES: ComponentCapabilities = {
   elementHook: true
 };
 
-export const EMBERISH_CURLY_CAPABILITIES = {
+export const EMBERISH_CURLY_CAPABILITIES: ComponentCapabilities = {
   ...CURLY_CAPABILITIES,
-  staticDefinitions: true,
   dynamicLayout: false,
   attributeHook: false
 };

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-glimmer.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-glimmer.ts
@@ -16,7 +16,6 @@ import EagerRuntimeResolver from '../modes/eager/runtime-resolver';
 
 export const EMBERISH_GLIMMER_CAPABILITIES = {
   ...BASIC_CAPABILITIES,
-  staticDefinitions: false,
   dynamicTag: true,
   createArgs: true,
   attributeHook: true

--- a/packages/@glimmer/test-helpers/lib/environment/components/tagless.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/tagless.ts
@@ -9,7 +9,6 @@ import LazyRuntimeResolver from '../modes/lazy/runtime-resolver';
 import { TestComponentDefinitionState } from '../components';
 
 export const STATIC_TAGLESS_CAPABILITIES = {
-  staticDefinitions: false,
   dynamicLayout: false,
   dynamicTag: false,
   prepareArgs: false,
@@ -24,14 +23,14 @@ export class StaticTaglessComponentManager extends BasicComponentManager {
   }
 
   getLayout(state: TestComponentDefinitionState, resolver: LazyRuntimeResolver): Invocation {
-    let { name } = state;
+    let { name, capabilities } = state;
 
     let handle = resolver.lookup('template-source', name)!;
 
     return resolver.compileTemplate(handle, name, (source, options) => {
       let template = createTemplate(source, {});
       let compileOptions = assign({}, options, { asPartial: false, referrer: null });
-      let builder = new WrappedBuilder(compileOptions, template, STATIC_TAGLESS_CAPABILITIES);
+      let builder = new WrappedBuilder(compileOptions, template, capabilities);
 
       return {
         handle: builder.compile(),


### PR DESCRIPTION
This PR adds inline comments to the ComponentCapabilities interface to explain each flag. It also removes the `staticDefinitions` capability that appears to no longer be used.