### PR TITLE
Don't infer the return type of the builder factories

### DIFF
--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -96,6 +96,6 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
   }
 }
 
-export function serializeBuilder(env: Environment, cursor: { element: Simple.Element, nextSibling: Option<Simple.Node> }) {
+export function serializeBuilder(env: Environment, cursor: { element: Simple.Element, nextSibling: Option<Simple.Node> }): ElementBuilder {
   return SerializeBuilder.forInitialRender(env, cursor);
 }

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -573,6 +573,6 @@ class BlockListTracker implements Tracker {
   }
 }
 
-export function clientBuilder(env: Environment, cursor: Cursor) {
+export function clientBuilder(env: Environment, cursor: Cursor): ElementBuilder {
   return NewElementBuilder.forInitialRender(env, cursor);
 }

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -430,6 +430,6 @@ function findByName(array: Simple.Attribute[], name: string): Simple.Attribute |
   return undefined;
 }
 
-export function rehydrationBuilder(env: Environment, cursor: Cursor) {
+export function rehydrationBuilder(env: Environment, cursor: Cursor): ElementBuilder {
   return RehydrateBuilder.forInitialRender(env, cursor);
 }


### PR DESCRIPTION
In Glimmer.js, we [wrap these](https://github.com/glimmerjs/glimmer.js/blob/master/packages/%40glimmer/application/src/builders/rehydrating-builder.ts) so an application can choose how to build/rehydrate DOM. These return types need to be widened to the generic type so we don't get errors about have the specific instance types. 