### PR TITLE
[BUGFIX] Fix Frozen Args When Currying

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -373,6 +373,10 @@ export class NamedArguments implements INamedArguments {
       let { names, length, stack } = this;
       let { names: extraNames } = other;
 
+      if (Object.isFrozen(names) && names.length === 0) {
+        names = [];
+      }
+
       for (let i = 0; i < extras; i++) {
         let name = extraNames[i];
         let idx = names.indexOf(name);

--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -16,6 +16,22 @@ export class EmberishComponentTests extends RenderTest {
   }
 
   @test({ kind: 'glimmer' })
+  "[BUG] Gracefully handles application of curried args when invoke starts with 0 args"() {
+    class MainComponent extends EmberishGlimmerComponent {
+      salutation = 'Glimmer';
+    }
+    this.registerComponent('Glimmer', 'Main', '<div><HelloWorld @a={{@a}} as |wat|>{{wat}}</HelloWorld></div>', MainComponent);
+    this.registerComponent('Glimmer', 'HelloWorld', '{{yield (component "A" a=@a)}}');
+    this.registerComponent('Glimmer', 'A', 'A {{@a}}');
+    this.render('<Main @a={{a}} />', { a: 'a' });
+    this.assertHTML('<div>A a</div>');
+    this.assertStableRerender();
+    this.rerender({a: 'A' });
+    this.assertHTML('<div>A A</div>');
+    this.assertStableNodes();
+  }
+
+  @test({ kind: 'glimmer' })
   "top level in-element"() {
     this.registerComponent('Glimmer', 'Foo', '<Bar data-bar={{@childName}} @data={{@data}} />');
     this.registerComponent('Glimmer', 'Bar', '<div ...attributes>Hello World</div>');


### PR DESCRIPTION
In #712 we placed a "WELL_KNOWN_EMPTY_ARRAY" into the constants pool to canonicalize
the empty arrays. This allowed us to reduce the number of empty arrays to 1. That being
said it appears we were relying on the mutability of these empty arrays in the constant
pool. This is because an ambigous invocation will start out with 0 args but could have
been yielded with pre-loaded args. We don't have the introspection (today) to realize
this has occured. To fix this when we realize this at runtime we should be able to swap
back in a mutable array when we discover there are more args for the invoke.

Fixes https://github.com/glimmerjs/glimmer.js/issues/40.