### PR TITLE
[BUGFIX] Don't continuously recompile the layout

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -211,7 +211,11 @@ class BundlingLookup implements CompileTimeLookup<Specifier> {
 
     expect(block, 'Should have a SerializedTemplateBlock');
 
-    return this.delegate.getComponentLayout(specifier, block!, this.compiler.compileOptions(specifier));
+    block = this.delegate.getComponentLayout(specifier, block!, this.compiler.compileOptions(specifier));
+
+    this.compiler.compiledBlocks.set(specifier, block);
+
+    return block;
   }
 
   lookupHelper(name: string, referrer: Specifier): Option<number> {


### PR DESCRIPTION
Prior to this fix we were compiling the layout and returning which meant
the next time we see an invoke we wouldn't just compile the args, but also
compile the layout despite the compilation beind exactly the same e.g.
templates are a pure function.