### PR TITLE
fix(bundle-compiler): Properly cache compileOptions

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -17,7 +17,8 @@ import {
   CompileTimeLookup,
   CompileOptions,
   ICompilableTemplate,
-  EagerOpcodeBuilder
+  EagerOpcodeBuilder,
+  TemplateOptions
 } from "@glimmer/opcode-compiler";
 import {
   WriteOnlyProgram,
@@ -93,7 +94,7 @@ export class BundleCompiler {
   protected Builder: OpcodeBuilderConstructor;
   protected plugins: ASTPluginBuilder[];
   private program: WriteOnlyProgram;
-  private _compileOptions: CompileOptions<Specifier>;
+  private _templateOptions: TemplateOptions<Specifier>;
 
   private specifiers = new SpecifierMap();
   public compiledBlocks = new Map<Specifier, AddedTemplate>();
@@ -141,19 +142,19 @@ export class BundleCompiler {
   }
 
   compileOptions(specifier: Specifier, asPartial = false): CompileOptions<Specifier> {
-    if (this._compileOptions) { return this._compileOptions; }
+    let templateOptions = this._templateOptions;
+    if (!templateOptions) {
+      let { program, macros, Builder } = this;
+      let lookup = new BundlingLookup(this.delegate, this.specifiers, this);
+      templateOptions = this._templateOptions = {
+        program,
+        macros,
+        Builder,
+        lookup
+      };
+    }
 
-    let { program, macros, Builder } = this;
-    let lookup = new BundlingLookup(this.delegate, this.specifiers, this);
-
-    return this._compileOptions = {
-      program,
-      macros,
-      Builder,
-      lookup,
-      asPartial,
-      referrer: specifier
-    };
+    return { ...templateOptions, asPartial, referrer: specifier };
   }
 
   compileSpecifier(specifier: Specifier): VMHandle {

--- a/packages/@glimmer/bundle-compiler/test/compiler-delegate-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/compiler-delegate-test.ts
@@ -1,0 +1,54 @@
+import { BundleCompiler, Specifier, specifierFor } from '@glimmer/bundle-compiler';
+import { ComponentCapabilities, ProgramSymbolTable } from '@glimmer/interfaces';
+import { BASIC_CAPABILITIES } from '@glimmer/test-helpers';
+import { CompilableTemplate, CompileOptions, ICompilableTemplate } from '@glimmer/opcode-compiler';
+import { SerializedTemplateBlock } from '@glimmer/wire-format';
+
+const { test } = QUnit;
+
+QUnit.module("[glimmer-bundle-compiler] CompilerDelegate");
+
+test("correct referrer is passed during component lookup", function(assert) {
+  let inScopeReferrers: Specifier[] = [];
+  let resolveComponentReferrers: Specifier[] = [];
+
+  // This partial implementation of CompilerDelegate tracks what referrers are
+  // passed to hasComponentInScope and resolveComponentSpecifier so that they
+  // can be verified after compilation has finished.
+  class TestDelegate {
+    hasComponentInScope(_componentName: string, referrer: Specifier): boolean {
+      inScopeReferrers.push(referrer);
+      return true;
+    }
+
+    resolveComponentSpecifier(componentName: string, referrer: Specifier): Specifier {
+      resolveComponentReferrers.push(referrer);
+      return specifierFor(componentName, 'default');
+    }
+
+    getComponentCapabilities(): ComponentCapabilities {
+      return BASIC_CAPABILITIES;
+    }
+
+    getComponentLayout(_specifier: Specifier, block: SerializedTemplateBlock, options: CompileOptions<Specifier>): ICompilableTemplate<ProgramSymbolTable> {
+      return CompilableTemplate.topLevel(block, options);
+    }
+  }
+
+  let bundleCompiler = new BundleCompiler(new TestDelegate() as any);
+
+  bundleCompiler.add(specifierFor('UserNav', 'default'), '<div class="user-nav"></div>');
+  bundleCompiler.add(specifierFor('Main', 'default'), '<UserNav />');
+  bundleCompiler.add(specifierFor('SideBar', 'default'), '<UserNav />');
+  bundleCompiler.compile();
+
+  assert.deepEqual(inScopeReferrers, [
+    { module: 'Main', name: 'default' },
+    { module: 'SideBar', name: 'default' }
+  ]);
+
+  assert.deepEqual(resolveComponentReferrers, [
+    { module: 'Main', name: 'default' },
+    { module: 'SideBar', name: 'default' }
+  ]);
+});


### PR DESCRIPTION
The compileOptions object gets passed around to compilable templates and includes relatively-expensive-to-construct objects like BundlingLookup. To avoid doing lots of repeat work, this object was being cached after the first time it was created.

Unfortunately, this object is not cacheable because variants need to be produced for each specifier/asPartial combination. This lead to a bug where the same referrer was always passed to component delegate methods (it was always the first template to be added).

This commit changes the caching strategy to cache a base "template options" object that contains the expensive objects, which gets used to initialize a new, lightweight CompileOptions object tailored to the requested specifier and asPartial setting.