### PR TITLE
[Cleanup] Remove top-level invocations

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -8,7 +8,7 @@ import { Statement, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { DEBUG } from '@glimmer/local-debug-flags';
 import { debugSlice } from './debug';
 import { CompilableTemplate as ICompilableTemplate, ParsedLayout } from './interfaces';
-import { CompileOptions, compileStatement } from './syntax';
+import { CompileOptions, statementCompiler, Compilers } from './syntax';
 
 export { ICompilableTemplate };
 
@@ -24,7 +24,11 @@ export default class CompilableTemplate<S extends SymbolTable, Specifier> implem
 
   private compiled: Option<VMHandle> = null;
 
-  constructor(private statements: Statement[], private containingLayout: ParsedLayout, private options: CompileOptions<Specifier>, public symbolTable: S) {}
+  private statementCompiler: Compilers<Statement>;
+
+  constructor(private statements: Statement[], private containingLayout: ParsedLayout, private options: CompileOptions<Specifier>, public symbolTable: S) {
+    this.statementCompiler = statementCompiler();
+  }
 
   compile(): VMHandle {
     let { compiled } = this;
@@ -37,7 +41,7 @@ export default class CompilableTemplate<S extends SymbolTable, Specifier> implem
     let builder = new Builder(program, lookup, referrer, macros, containingLayout, asPartial);
 
     for (let i = 0; i < statements.length; i++) {
-      compileStatement(statements[i], builder);
+      this.statementCompiler.compile(statements[i], builder);
     }
 
     let handle = builder.commit(program.heap);

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -132,8 +132,8 @@ STATEMENTS.add(Ops.Append, (sexp: S.Append, builder) => {
 
   if (returned === true) return;
 
-  let isGet = E.isGet(value);
-  let isMaybeLocal = E.isMaybeLocal(value);
+  let isGet = WireFormat.isGet(value);
+  let isMaybeLocal = WireFormat.isMaybeLocal(value);
 
   if (trusting) {
     builder.guardedAppend(value, true);

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -82,23 +82,6 @@ export namespace Expressions {
     [2]: Params;
     [3]: Hash;
   }
-
-  export const isUnknown        = is<Unknown>(Opcodes.Unknown);
-  export const isGet            = is<Get>(Opcodes.Get);
-  export const isConcat         = is<Concat>(Opcodes.Concat);
-  export const isHelper         = is<Helper>(Opcodes.Helper);
-  export const isHasBlock       = is<HasBlock>(Opcodes.HasBlock);
-  export const isHasBlockParams = is<HasBlockParams>(Opcodes.HasBlockParams);
-  export const isUndefined      = is<Undefined>(Opcodes.Undefined);
-  export const isClientSide     = is<ClientSide>(Opcodes.ClientSideExpression);
-  export const isMaybeLocal     = is<MaybeLocal>(Opcodes.MaybeLocal);
-
-  export function isPrimitiveValue(value: any): value is Value {
-    if (value === null) {
-      return true;
-    }
-    return typeof value !== 'object';
-  }
 }
 
 export type Expression = Expressions.Expression;
@@ -132,27 +115,6 @@ export namespace Statements {
   export type Debugger      = [Opcodes.Debugger, Core.EvalInfo];
   export type ClientSide    = [Opcodes.ClientSideStatement, any];
 
-  export const isText         = is<Text>(Opcodes.Text);
-  export const isAppend       = is<Append>(Opcodes.Append);
-  export const isComment      = is<Comment>(Opcodes.Comment);
-  export const isModifier     = is<Modifier>(Opcodes.Modifier);
-  export const isBlock        = is<Block>(Opcodes.Block);
-  export const isComponent    = is<Component>(Opcodes.Component);
-  export const isOpenElement  = is<OpenElement>(Opcodes.OpenElement);
-  export const isSplatElement = is<SplatElement>(Opcodes.OpenSplattedElement);
-  export const isFlushElement = is<FlushElement>(Opcodes.FlushElement);
-  export const isCloseElement = is<CloseElement>(Opcodes.CloseElement);
-  export const isStaticAttr   = is<StaticAttr>(Opcodes.StaticAttr);
-  export const isDynamicAttr  = is<DynamicAttr>(Opcodes.DynamicAttr);
-  export const isAttrSplat    = is<AttrSplat>(Opcodes.AttrSplat);
-  export const isYield        = is<Yield>(Opcodes.Yield);
-  export const isPartial      = is<Partial>(Opcodes.Partial);
-  export const isDynamicArg   = is<DynamicArg>(Opcodes.DynamicArg);
-  export const isStaticArg    = is<StaticArg>(Opcodes.StaticArg);
-  export const isTrustingAttr = is<TrustingAttr>(Opcodes.TrustingAttr);
-  export const isDebugger     = is<Debugger>(Opcodes.Debugger);
-  export const isClientSide   = is<ClientSide>(Opcodes.ClientSideStatement);
-
   export type Statement =
       Text
     | Append
@@ -182,24 +144,12 @@ export namespace Statements {
     | Statements.AttrSplat
     ;
 
-  export function isAttribute(val: Statement): val is Attribute {
-    return val[0] === Opcodes.StaticAttr || val[0] === Opcodes.DynamicAttr || val[0] === Opcodes.TrustingAttr;
-  }
-
   export type Argument =
       Statements.StaticArg
     | Statements.DynamicArg
     ;
 
-  export function isArgument(val: Statement): val is Argument {
-    return val[0] === Opcodes.StaticArg || val[0] === Opcodes.DynamicArg;
-  }
-
   export type Parameter = Attribute | Argument;
-
-  export function isParameter(val: Statement): val is Parameter {
-    return isAttribute(val) || isArgument(val);
-  }
 }
 
 export type Statement = Statements.Statement;
@@ -258,3 +208,19 @@ export interface SerializedTemplateWithLazyBlock<Specifier> {
  * concatenated into a Javascript module.
  */
 export type TemplateJavascript = string;
+
+// Statements
+export const isModifier       = is<Statements.Modifier>(Opcodes.Modifier);
+export const isFlushElement   = is<Statements.FlushElement>(Opcodes.FlushElement);
+
+export function isAttribute(val: Statement): val is Statements.Attribute {
+  return val[0] === Opcodes.StaticAttr || val[0] === Opcodes.DynamicAttr || val[0] === Opcodes.TrustingAttr;
+}
+
+export function isArgument(val: Statement): val is Statements.Argument {
+  return val[0] === Opcodes.StaticArg || val[0] === Opcodes.DynamicArg;
+}
+
+// Expressions
+export const isGet            = is<Expressions.Get>(Opcodes.Get);
+export const isMaybeLocal     = is<Expressions.MaybeLocal>(Opcodes.MaybeLocal);


### PR DESCRIPTION
**TL;DR: We can't have top-level invokes if we want tree shaking**

After investigating why @glimmer/syntax and the opcode builder was being retained it turned out that it's because typescript namespaces compile into a top level iifee. Rollup cannot determine the side effects so it just [inlines it](https://tinyurl.com/ybe4n2st). So this PR initially was intended to remove the namespaces, however it turned out that a lot of the functions in the namespace were actually dead code. This moves the functions out of the namespace and removes all the unused functions.

This also refactors the all of the `STATEMENT` and `EXPRESSION` compilers so they are not top-level but still cache.