### PR TITLE
[BUGFIX beta] Fix range element reporting wrong initial value

### DIFF
--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -1,7 +1,7 @@
 import TemplateVisitor, { SymbolTable, Action } from "./template-visitor";
 import JavaScriptCompiler, { Template } from "./javascript-compiler";
 import { Stack } from "@glimmer/util";
-import { assert, expect } from "@glimmer/util";
+import { assert, expect, Option } from "@glimmer/util";
 import { AST, isLiteral, SyntaxError } from '@glimmer/syntax';
 import { getAttrNamespace } from './utils';
 import { Opaque } from "@glimmer/interfaces";
@@ -95,8 +95,18 @@ export default class TemplateCompiler {
       this.opcode('openElement', action, action);
     }
 
-    for (let i = 0; i < action.attributes.length; i++) {
-      this.attribute([action.attributes[i]]);
+    let typeAttr : Option<AST.AttrNode> = null;
+    let attrs = action.attributes;
+    for (let i = 0; i < attrs.length; i++) {
+      if (attrs[i].name === 'type') {
+        typeAttr = attrs[i];
+        continue;
+      }
+      this.attribute([attrs[i]]);
+    }
+
+    if (typeAttr) {
+      this.attribute([typeAttr]);
     }
 
     for (let i = 0; i < action.modifiers.length; i++) {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -310,7 +310,22 @@ export class ComponentElementOperations {
         reference = new ClassListReference(this.classes);
       }
 
+      if (name === 'type') {
+        continue;
+      }
+
       let attribute = vm.elements().setDynamicAttribute(name, reference.value(), trusting, namespace);
+
+      if (!isConst(reference)) {
+        vm.updateWith(new UpdateDynamicAttributeOpcode(reference, attribute));
+      }
+    }
+
+    if ('type' in this.attributes) {
+      let type = this.attributes.type;
+      let { value: reference, namespace, trusting } = type;
+
+      let attribute = vm.elements().setDynamicAttribute('type', reference.value(), trusting, namespace);
 
       if (!isConst(reference)) {
         vm.updateWith(new UpdateDynamicAttributeOpcode(reference, attribute));

--- a/packages/@glimmer/runtime/test/attributes-test.ts
+++ b/packages/@glimmer/runtime/test/attributes-test.ts
@@ -3,7 +3,7 @@ import { SVG_NAMESPACE, normalizeProperty } from '@glimmer/runtime';
 import { ConstReference, PathReference } from "@glimmer/reference";
 import { Opaque } from '@glimmer/util';
 
-class AttributesTests extends RenderTest {
+export class AttributesTests extends RenderTest {
 
   protected readDOMAttr(attr : string, element = this.element.firstChild as Element) {
     let isSVG = element.namespaceURI === SVG_NAMESPACE;

--- a/packages/@glimmer/runtime/test/input-range-test.ts
+++ b/packages/@glimmer/runtime/test/input-range-test.ts
@@ -1,0 +1,175 @@
+import {AttributesTests} from './attributes-test';
+import { module, test, EmberishCurlyComponent, EmberishCurlyComponentFactory, TestEnvironment } from '@glimmer/test-helpers';
+import { EmberishRootView } from '@glimmer/runtime/test/ember-component-test';
+
+abstract class RangeTests extends AttributesTests {
+  min = -5;
+  max = 50;
+
+  abstract renderRange(value : number) : void;
+  abstract assertRangeValue(value : number) : void;
+  setup() {
+
+  }
+
+  @test 'value over default max but below set max is kept'() {
+    this.setup();
+    this.renderRange(25);
+    this.assertRangeValue(25);
+  }
+
+  @test 'value below default min but above set min is kept'() {
+    this.setup();
+    this.renderRange(-2);
+    this.assertRangeValue(-2);
+  }
+
+  @test 'in the valid default range is kept'() {
+    this.setup();
+    this.renderRange(5);
+    this.assertRangeValue(5);
+  }
+
+  @test 'value above max is reset to max'() {
+    this.setup();
+    this.renderRange(55);
+    this.assertRangeValue(50);
+  }
+
+  @test 'value below min is reset to min'() {
+    this.setup();
+    this.renderRange(-10);
+    this.assertRangeValue(-5);
+  }
+}
+
+class TemplateRangeTests extends RangeTests {
+  attrs : string;
+
+  renderRange(value: number) {
+    this.render(`<input ${this.attrs} />`, {
+      max: this.max,
+      min: this.min,
+      value
+    });
+  }
+
+  assertRangeValue(value: number) {
+    this.assert.equal(this.readDOMAttr('value'), value.toString());
+  }
+}
+
+// These are the permutations/:s/.&&&& of the set
+// ['type="range"', 'min="-5" max="50"', 'value="%x"']
+permutations(['type="range"', 'min={{min}} max={{max}}', 'value={{value}}'])
+  .map(x => x.join(' '))
+  .forEach(attrs => {
+    module(`[emberjs/ember.js#15675] Template <input ${attrs} />`, class extends TemplateRangeTests {
+      attrs = attrs;
+    });
+});
+
+// Ember Components attributeBindings
+
+class EmberInputRangeComponent extends EmberishCurlyComponent {
+  tagName = 'input';
+  type = 'range';
+}
+
+abstract class EmberComponentRangeTests extends RangeTests {
+  env : TestEnvironment;
+  view : EmberishRootView;
+
+  setup() {
+    this.env = new TestEnvironment();
+  }
+
+  abstract component() : EmberishCurlyComponentFactory;
+
+  appendViewFor(template: string, context: Object = {}) {
+    this.view = new EmberishRootView(this.env, template, context);
+
+    this.env.begin();
+    this.view.appendTo('#qunit-fixture');
+    this.env.commit();
+  }
+
+  renderRange(value: number): void {
+    this.env.registerEmberishCurlyComponent('range-input', this.component(), '');
+    this.appendViewFor(`{{range-input max=max min=min value=value}}`, {
+      max: this.max,
+      min: this.min,
+      value
+    });
+  }
+  assertRangeValue(value: number): void {
+    let attr = this.view.element['value'];
+    this.assert.equal(attr, value.toString());
+  }
+}
+
+permutations(['type', 'min', 'max', 'value']).forEach(attrs => {
+  module(`Components - [emberjs/ember.js#15675] - ${attrs.join(', ')}`,
+  class extends EmberComponentRangeTests {
+    component(): EmberishCurlyComponentFactory {
+      return class extends EmberInputRangeComponent {
+        attributeBindings = attrs;
+      };
+    }
+  });
+});
+
+class BasicComponentImplicitAttributesRangeTest extends RangeTests {
+  attrs: string;
+
+  renderRange(value: number): void {
+    this.registerComponent('Glimmer', 'RangeInput', '<input ...attributes/>');
+    this.render(`<RangeInput ${this.attrs.replace('%x', value.toString())} />`);
+  }
+
+  assertRangeValue(value: number): void {
+    let attr = this.readDOMAttr('value');
+    this.assert.equal(attr, value.toString());
+  }
+}
+
+permutations(['type="range"', 'min="-5" max="50"', 'value="%x"'])
+  .map(x => x.join(' '))
+  .forEach(attrs => {
+    module(`GlimmerComponent - [emberjs/ember.js#15675] ...attributes <input ${attrs} />`, class extends BasicComponentImplicitAttributesRangeTest {
+      attrs = attrs;
+    });
+  });
+
+function permutations<T>(coll : T[]) : T[][] {
+  if (coll.length <= 1) {
+    return [coll];
+  }
+
+  let result : T[][] = [];
+
+  for (let i = 0; i < coll.length; i++) {
+    let element = coll[i];
+    let subpermutations = permutations(arrayWithout(coll, i));
+
+    result.push(...subpermutations.map(x => [element].concat(x)));
+  }
+
+  return result;
+}
+
+function arrayWithout<T>(coll : T[], i : number) : T[] {
+  if (i < 0 || i >= coll.length) {
+    return coll;
+  }
+
+  if (i === 0) {
+    return coll.slice(1);
+  }
+
+  if (i === coll.length - 1) {
+    return coll.slice(0, i);
+  }
+
+  return coll.slice(0, i).concat(...coll.slice(i+1));
+}


### PR DESCRIPTION
If a template had an `input` `range` whose type was set before a max or a min
attribute was added, the initial value would be wrong.

In plain HTML, the initial value for `<input max="10" type="range" />` would be
`5` (`(min + max) / 2 = (0 + 10) / 2 = 5`).

In Glimmer, this would be 10 because the code would be equivalent to:

```js
let input = document.createElement('input');
input.type = "range";
input.max = "10";
```

Setting `type` to `range` would make the value sanitization algorihtm to kick
in, setting the value to 50. When setting the `max` to `10`, the algorithm
would sanitize the value (50 by now) to the maximum (10).

This was originally discussed in #425, but an alternative solution was
asked for. While this PR keeps part of the original implementation
(could not find a simple way to fix the issue when a template is being
rendered), this PR goes further and fixes it for Emberish components and
`...attributes` in Glimmer components.

More info in whatwg/html#2427
Fixes emberjs/ember.js#14958

While currently the tests contains all the permutations, the final state will only contain tests for the ordering `type`, `value`, `min max`.