### PR TITLE
[WIP] U32 stack

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -212,14 +212,11 @@ export default class BundleCompiler<TemplateMeta> {
    * Performs the actual compilation of the template identified by the passed
    * locator into the Program. Returns the VM handle for the compiled template.
    */
-  protected compileTemplate(locator: ModuleLocator): VMHandle {
+  protected compileTemplate(locator: ModuleLocator): number {
     // If this locator already has an assigned VM handle, it means we've already
     // compiled it. We need to skip compiling it again and just return the same
     // VM handle.
-    let vmHandle = this.table.vmHandleByModuleLocator.get(locator) as Recast<
-      number,
-      VMHandle
-    >;
+    let vmHandle = this.table.vmHandleByModuleLocator.get(locator);
     if (vmHandle) return vmHandle;
 
     // It's an error to try to compile a template that wasn't first added to the

--- a/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
@@ -1,6 +1,6 @@
 import { module, test, EagerTestEnvironment } from "@glimmer/test-helpers";
 import { BundleCompiler, CompilerDelegate } from "@glimmer/bundle-compiler";
-import { RuntimeResolver, ComponentCapabilities, Option, VMHandle, Recast } from "@glimmer/interfaces";
+import { RuntimeResolver, ComponentCapabilities, Option } from "@glimmer/interfaces";
 import { RuntimeProgram } from "@glimmer/program";
 import { LowLevelVM, NewElementBuilder, ComponentManager, MINIMAL_CAPABILITIES, ARGS, UNDEFINED_REFERENCE, PrimitiveReference } from "@glimmer/runtime";
 import { CONSTANT_TAG, VersionedPathReference, Tag } from "@glimmer/reference";
@@ -143,7 +143,7 @@ export class EntryPointTest {
     vm.stack.push({ state: null, manager: new BasicManager() });
 
     // invoke main()
-    vm.execute(main as Recast<number, VMHandle>);
+    vm.execute(main);
 
     env.commit();
 

--- a/packages/@glimmer/debug/lib/stack-check.ts
+++ b/packages/@glimmer/debug/lib/stack-check.ts
@@ -1,4 +1,4 @@
-import { Opaque, Option, Dict, BlockSymbolTable, ProgramSymbolTable, Simple, VMHandle } from "@glimmer/interfaces";
+import { Opaque, Option, Dict, BlockSymbolTable, ProgramSymbolTable, Simple } from "@glimmer/interfaces";
 
 export interface Checker<T> {
   type: T;
@@ -214,7 +214,7 @@ export const CheckPrimitive: Checker<Primitive> = new PrimitiveChecker();
 export const CheckFunction: Checker<Function> = new TypeofChecker<Function>('function');
 export const CheckNumber: Checker<number> = new TypeofChecker<number>('number');
 export const CheckBoolean: Checker<boolean> = new TypeofChecker<boolean>('boolean');
-export const CheckHandle: Checker<VMHandle> = CheckNumber as any as Checker<VMHandle>;
+export const CheckHandle: Checker<number> = CheckNumber;
 export const CheckString: Checker<string> = new TypeofChecker<string>('string');
 export const CheckOpaque: Checker<Opaque> = new OpaqueChecker();
 

--- a/packages/@glimmer/encoder/lib/encoder.ts
+++ b/packages/@glimmer/encoder/lib/encoder.ts
@@ -5,6 +5,7 @@ const MAX_SIZE                = 0b1111111111111111;
 export const TYPE_SIZE        = 0b11111111;
 export const TYPE_MASK        = 0b0000000011111111;
 export const OPERAND_LEN_MASK = 0b0000001100000000;
+export const MACHINE_MASK     = 0b0000010000000000;
 
 export type Operand = number | (() => number);
 
@@ -12,12 +13,12 @@ export class InstructionEncoder {
   constructor(public buffer: Operand[]) {}
   typePos = 0;
   size = 0;
-  encode(type: Op, ...operands: Operand[]) {
+  encode(type: Op, machine: 0 | typeof MACHINE_MASK, ...operands: Operand[]) {
     if (type > TYPE_SIZE) {
       throw new Error(`Opcode type over 8-bits. Got ${type}.`);
     }
 
-    this.buffer.push((type | (operands.length << ARG_SHIFT)));
+    this.buffer.push((type | machine | (operands.length << ARG_SHIFT)));
 
     this.typePos = this.buffer.length - 1;
 

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -8,6 +8,7 @@ export interface Opcode {
   op2: number;
   op3: number;
   size: number;
+  isMachine: number;
 }
 
 export type VMHandle = Unique<"Handle">;

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -16,12 +16,12 @@ export type VMHandle = Unique<"Handle">;
 export interface CompileTimeHeap {
   push(name: /* TODO: Op */ number, op1?: number, op2?: number, op3?: number): void;
   pushPlaceholder(valueFunc: () => number): void;
-  malloc(): VMHandle;
-  finishMalloc(handle: VMHandle, scopeSize: number): void;
+  malloc(): number;
+  finishMalloc(handle: number, scopeSize: number): void;
 
   // for debugging
-  getaddr(handle: VMHandle): number;
-  sizeof(handle: VMHandle): number;
+  getaddr(handle: number): number;
+  sizeof(handle: number): number;
 }
 
 export interface CompileTimeProgram {

--- a/packages/@glimmer/low-level/index.ts
+++ b/packages/@glimmer/low-level/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/glue/storage';
+export * from './lib/asm/stack';

--- a/packages/@glimmer/low-level/index.ts
+++ b/packages/@glimmer/low-level/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/glue/storage';

--- a/packages/@glimmer/low-level/lib/asm/stack.ts
+++ b/packages/@glimmer/low-level/lib/asm/stack.ts
@@ -1,0 +1,77 @@
+export type u64 = number;
+export type u32 = number;
+export type i32 = number;
+
+export class Stack {
+  constructor(private vec: u64[] = []) {}
+
+  clone(): Stack {
+    return new Stack(this.vec.slice());
+  }
+
+  sliceFrom(start: u32): Stack {
+    return new Stack(this.vec.slice(start));
+  }
+
+  slice(start: u32, end: i32): Stack {
+    return new Stack(this.vec.slice(start, end));
+  }
+
+  copy(from: u32, to: u32) {
+    this.vec[to] = this.vec[from];
+  }
+
+  // TODO: how to model u64 argument?
+  writeRaw(pos: u32, value: u64): void {
+    // TODO: Grow?
+    this.vec[pos] = value;
+  }
+
+  writeSmi(pos: u32, value: i32): void {
+    this.vec[pos] = encodeSmi(value);
+  }
+
+  // TODO: partially decoded enum?
+  getRaw(pos: u32): u32 {
+    return this.vec[pos];
+  }
+
+  getSmi(pos: u32): i32 {
+    return decodeSmi(this.vec[pos]);
+  }
+
+  reset(): void {
+    this.vec.length = 0;
+  }
+
+  len(): number {
+    return this.vec.length;
+  }
+}
+
+export const enum PrimitiveType {
+  NUMBER          = 0b000,
+  FLOAT           = 0b001,
+  STRING          = 0b010,
+  BOOLEAN_OR_VOID = 0b011,
+  NEGATIVE        = 0b100
+}
+
+function decodeSmi(smi: number): number {
+  switch (smi & 0b111) {
+    case PrimitiveType.NUMBER:
+      return smi >> 3;
+    case PrimitiveType.NEGATIVE:
+      return -(smi >> 3);
+    default:
+      throw new Error('unreachable');
+  }
+}
+
+function encodeSmi(primitive: number) {
+  if (primitive < 0) {
+    return Math.abs(primitive) << 3 | PrimitiveType.NEGATIVE;
+  } else {
+    return primitive << 3 | PrimitiveType.NUMBER;
+  }
+}

--- a/packages/@glimmer/low-level/lib/glue/storage.ts
+++ b/packages/@glimmer/low-level/lib/glue/storage.ts
@@ -1,0 +1,29 @@
+export type Opaque = {} | null | undefined;
+
+export class Storage {
+  private readonly array: Opaque[] = [];
+  private next = 0;
+
+  add(element: Opaque): number {
+    let { next: slot, array } = this;
+
+    if (slot === array.length) {
+      this.next++;
+    } else {
+      let prev = array[slot] as number;
+      this.next = prev;
+    }
+
+    this.array[slot] = element;
+    return slot;
+  }
+
+  deref(pointer: number): Opaque {
+    return this.array[pointer];
+  }
+
+  drop(pointer: number): void {
+    this.array[pointer] = this.next;
+    this.next = pointer;
+  }
+}

--- a/packages/@glimmer/low-level/package.json
+++ b/packages/@glimmer/low-level/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@glimmer/low-level",
+  "version": "0.30.3",
+  "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/low-level",
+  "devDependencies": {
+    "typescript": "^2.2.0"
+  }
+}

--- a/packages/@glimmer/low-level/test/glue/storage-test.ts
+++ b/packages/@glimmer/low-level/test/glue/storage-test.ts
@@ -1,0 +1,56 @@
+import { Storage } from '@glimmer/low-level';
+
+QUnit.module('[low-level glue] Storage');
+
+QUnit.test('basic functionality', assert => {
+  let storage = new Storage();
+
+  let ref = {};
+  let func = () => null;
+
+  let p1 = storage.add(ref);
+  let p2 = storage.add(func);
+  let p3 = storage.add('hello');
+  let p4 = storage.add(null);
+
+  assert.strictEqual(storage.deref(p1), ref, 'storage.deref(p1)');
+  assert.strictEqual(storage.deref(p2), func, 'storage.deref(p2)');
+  assert.strictEqual(storage.deref(p3), 'hello', 'storage.deref(p3)');
+  assert.strictEqual(storage.deref(p4), null, 'storage.deref(p4)');
+
+  storage.drop(p2);
+
+  let newFunc = () => null;
+
+  let secondP2 = storage.add(newFunc);
+
+  // it's ok if this test eventually fails if we go
+  // with a smarter strategy -- this is just a smoke
+  // test for now
+  assert.strictEqual(p2, secondP2, 'p2 === secondP2');
+
+  assert.strictEqual(storage.deref(p2), newFunc, 'storage.deref(p2)');
+
+  storage.drop(p1);
+  storage.drop(secondP2);
+  storage.drop(p4);
+  storage.drop(p3);
+
+  let newFunc2 = () => null;
+  let newRef = {};
+
+  let newP1 = storage.add(newRef);
+  let newP2 = storage.add(newFunc2);
+  let newP3 = storage.add('hello');
+  let newP4 = storage.add(null);
+
+  assert.strictEqual(storage.deref(newP1), newRef, 'newP1');
+  assert.strictEqual(storage.deref(newP2), newFunc2, 'newP2');
+  assert.strictEqual(storage.deref(newP3), 'hello', 'newP3');
+  assert.strictEqual(storage.deref(newP4), null, 'newP4');
+
+  // it's ok if this test eventually fails if we go
+  // with a smarter strategy -- this is just a smoke
+  // test for now
+  assert.strictEqual(storage['next'], 4);
+});

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -1,9 +1,7 @@
 import {
   Option,
   SymbolTable,
-  ProgramSymbolTable,
-  VMHandle,
-  Recast
+  ProgramSymbolTable
 } from '@glimmer/interfaces';
 import { Statement, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { DEBUG } from '@glimmer/local-debug-flags';
@@ -13,7 +11,7 @@ import { CompileOptions, statementCompiler, Compilers } from './syntax';
 
 export { ICompilableTemplate };
 
-export const PLACEHOLDER_HANDLE: VMHandle = -1 as Recast<number, VMHandle>;
+export const PLACEHOLDER_HANDLE = -1;
 
 export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> implements ICompilableTemplate<S> {
   static topLevel<TemplateMeta>(block: SerializedTemplateBlock, options: CompileOptions<TemplateMeta>): ICompilableTemplate<ProgramSymbolTable> {
@@ -25,7 +23,7 @@ export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> imp
     );
   }
 
-  private compiled: Option<VMHandle> = null;
+  private compiled: Option<number> = null;
 
   private statementCompiler: Compilers<Statement>;
 
@@ -33,7 +31,7 @@ export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> imp
     this.statementCompiler = statementCompiler();
   }
 
-  compile(): VMHandle {
+  compile(): number {
     let { compiled } = this;
     if (compiled !== null) return compiled;
 

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -1,12 +1,10 @@
 import {
-  VMHandle,
   Opaque,
   SymbolTable,
   Option,
   BlockSymbolTable,
   ComponentCapabilities,
-  CompileTimeProgram,
-  Recast
+  CompileTimeProgram
 } from '@glimmer/interfaces';
 import { Core, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { Macros } from './syntax';
@@ -23,10 +21,10 @@ export interface EagerCompilationOptions<TemplateMeta, R extends EagerResolver<T
 
 export interface CompilableTemplate<S extends SymbolTable> {
   symbolTable: S;
-  compile(): VMHandle;
+  compile(): number;
 }
 
-export const PLACEHOLDER_HANDLE: VMHandle = -1 as Recast<number, VMHandle>;
+export const PLACEHOLDER_HANDLE = -1;
 
 export type CompilableBlock = CompilableTemplate<BlockSymbolTable>;
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -36,22 +36,20 @@ import CompilableTemplate, { ICompilableTemplate, PLACEHOLDER_HANDLE } from './c
 import {
   ComponentBuilder
 } from './wrapped-component';
-import { InstructionEncoder, Operand } from "@glimmer/encoder";
+import { InstructionEncoder, Operand, MACHINE_MASK } from "@glimmer/encoder";
 
 export type Label = string;
 
-type TargetOpcode = Op.Jump | Op.JumpIf | Op.JumpUnless | Op.EnterList | Op.Iterate | Op.ReturnTo;
-
 class Labels {
   labels = dict<number>();
-  targets: Array<{ at: number, Target: TargetOpcode, target: string }> = [];
+  targets: Array<{ at: number, target: string }> = [];
 
   label(name: string, index: number) {
     this.labels[name] = index;
   }
 
-  target(at: number, Target: TargetOpcode, target: string) {
-    this.targets.push({ at, Target, target });
+  target(at: number, target: string) {
+    this.targets.push({ at, target });
   }
 
   patch(encoder: InstructionEncoder): void {
@@ -101,12 +99,15 @@ export class SimpleOpcodeBuilder {
   protected encoder = new InstructionEncoder([]);
 
   push(name: Op, ...ops: Operand[]) {
-    let { encoder } = this;
-    encoder.encode(name, ...ops);
+    this.encoder.encode(name, 0, ...ops);
+  }
+
+  pushMachine(name: Op, ...ops: Operand[]) {
+    this.encoder.encode(name, MACHINE_MASK, ...ops);
   }
 
   commit(heap: CompileTimeHeap, scopeSize: number): VMHandle {
-    this.push(Op.Return);
+    this.pushMachine(Op.Return);
 
     let { buffer } = this.encoder;
 
@@ -132,6 +133,15 @@ export class SimpleOpcodeBuilder {
     }
 
     this.push(name, ...reservedOperands);
+  }
+
+  reserveMachine(name: Op, size = 1) {
+    let reservedOperands = [];
+    for (let i = 0; i < size; i++) {
+      reservedOperands[i] = -1;
+    }
+
+    this.pushMachine(name, ...reservedOperands);
   }
 
   ///
@@ -223,15 +233,15 @@ export class SimpleOpcodeBuilder {
   }
 
   pushFrame() {
-    this.push(Op.PushFrame);
+    this.pushMachine(Op.PushFrame);
   }
 
   popFrame() {
-    this.push(Op.PopFrame);
+    this.pushMachine(Op.PopFrame);
   }
 
   invokeVirtual(): void {
-    this.push(Op.InvokeVirtual);
+    this.pushMachine(Op.InvokeVirtual);
   }
 
   invokeYield(): void {
@@ -464,7 +474,7 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
 
   enterList(start: string) {
     this.reserve(Op.EnterList);
-    this.labels.target(this.pos, Op.EnterList, start);
+    this.labels.target(this.pos, start);
   }
 
   exitList() {
@@ -473,7 +483,7 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
 
   iterate(breaks: string) {
     this.reserve(Op.Iterate);
-    this.labels.target(this.pos, Op.Iterate, breaks);
+    this.labels.target(this.pos, breaks);
   }
 
   // expressions
@@ -531,8 +541,8 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
   // vm
 
   returnTo(label: string) {
-    this.reserve(Op.ReturnTo);
-    this.labels.target(this.pos, Op.ReturnTo, label);
+    this.reserveMachine(Op.ReturnTo);
+    this.labels.target(this.pos, label);
   }
 
   primitive(_primitive: Primitive) {
@@ -614,22 +624,22 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
   }
 
   return() {
-    this.push(Op.Return);
+    this.pushMachine(Op.Return);
   }
 
   jump(target: string) {
-    this.reserve(Op.Jump);
-    this.labels.target(this.pos, Op.Jump, target);
+    this.reserveMachine(Op.Jump);
+    this.labels.target(this.pos, target);
   }
 
   jumpIf(target: string) {
     this.reserve(Op.JumpIf);
-    this.labels.target(this.pos, Op.JumpIf, target);
+    this.labels.target(this.pos, target);
   }
 
   jumpUnless(target: string) {
     this.reserve(Op.JumpUnless);
-    this.labels.target(this.pos, Op.JumpUnless, target);
+    this.labels.target(this.pos, target);
   }
 
   // internal helpers
@@ -1047,7 +1057,7 @@ export class LazyOpcodeBuilder<TemplateMeta> extends OpcodeBuilder<TemplateMeta>
   invokeStatic(compilable: ICompilableTemplate<SymbolTable>): void {
     this.pushOther(compilable);
     this.push(Op.CompileBlock);
-    this.push(Op.InvokeVirtual);
+    this.pushMachine(Op.InvokeVirtual);
   }
 
   protected pushOther<T>(value: T) {
@@ -1087,9 +1097,9 @@ export class EagerOpcodeBuilder<TemplateMeta> extends OpcodeBuilder<TemplateMeta
     // function that will produce the correct handle when the heap is
     // serialized.
     if (handle === PLACEHOLDER_HANDLE) {
-      this.push(Op.InvokeStatic, () => compilable.compile() as Recast<VMHandle, number>);
+      this.pushMachine(Op.InvokeStatic, () => compilable.compile() as Recast<VMHandle, number>);
     } else {
-      this.push(Op.InvokeStatic, handle as Recast<VMHandle, number>);
+      this.pushMachine(Op.InvokeStatic, handle as Recast<VMHandle, number>);
     }
   }
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -106,7 +106,7 @@ export class SimpleOpcodeBuilder {
     this.encoder.encode(name, MACHINE_MASK, ...ops);
   }
 
-  commit(heap: CompileTimeHeap, scopeSize: number): VMHandle {
+  commit(heap: CompileTimeHeap, scopeSize: number): number {
     this.pushMachine(Op.Return);
 
     let { buffer } = this.encoder;

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -1,5 +1,5 @@
 import { Register } from '@glimmer/vm';
-import { ProgramSymbolTable, BlockSymbolTable, VMHandle, ComponentCapabilities } from '@glimmer/interfaces';
+import { ProgramSymbolTable, BlockSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
 
 import {
   ComponentArgs,
@@ -31,7 +31,7 @@ export class WrappedBuilder<TemplateMeta> implements ICompilableTemplate<Program
     };
   }
 
-  compile(): VMHandle {
+  compile(): number {
     //========DYNAMIC
     //        PutValue(TagExpr)
     //        Test

--- a/packages/@glimmer/program/lib/opcode.ts
+++ b/packages/@glimmer/program/lib/opcode.ts
@@ -1,5 +1,5 @@
 import { Heap } from './program';
-import { TYPE_MASK, OPERAND_LEN_MASK, ARG_SHIFT } from "@glimmer/encoder";
+import { TYPE_MASK, OPERAND_LEN_MASK, ARG_SHIFT, MACHINE_MASK } from "@glimmer/encoder";
 
 export class Opcode {
   public offset = 0;
@@ -8,6 +8,11 @@ export class Opcode {
   get size() {
     let rawType = this.heap.getbyaddr(this.offset);
     return ((rawType & OPERAND_LEN_MASK) >> ARG_SHIFT) + 1;
+  }
+
+  get isMachine() {
+    let rawType = this.heap.getbyaddr(this.offset);
+    return rawType & MACHINE_MASK;
   }
 
   get type() {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -73,7 +73,7 @@ export interface ComponentInstance {
   definition: ComponentDefinition;
   manager: InternalComponentManager;
   state: ComponentInstanceState;
-  handle: VMHandle;
+  handle: number;
   table: ProgramSymbolTable;
 }
 
@@ -89,7 +89,7 @@ export interface PopulatedComponentInstance {
   definition: ComponentDefinition;
   manager: InternalComponentManager;
   state: null;
-  handle: Option<VMHandle>;
+  handle: Option<number>;
   table: Option<ProgramSymbolTable>;
 }
 
@@ -374,7 +374,7 @@ APPEND_OPCODES.add(Op.GetComponentLayout, (vm, { op1: _state }) => {
   let { state: instanceState } = instance;
   let { state: definitionState } = definition;
 
-  let invoke: { handle: VMHandle, symbolTable: ProgramSymbolTable };
+  let invoke: { handle: number, symbolTable: ProgramSymbolTable };
 
   if (hasStaticLayout(definitionState, manager)) {
     invoke = manager.getLayout(definitionState, resolver);
@@ -430,10 +430,8 @@ APPEND_OPCODES.add(Op.InvokeComponentLayout, (vm, { op1: _state }) => {
     let args = check(vm.stack.pop(), CheckArguments);
 
     let lookup: Option<Dict<ScopeSlot>> = null;
-    let $eval: Option<number> = -1;
 
     if (hasEval) {
-      $eval = symbols.indexOf('$eval') + 1;
       lookup = dict<ScopeSlot>();
     }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -7,7 +7,7 @@ import { FALSE_REFERENCE, TRUE_REFERENCE } from '../../references';
 import { PublicVM } from '../../vm';
 import { ConcatReference } from '../expressions/concat';
 import { assert } from "@glimmer/util";
-import { check, expectStackChange, CheckFunction, CheckOption, CheckHandle, CheckBlockSymbolTable, CheckOr } from '@glimmer/debug';
+import { check, CheckFunction, CheckOption, CheckHandle, CheckBlockSymbolTable, CheckOr } from '@glimmer/debug';
 import { stackAssert } from './assert';
 import { CheckArguments, CheckPathReference, CheckCompilableBlock, CheckScope } from './-debug-strip';
 
@@ -77,8 +77,6 @@ APPEND_OPCODES.add(Op.GetBlock, (vm, { op1: _block }) => {
     stack.push(null);
     stack.push(null);
   }
-
-  expectStackChange(vm.stack, 3, 'GetBlock');
 });
 
 APPEND_OPCODES.add(Op.HasBlock, (vm, { op1: _block }) => {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -9,7 +9,7 @@ import {
   Tag
 } from '@glimmer/reference';
 import { initializeGuid, assert } from '@glimmer/util';
-import { expectStackChange, CheckNumber, check, CheckInstanceof, CheckOption, CheckBlockSymbolTable, CheckHandle, CheckPrimitive } from '@glimmer/debug';
+import { CheckNumber, check, CheckInstanceof, CheckOption, CheckBlockSymbolTable, CheckHandle, CheckPrimitive } from '@glimmer/debug';
 import { stackAssert } from './assert';
 import { APPEND_OPCODES, UpdatingOpcode } from '../../opcodes';
 import { Scope } from '../../environment';
@@ -85,14 +85,11 @@ APPEND_OPCODES.add(Op.BindDynamicScope, (vm, { op1: _names }) => {
 
 APPEND_OPCODES.add(Op.PushFrame, vm => {
   vm.pushFrame();
-
-  check(vm.stack.peek(), CheckNumber);
-  check(vm.stack.peek(1), CheckNumber);
-});
+}, 'machine');
 
 APPEND_OPCODES.add(Op.PopFrame, vm => {
   vm.popFrame();
-});
+}, 'machine');
 
 APPEND_OPCODES.add(Op.Enter, (vm, { op1: args }) => {
   vm.enter(args);
@@ -127,11 +124,11 @@ APPEND_OPCODES.add(Op.CompileBlock, vm => {
 
 APPEND_OPCODES.add(Op.InvokeVirtual, vm => {
   vm.call(check(vm.stack.popSmi(), CheckHandle));
-});
+}, 'machine');
 
 APPEND_OPCODES.add(Op.InvokeStatic, (vm, { op1: handle }) => {
   vm.call(handle as Recast<number, VMHandle>);
-});
+}, 'machine');
 
 APPEND_OPCODES.add(Op.InvokeYield, vm => {
   let { stack } = vm;
@@ -175,7 +172,7 @@ APPEND_OPCODES.add(Op.InvokeYield, vm => {
 
 APPEND_OPCODES.add(Op.Jump, (vm, { op1: target }) => {
   vm.goto(target);
-});
+}, 'machine');
 
 APPEND_OPCODES.add(Op.JumpIf, (vm, { op1: target }) => {
   let reference = check(vm.stack.pop(), CheckReference);
@@ -215,13 +212,11 @@ APPEND_OPCODES.add(Op.JumpUnless, (vm, { op1: target }) => {
 
 APPEND_OPCODES.add(Op.Return, vm => {
   vm.return();
-
-  expectStackChange(vm.stack, 0, 'Return');
-});
+}, 'machine');
 
 APPEND_OPCODES.add(Op.ReturnTo, (vm, { op1: relative }) => {
   vm.returnTo(relative);
-});
+}, 'machine');
 
 APPEND_OPCODES.add(Op.ToBoolean, vm => {
   let { env, stack } = vm;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -83,14 +83,6 @@ APPEND_OPCODES.add(Op.BindDynamicScope, (vm, { op1: _names }) => {
   vm.bindDynamicScope(names);
 });
 
-APPEND_OPCODES.add(Op.PushFrame, vm => {
-  vm.pushFrame();
-}, 'machine');
-
-APPEND_OPCODES.add(Op.PopFrame, vm => {
-  vm.popFrame();
-}, 'machine');
-
 APPEND_OPCODES.add(Op.Enter, (vm, { op1: args }) => {
   vm.enter(args);
 });
@@ -121,14 +113,6 @@ APPEND_OPCODES.add(Op.CompileBlock, vm => {
 
   check(vm.stack.peek(), CheckOption(CheckNumber));
 });
-
-APPEND_OPCODES.add(Op.InvokeVirtual, vm => {
-  vm.call(check(vm.stack.popSmi(), CheckHandle));
-}, 'machine');
-
-APPEND_OPCODES.add(Op.InvokeStatic, (vm, { op1: handle }) => {
-  vm.call(handle as Recast<number, VMHandle>);
-}, 'machine');
 
 APPEND_OPCODES.add(Op.InvokeYield, vm => {
   let { stack } = vm;
@@ -170,10 +154,6 @@ APPEND_OPCODES.add(Op.InvokeYield, vm => {
   vm.call(handle!);
 });
 
-APPEND_OPCODES.add(Op.Jump, (vm, { op1: target }) => {
-  vm.goto(target);
-}, 'machine');
-
 APPEND_OPCODES.add(Op.JumpIf, (vm, { op1: target }) => {
   let reference = check(vm.stack.pop(), CheckReference);
 
@@ -209,14 +189,6 @@ APPEND_OPCODES.add(Op.JumpUnless, (vm, { op1: target }) => {
     vm.updateWith(new Assert(cache));
   }
 });
-
-APPEND_OPCODES.add(Op.Return, vm => {
-  vm.return();
-}, 'machine');
-
-APPEND_OPCODES.add(Op.ReturnTo, (vm, { op1: relative }) => {
-  vm.returnTo(relative);
-}, 'machine');
 
 APPEND_OPCODES.add(Op.ToBoolean, vm => {
   let { env, stack } = vm;

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -1,4 +1,4 @@
-import { Simple, Dict, Opaque, Option, RuntimeResolver, Unique, ProgramSymbolTable, VMHandle, ComponentCapabilities } from '@glimmer/interfaces';
+import { Simple, Dict, Opaque, Option, RuntimeResolver, Unique, ProgramSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
 import { Tag, VersionedPathReference } from '@glimmer/reference';
 import { Destroyable } from '@glimmer/util';
 import Bounds from '../bounds';
@@ -78,7 +78,7 @@ export interface ComponentManager<ComponentInstanceState, ComponentDefinitionSta
 }
 
 export interface Invocation {
-  handle: VMHandle;
+  handle: number;
   symbolTable: ProgramSymbolTable;
 }
 

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -1,6 +1,6 @@
 import { Reference, PathReference, OpaqueIterable } from '@glimmer/reference';
 import { Macros, OpcodeBuilderConstructor, ICompilableTemplate } from '@glimmer/opcode-compiler';
-import { Simple, RuntimeResolver, BlockSymbolTable, VMHandle } from '@glimmer/interfaces';
+import { Simple, RuntimeResolver, BlockSymbolTable } from '@glimmer/interfaces';
 import { Program } from "@glimmer/program";
 import {
   Dict,
@@ -23,7 +23,7 @@ import {
 } from './modifier/interfaces';
 import { Component, ComponentManager } from "./internal-interfaces";
 
-export type ScopeBlock = [VMHandle | ICompilableTemplate<BlockSymbolTable>, Scope, BlockSymbolTable];
+export type ScopeBlock = [number | ICompilableTemplate<BlockSymbolTable>, Scope, BlockSymbolTable];
 export type BlockValue = ScopeBlock[0 | 1 | 2];
 export type ScopeSlot = Option<PathReference<Opaque>> | Option<ScopeBlock>;
 

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -26,6 +26,8 @@ export type MachineOpcode = (vm: LowLevelVM, opcode: Opcode) => void;
 
 export type Evaluate = { syscall: true, evaluate: Syscall } | { syscall: false, evaluate: MachineOpcode };
 
+export type DebugState = { sp: number, state: Opaque };
+
 export class AppendOpcodes {
   private evaluateOpcode: Evaluate[] = fillNulls<Evaluate>(Op.Size).slice();
 
@@ -35,7 +37,7 @@ export class AppendOpcodes {
     this.evaluateOpcode[name as number] = { syscall: kind === 'syscall', evaluate } as Evaluate;
   }
 
-  debugBefore(vm: VM<Opaque>, opcode: Opcode, type: number): { sp: number, state: Opaque } {
+  debugBefore(vm: VM<Opaque>, opcode: Opcode, type: number): DebugState {
     if (DEBUG) {
       /* tslint:disable */
       let [name, params] = debug(vm.constants, opcode.type, opcode.op1, opcode.op2, opcode.op3);
@@ -70,7 +72,7 @@ export class AppendOpcodes {
     return { sp: sp!, state };
   }
 
-  debugAfter(vm: VM<Opaque>, opcode: Opcode, type: number, pre: { sp: number, state: Opaque }) {
+  debugAfter(vm: VM<Opaque>, opcode: Opcode, type: number, pre: DebugState) {
     let expectedChange: number;
     let { sp, state } = pre;
 

--- a/packages/@glimmer/runtime/lib/partial.ts
+++ b/packages/@glimmer/runtime/lib/partial.ts
@@ -1,4 +1,4 @@
-import { ProgramSymbolTable, VMHandle } from '@glimmer/interfaces';
+import { ProgramSymbolTable } from '@glimmer/interfaces';
 import { Template } from './template';
 
 export class PartialDefinition {
@@ -8,7 +8,7 @@ export class PartialDefinition {
   ) {
   }
 
-  getPartial(): { symbolTable: ProgramSymbolTable, handle: VMHandle } {
+  getPartial(): { symbolTable: ProgramSymbolTable, handle: number } {
     let partial = this.template.asPartial();
     let handle = partial.compile();
     return { symbolTable: partial.symbolTable, handle };

--- a/packages/@glimmer/runtime/lib/syntax/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/syntax/interfaces.ts
@@ -1,13 +1,12 @@
 import {
   BlockSymbolTable,
   ProgramSymbolTable,
-  SymbolTable,
-  VMHandle
+  SymbolTable
 } from '@glimmer/interfaces';
 
 export interface CompilableTemplate<S extends SymbolTable = SymbolTable> {
   symbolTable: S;
-  compile(): VMHandle;
+  compile(): number;
 }
 
 export type BlockSyntax = CompilableTemplate<BlockSymbolTable>;

--- a/packages/@glimmer/runtime/lib/vm.ts
+++ b/packages/@glimmer/runtime/lib/vm.ts
@@ -1,3 +1,4 @@
 export { default as VM, PublicVM, IteratorResult } from './vm/append';
 export { default as UpdatingVM } from './vm/update';
 export { default as RenderResult } from './vm/render-result';
+export { default as LowLevelVM } from './vm/low-level';

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -9,6 +9,7 @@ import LowLevelVM from './low-level';
 import { VMState, ListBlockOpcode, TryOpcode, BlockOpcode } from './update';
 import RenderResult from './render-result';
 import EvaluationStack from './stack';
+import { DEVMODE } from '@glimmer/local-debug-flags';
 
 import {
   APPEND_OPCODES,
@@ -413,7 +414,13 @@ export default class VM<TemplateMeta> implements PublicVM {
     let opcode = this.inner.nextStatement();
     let result: IteratorResult<RenderResult>;
     if (opcode !== null) {
-      APPEND_OPCODES.evaluate(this, opcode, opcode.type);
+      if (DEVMODE) {
+        let state = APPEND_OPCODES.debugBefore(this, opcode, opcode.type);
+        APPEND_OPCODES.evaluate(this, opcode, opcode.type);
+        APPEND_OPCODES.debugAfter(this, opcode, opcode.type, state);
+      } else {
+        APPEND_OPCODES.evaluate(this, opcode, opcode.type);
+      }
       result = { done: false, value: null };
     } else {
       // Unload the stack

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -116,16 +116,16 @@ export default class VM<TemplateMeta> implements PublicVM {
 
   // Start a new frame and save $ra and $fp on the stack
   pushFrame() {
-    this.stack.push(this.ra);
-    this.stack.push(this.fp);
+    this.stack.pushSmi(this.ra);
+    this.stack.pushSmi(this.fp);
     this.fp = this.sp - 1;
   }
 
   // Restore $ra, $sp and $fp
   popFrame() {
     this.sp = this.fp - 1;
-    this.ra = this.stack.get<number>(0);
-    this.fp = this.stack.get<number>(1);
+    this.ra = this.stack.getSmi(0);
+    this.fp = this.stack.getSmi(1);
   }
 
   // Jump to an address in `program`

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -1,4 +1,4 @@
-import { EvaluationStack } from './append';
+import EvaluationStack from './stack';
 import { dict, EMPTY_ARRAY } from '@glimmer/util';
 import { combineTagged } from '@glimmer/reference';
 import { Dict, Opaque, Option, unsafe, BlockSymbolTable, VMHandle } from '@glimmer/interfaces';
@@ -237,7 +237,7 @@ export class PositionalArguments implements IPositionalArguments {
 
     if (!references) {
       let { stack, base, length } = this;
-      references = this._references = stack.slice<VersionedPathReference<Opaque>>(base, base + length);
+      references = this._references = stack.sliceArray<VersionedPathReference<Opaque>>(base, base + length);
     }
 
     return references;
@@ -400,7 +400,7 @@ export class NamedArguments implements INamedArguments {
 
     if (!references) {
       let { base, length, stack } = this;
-      references = this._references = stack.slice<VersionedPathReference<Opaque>>(base, base + length);
+      references = this._references = stack.sliceArray<VersionedPathReference<Opaque>>(base, base + length);
     }
 
     return references;
@@ -503,7 +503,7 @@ export class BlockArguments implements IBlockArguments {
 
     if (!values) {
       let { base, length, stack } = this;
-      values = this.internalValues = stack.slice<VMHandle>(base, base + length * 3);
+      values = this.internalValues = stack.sliceArray<VMHandle>(base, base + length * 3);
     }
 
     return values;

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -1,7 +1,7 @@
 import EvaluationStack from './stack';
 import { dict, EMPTY_ARRAY } from '@glimmer/util';
 import { combineTagged } from '@glimmer/reference';
-import { Dict, Opaque, Option, unsafe, BlockSymbolTable, VMHandle } from '@glimmer/interfaces';
+import { Dict, Opaque, Option, unsafe, BlockSymbolTable } from '@glimmer/interfaces';
 import { Tag, VersionedPathReference, CONSTANT_TAG } from '@glimmer/reference';
 import { PrimitiveReference, UNDEFINED_REFERENCE } from '../references';
 import { ScopeBlock, Scope, BlockValue } from '../environment';
@@ -290,7 +290,6 @@ export class NamedArguments implements INamedArguments {
 
   private stack: EvaluationStack;
 
-  private _tag: Option<Tag> = null;
   private _references: Option<VersionedPathReference<Opaque>[]> = null;
 
   private _names: Option<string[]> = EMPTY_ARRAY;
@@ -302,12 +301,10 @@ export class NamedArguments implements INamedArguments {
     this.length = length;
 
     if (length === 0) {
-      this._tag = CONSTANT_TAG;
       this._references = EMPTY_ARRAY;
       this._names = EMPTY_ARRAY;
       this._atNames = EMPTY_ARRAY;
     } else {
-      this._tag = null;
       this._references = null;
 
       if (synthetic) {
@@ -388,7 +385,6 @@ export class NamedArguments implements INamedArguments {
       }
 
       this.length = length;
-      this._tag = null;
       this._references = null;
       this._names = names;
       this._atNames = null;
@@ -475,7 +471,7 @@ class CapturedNamedArguments implements ICapturedNamedArguments {
 
 export class BlockArguments implements IBlockArguments {
   private stack: EvaluationStack;
-  private internalValues: Option<VMHandle[]> = null;
+  private internalValues: Option<number[]> = null;
 
   public internalTag: Option<Tag> = null;
   public names: string[] = EMPTY_ARRAY;
@@ -503,7 +499,7 @@ export class BlockArguments implements IBlockArguments {
 
     if (!values) {
       let { base, length, stack } = this;
-      values = this.internalValues = stack.sliceArray<VMHandle>(base, base + length * 3);
+      values = this.internalValues = stack.sliceArray<number>(base, base + length * 3);
     }
 
     return values;
@@ -555,7 +551,7 @@ class CapturedBlockArguments implements ICapturedBlockArguments {
     if (idx === -1) return null;
 
     return [
-      this.values[idx * 3 + 2] as VMHandle,
+      this.values[idx * 3 + 2] as number,
       this.values[idx * 3 + 1] as Scope,
       this.values[idx * 3] as BlockSymbolTable
     ];

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -141,7 +141,7 @@ export class Arguments implements IArguments {
       let length = positional.length + named.length;
 
       for(let i=length-1; i>=0; i--) {
-        stack.set(stack.get(i, positional.base), i, newBase);
+        stack.copy(i + positional.base, i + newBase);
       }
 
       positional.base += offset;

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -1,5 +1,7 @@
 import { Heap, Opcode } from "@glimmer/program";
-import { VMHandle, Option } from "@glimmer/interfaces";
+import { VMHandle, Option, Opaque } from "@glimmer/interfaces";
+import { APPEND_OPCODES } from "../opcodes";
+import VM from './append';
 
 export interface Stack {
   sp: number;
@@ -83,4 +85,27 @@ export default class LowLevelVM {
 
     return program.opcode(pc);
   }
+
+  next(vm: VM<Opaque>) {
+    let opcode = this.nextStatement();
+
+    if (opcode) {
+      this.nextOpcode(opcode, vm);
+    } else {
+
+    }
+  }
+
+  nextOpcode(opcode: Opcode, vm: VM<Opaque>) {
+    APPEND_OPCODES.evaluate(vm, opcode, opcode.type);
+    // if (opcode.isMachine) {
+    //   APPEND_OPCODES.evaluateMachine(this, opcode, opcode.type);
+    // } else {
+    //   this.nextSyscall(opcode, vm);
+    // }
+  }
+
+  // nextSyscall(opcode: Opcode, vm: VM<Opaque>) {
+  //   APPEND_OPCODES.evaluateSyscall(vm, opcode, opcode.type);
+  // }
 }

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -1,7 +1,9 @@
 import { Heap, Opcode } from "@glimmer/program";
-import { VMHandle, Option, Opaque } from "@glimmer/interfaces";
+import { Option, Opaque } from "@glimmer/interfaces";
 import { APPEND_OPCODES } from "../opcodes";
 import VM from './append';
+import { DEVMODE } from "@glimmer/local-debug-flags";
+import { Op } from "@glimmer/vm";
 
 export interface Stack {
   sp: number;
@@ -19,6 +21,11 @@ export interface Program {
   opcode(offset: number): Opcode;
 }
 
+export interface Externs {
+  debugBefore(opcode: Opcode): Opaque;
+  debugAfter(opcode: Opcode, state: Opaque): void;
+}
+
 export default class LowLevelVM {
   public currentOpSize = 0;
 
@@ -26,6 +33,7 @@ export default class LowLevelVM {
     public stack: Stack,
     public heap: Heap,
     public program: Program,
+    public externs: Externs,
     public pc = -1,
     public ra = -1
   ) {}
@@ -51,7 +59,7 @@ export default class LowLevelVM {
   }
 
   // Save $pc into $ra, then jump to a new address in `program` (jal in MIPS)
-  call(handle: VMHandle) {
+  call(handle: number) {
     this.ra = this.pc;
     this.pc = this.heap.getaddr(handle);
   }
@@ -86,18 +94,18 @@ export default class LowLevelVM {
     return program.opcode(pc);
   }
 
-  next(vm: VM<Opaque>) {
-    let opcode = this.nextStatement();
+  evaluateOuter(opcode: Opcode, vm: VM<Opaque>) {
+    let { externs: { debugBefore, debugAfter } } = this;
 
-    if (opcode) {
-      this.nextOpcode(opcode, vm);
+    if (DEVMODE) {
+      let state = debugBefore(opcode);
+      this.evaluateInner(opcode, vm);
+      // APPEND_OPCODES.evaluate(vm, opcode, opcode.type);
+      debugAfter(opcode, state);
     } else {
-
+      this.evaluateInner(opcode, vm);
+      APPEND_OPCODES.evaluate(vm, opcode, opcode.type);
     }
-  }
-
-  nextOpcode(opcode: Opcode, vm: VM<Opaque>) {
-    APPEND_OPCODES.evaluate(vm, opcode, opcode.type);
     // if (opcode.isMachine) {
     //   APPEND_OPCODES.evaluateMachine(this, opcode, opcode.type);
     // } else {
@@ -105,7 +113,34 @@ export default class LowLevelVM {
     // }
   }
 
-  // nextSyscall(opcode: Opcode, vm: VM<Opaque>) {
-  //   APPEND_OPCODES.evaluateSyscall(vm, opcode, opcode.type);
-  // }
+  evaluateInner(opcode: Opcode, vm: VM<Opaque>) {
+    if (opcode.isMachine) {
+      this.evaluateMachine(opcode);
+    } else {
+      this.evaluateSyscall(opcode, vm);
+    }
+  }
+
+  evaluateMachine(opcode: Opcode) {
+    switch (opcode.type) {
+      case Op.PushFrame:
+        return this.pushFrame();
+      case Op.PopFrame:
+        return this.popFrame();
+      case Op.InvokeStatic:
+        return this.call(opcode.op1);
+      case Op.InvokeVirtual:
+        return this.call(this.stack.popSmi());
+      case Op.Jump:
+        return this.goto(opcode.op1);
+      case Op.Return:
+        return this.return();
+      case Op.ReturnTo:
+        return this.returnTo(opcode.op1);
+    }
+  }
+
+  evaluateSyscall(opcode: Opcode, vm: VM<Opaque>) {
+    APPEND_OPCODES.evaluate(vm, opcode, opcode.type);
+  }
 }

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -1,0 +1,60 @@
+import { Heap } from "@glimmer/program";
+import { VMHandle } from "@glimmer/interfaces";
+
+export interface Stack {
+  sp: number;
+  fp: number;
+
+  pushSmi(value: number): void;
+  pushEncodedImmediate(value: number): void;
+
+  getSmi(position: number): number;
+}
+
+export default class LowLevelVM {
+  public currentOpSize = 0;
+
+  constructor(
+    public stack: Stack,
+    public heap: Heap,
+    public pc = -1,
+    public ra = -1
+  ) {}
+
+  // Start a new frame and save $ra and $fp on the stack
+  pushFrame() {
+    this.stack.pushSmi(this.ra);
+    this.stack.pushSmi(this.stack.fp);
+    this.stack.fp = this.stack.sp - 1;
+  }
+
+  // Restore $ra, $sp and $fp
+  popFrame() {
+    this.stack.sp = this.stack.fp - 1;
+    this.ra = this.stack.getSmi(0);
+    this.stack.fp = this.stack.getSmi(1);
+  }
+
+  // Jump to an address in `program`
+  goto(offset: number) {
+    let addr = (this.pc + offset) - this.currentOpSize;
+    this.pc = addr;
+  }
+
+  // Save $pc into $ra, then jump to a new address in `program` (jal in MIPS)
+  call(handle: VMHandle) {
+    this.ra = this.pc;
+    this.pc = this.heap.getaddr(handle);
+  }
+
+  // Put a specific `program` address in $ra
+  returnTo(offset: number) {
+    let addr = (this.pc + offset) - this.currentOpSize;
+    this.ra = addr;
+  }
+
+  // Return to the `program` address stored in $ra
+  return() {
+    this.pc = this.ra;
+  }
+}

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -41,7 +41,7 @@ export class InnerStack {
   }
 
   writeSmi(pos: number, value: number): void {
-    this.inner[pos] = encodeImmediate(value); // value << 3 | PrimitiveType.NUMBER;
+    this.inner[pos] = encodeSmi(value); // value << 3 | PrimitiveType.NUMBER;
   }
 
   writeImmediate(pos: number, value: number): void {
@@ -213,14 +213,18 @@ export const enum Immediates {
   Undef = 3 << 3 | Type.BOOLEAN_OR_VOID
 }
 
+function encodeSmi(primitive: number) {
+  if (primitive < 0) {
+    return Math.abs(primitive) << 3 | PrimitiveType.NEGATIVE;
+  } else {
+    return primitive << 3 | PrimitiveType.NUMBER;
+  }
+}
+
 function encodeImmediate(primitive: number | boolean | null | undefined): number {
   switch (typeof primitive) {
     case 'number':
-      if (primitive as number < 0) {
-        return Math.abs(primitive as number) << 3 | PrimitiveType.NEGATIVE;
-      } else {
-        return (primitive as number) << 3 | PrimitiveType.NUMBER;
-      }
+      return encodeSmi(primitive as number);
     case 'boolean':
       return primitive ? Immediates.True : Immediates.False;
     case 'object':

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -1,0 +1,96 @@
+import { DEBUG } from '@glimmer/local-debug-flags';
+import { Opaque } from '@glimmer/interfaces';
+
+export class CapturedStack {
+  [index: number]: never;
+
+  constructor(private inner: Opaque[] = []) {}
+
+  slice(start?: number, end?: number): CapturedStack {
+    return new CapturedStack(this.inner.slice(start, end));
+  }
+
+  sliceInner<T = Opaque>(start: number, end: number): T[] {
+    return this.inner.slice(start, end) as T[];
+  }
+
+  update(pos: number, value: Opaque): void {
+    this.inner[pos] = value;
+  }
+
+  get<T>(pos: number): T {
+    return this.inner[pos] as T;
+  }
+
+  reset(): void {
+    this.inner.length = 0;
+  }
+
+  get length(): number {
+    return this.inner.length;
+  }
+}
+
+export default class EvaluationStack {
+  static empty(): EvaluationStack {
+    return new this(new CapturedStack(), 0, -1);
+  }
+
+  static restore(snapshot: CapturedStack): EvaluationStack {
+    return new this(snapshot.slice(), 0, snapshot.length - 1);
+  }
+
+  constructor(private stack: CapturedStack, public fp: number, public sp: number) {
+    if (DEBUG) {
+      Object.seal(this);
+    }
+  }
+
+  push(value: Opaque): void {
+    this.stack.update(++this.sp, value);
+  }
+
+  dup(position = this.sp): void {
+    this.push(this.stack.get(position));
+  }
+
+  pop<T>(n = 1): T {
+    let top = this.stack.get<T>(this.sp);
+    this.sp -= n;
+    return top;
+  }
+
+  peek<T>(offset = 0): T {
+    return this.stack.get<T>(this.sp - offset);
+  }
+
+  get<T>(offset: number, base = this.fp): T {
+    return this.stack.get<T>(base + offset);
+  }
+
+  set(value: Opaque, offset: number, base = this.fp) {
+    this.stack.update(base + offset, value);
+  }
+
+  slice(start: number, end: number): CapturedStack {
+    return this.stack.slice(start, end);
+  }
+
+  sliceArray<T = Opaque>(start: number, end: number): T[] {
+    return this.stack.sliceInner(start, end);
+  }
+
+  capture(items: number): CapturedStack {
+    let end = this.sp + 1;
+    let start = end - items;
+    return this.stack.slice(start, end);
+  }
+
+  reset() {
+    this.stack.reset();
+  }
+
+  toArray() {
+    return this.stack.slice(this.fp, this.sp + 1);
+  }
+}

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -135,6 +135,10 @@ export default class EvaluationStack {
     return this.stack.get<T>(this.sp - offset);
   }
 
+  peekSmi(offset = 0): number {
+    return this.stack.getSmi(this.sp - offset);
+  }
+
   get<T>(offset: number, base = this.fp): T {
     return this.stack.get<T>(base + offset);
   }

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -23,13 +23,17 @@ export class InnerStack {
     return out;
   }
 
+  copy(from: number, to: number): void {
+    this.inner[to] = this.inner[from];
+  }
+
   update(pos: number, value: Opaque): void {
-    if (typeof value === 'number' && !(value & HI)) {
+    if (typeof value === 'number' && !((value as number) & HI)) {
       this.inner[pos] = value;
-      this.js[pos] = null;
     } else {
-      this.inner[pos] = pos | HI;
-      this.js[pos] = value;
+      let idx = this.js.length;
+      this.js.push(value);
+      this.inner[pos] = idx | HI;
     }
   }
 
@@ -78,7 +82,11 @@ export default class EvaluationStack {
   }
 
   dup(position = this.sp): void {
-    this.push(this.stack.get(position));
+    this.stack.copy(position, ++this.sp);
+  }
+
+  copy(from: number, to: number): void {
+    this.stack.copy(from, to);
   }
 
   pop<T>(n = 1): T {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -20,7 +20,7 @@ import {
 } from '@glimmer/reference';
 import { UpdatingOpcode, UpdatingOpSeq } from '../opcodes';
 import { DOMChanges } from '../dom/helper';
-import { Simple, VMHandle } from '@glimmer/interfaces';
+import { Simple } from '@glimmer/interfaces';
 
 import EvaluationStack from './stack';
 import VM from './append';
@@ -98,7 +98,7 @@ export abstract class BlockOpcode extends UpdatingOpcode implements DestroyableB
 
   protected bounds: DestroyableBounds;
 
-  constructor(public start: VMHandle, protected state: VMState, bounds: DestroyableBounds, children: LinkedList<UpdatingOpcode>) {
+  constructor(public start: number, protected state: VMState, bounds: DestroyableBounds, children: LinkedList<UpdatingOpcode>) {
     super();
 
     this.children = children;
@@ -141,7 +141,7 @@ export class TryOpcode extends BlockOpcode implements ExceptionHandler {
 
   protected bounds: UpdatableTracker;
 
-  constructor(start: VMHandle, state: VMState, bounds: UpdatableTracker, children: LinkedList<UpdatingOpcode>) {
+  constructor(start: number, state: VMState, bounds: UpdatableTracker, children: LinkedList<UpdatingOpcode>) {
     super(start, state, bounds, children);
     this.tag = this._tag = UpdatableTag.create(CONSTANT_TAG);
   }
@@ -266,7 +266,7 @@ export class ListBlockOpcode extends BlockOpcode {
   private lastIterated: Revision = INITIAL;
   private _tag: TagWrapper<UpdatableTag>;
 
-  constructor(start: VMHandle, state: VMState, bounds: Tracker, children: LinkedList<UpdatingOpcode>, artifacts: IterationArtifacts) {
+  constructor(start: number, state: VMState, bounds: Tracker, children: LinkedList<UpdatingOpcode>, artifacts: IterationArtifacts) {
     super(start, state, bounds, children);
     this.artifacts = artifacts;
     let _tag = this._tag = UpdatableTag.create(CONSTANT_TAG);

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -22,7 +22,8 @@ import { UpdatingOpcode, UpdatingOpSeq } from '../opcodes';
 import { DOMChanges } from '../dom/helper';
 import { Simple, VMHandle } from '@glimmer/interfaces';
 
-import VM, { CapturedStack, EvaluationStack } from './append';
+import EvaluationStack, { CapturedStack } from './stack';
+import VM from './append';
 import { RuntimeConstants as Constants, RuntimeProgram as Program } from "@glimmer/program";
 
 export default class UpdatingVM<TemplateMeta = Opaque> {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -69,7 +69,7 @@ export default class UpdatingVM<TemplateMeta = Opaque> {
   }
 
   try(ops: UpdatingOpSeq, handler: Option<ExceptionHandler>) {
-    this.frameStack.push(new UpdatingVMFrame(this, ops, handler));
+    this.frameStack.push(new UpdatingVMFrame(ops, handler));
   }
 
   throw() {
@@ -318,7 +318,7 @@ export class ListBlockOpcode extends BlockOpcode {
 class UpdatingVMFrame {
   private current: Option<UpdatingOpcode>;
 
-  constructor(private vm: UpdatingVM<Opaque>, private ops: UpdatingOpSeq, private exceptionHandler: Option<ExceptionHandler>) {
+  constructor(private ops: UpdatingOpSeq, private exceptionHandler: Option<ExceptionHandler>) {
     this.current = ops.head();
   }
 

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -22,7 +22,7 @@ import { UpdatingOpcode, UpdatingOpSeq } from '../opcodes';
 import { DOMChanges } from '../dom/helper';
 import { Simple, VMHandle } from '@glimmer/interfaces';
 
-import EvaluationStack, { CapturedStack } from './stack';
+import EvaluationStack from './stack';
 import VM from './append';
 import { RuntimeConstants as Constants, RuntimeProgram as Program } from "@glimmer/program";
 
@@ -87,7 +87,7 @@ export interface VMState {
   program: Program<Opaque>;
   scope: Scope;
   dynamicScope: DynamicScope;
-  stack: CapturedStack;
+  stack: Opaque[];
 }
 
 export abstract class BlockOpcode extends UpdatingOpcode implements DestroyableBounds {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -319,8 +319,6 @@ class UpdatingVMFrame {
   private current: Option<UpdatingOpcode>;
 
   constructor(private vm: UpdatingVM<Opaque>, private ops: UpdatingOpSeq, private exceptionHandler: Option<ExceptionHandler>) {
-    this.vm = vm;
-    this.ops = ops;
     this.current = ops.head();
   }
 

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/runtime",
   "license": "MIT",
   "dependencies": {
+    "@glimmer/low-level": "^0.30.3",
     "@glimmer/util": "^0.30.3",
     "@glimmer/reference": "^0.30.3",
     "@glimmer/object": "^0.30.3",

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
@@ -1,5 +1,5 @@
 import { WrappedBuilder } from '@glimmer/opcode-compiler';
-import { Option, Opaque, ProgramSymbolTable, ComponentCapabilities, Recast, VMHandle } from '@glimmer/interfaces';
+import { Option, Opaque, ProgramSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
 import GlimmerObject from '@glimmer/object';
 import { Tag, combine, PathReference, TagWrapper, DirtyableTag } from '@glimmer/reference';
 import { EMPTY_ARRAY, assign, Destroyable, expect } from '@glimmer/util';
@@ -86,7 +86,7 @@ export class EmberishCurlyComponentManager implements
   getLayout(state: EmberishCurlyComponentDefinitionState, resolver: EagerRuntimeResolver): Invocation {
     let handle = resolver.getVMHandle(expect(state.locator, 'expected locator'));
     return {
-      handle: handle as Recast<number, VMHandle>,
+      handle,
       symbolTable: state.symbolTable! as ProgramSymbolTable
     };
   }

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -15,7 +15,7 @@ import {
 import { DebugConstants, BundleCompiler, ModuleLocatorMap, ModuleLocator } from '@glimmer/bundle-compiler';
 import { Opaque, assert, Dict, assign, expect, Option } from '@glimmer/util';
 import { WriteOnlyProgram, RuntimeProgram, RuntimeConstants, Heap } from '@glimmer/program';
-import { ProgramSymbolTable, Recast, VMHandle, ComponentCapabilities } from '@glimmer/interfaces';
+import { ProgramSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
 import { UpdatableReference } from '@glimmer/object-reference';
 
 import RenderDelegate from '../../../render-delegate';
@@ -202,7 +202,7 @@ export default class EagerRenderDelegate implements RenderDelegate {
 
     let { heap, pool, table } = compiler.compile();
 
-    let handle = table.vmHandleByModuleLocator.get(locator)! as Recast<number, VMHandle>;
+    let handle = table.vmHandleByModuleLocator.get(locator)!;
     let { env } = this;
 
     let cursor = { element, nextSibling: null };

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/runtime-resolver.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/runtime-resolver.ts
@@ -1,4 +1,4 @@
-import { RuntimeResolver, ComponentDefinition, VMHandle, Recast, ProgramSymbolTable } from '@glimmer/interfaces';
+import { RuntimeResolver, ComponentDefinition, ProgramSymbolTable } from '@glimmer/interfaces';
 import { Opaque, Option, expect } from '@glimmer/util';
 import { Invocation } from "@glimmer/runtime";
 import { ExternalModuleTable, ModuleLocatorMap, ModuleLocator } from '@glimmer/bundle-compiler';
@@ -49,8 +49,8 @@ export default class EagerRuntimeResolver implements RuntimeResolver<TemplateMet
     };
   }
 
-  getVMHandle(locator: ModuleLocator): VMHandle {
+  getVMHandle(locator: ModuleLocator): number {
     let handle = expect(this.table.vmHandleByModuleLocator.get(locator), `could not find handle for module ${locator}`);
-    return handle as Recast<number, VMHandle>;
+    return handle;
   }
 }


### PR DESCRIPTION
> I don't think we should merge this until we make a few more improvements, at least the first two on the list of improvements below.

After this change, the main stack is an array of u32s. If a u32 is pushed onto the stack, it is treated as an immediate and stored directly. If any other value is pushed onto the stack, it is pushed onto a secondary array of JavaScript values, and it's stored as a pointer (a u32 offset with the high bit set).

When getting a value from the stack, if the high bit is set, the value is loaded from the JavaScript stack, otherwise the immediate is returned.

The goal of this work is to allow more of the VM to operate inside of wasm-ish code (operating on numbers and simple data structures). The endgame is to cleanly separate between normal VM operations (jumps, pushes, pops, dups, etc.) and specialized VM operations that work with JS objects ("syscalls") and to try to do a lot of contiguous work inside the VM, and batch work that requires syscalls.

There are many additional improvements I plan to make on top of this work:

- operations like dup() currently dereference the pointer and push it back onto the stack. This both requires the VM to unnecessarily work with JavaScript objects and also is wasteful in terms of work. It would be straight forward to modify dup() to duplicate the pointer directly and not worry about the JS stack.
- A number of simple values (null, undefined, true, false) are already encoded in the VM as u32s in some places. Today, since they are not u32s, they become pointers into the JavaScript stack. We should beef up the tagged pointer system to support more values as immediates.
- Avoid pushing null onto the JS stack when the value is an immediate. This is a temporary hack so I don't need to decide the allocation strategy for the JS stack. Two options:
  1. since appending is a bounded operation, just use a single arena for the entire append process
  2. split up the fp into a u16 pointer into the u32 stack and a u16 pointer into the js stack. This wouldn't require us to do anything in JS at the point where we popped the stack, it would just allow us to reuse slots in the JS stack throughout the appending process.

Without these improvements, there are already ~10,000 immediates on the stack in the test suite, compared to ~30,000 pointers (in large part because there's a decent amount of stack management around frames that is purely numeric).
