### PR TITLE
[CLEANUP] Use correct environment

### DIFF
--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -42,7 +42,7 @@ export class EmberishRootView extends EmberObject {
     let templateIterator = this.template.renderLayout({
       env: this.env,
       self,
-      builder: clientBuilder(env, cursor),
+      builder: clientBuilder(this.env, cursor),
       dynamicScope: new TestDynamicScope()
     });
 


### PR DESCRIPTION
In `EmberishRootView` `appendTo` method two different `TestEnvironments`
are being used:

1. In `renderLayout`, the view `env` is being passed as `env` option.
2. In `clientBuilder`, the first parameter is the global `env` declared
   down below.