### PR TITLE
Unify eager and lazy compilation metadata semantics

### DIFF
--- a/packages/@glimmer/bundle-compiler/index.ts
+++ b/packages/@glimmer/bundle-compiler/index.ts
@@ -7,6 +7,7 @@ export {
 
 export {
   ModuleLocator,
+  AnnotatedModuleLocator,
   TemplateLocator,
   ModuleLocatorMap
 } from './lib/module-locators';

--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -91,7 +91,7 @@ export interface PartialTemplateLocator<TemplateMeta> extends ModuleLocator {
  * which is suitable for serialization into bytecode and JavaScript assets that
  * can be loaded and run in the browser.
  */
-export default class BundleCompiler<TemplateMeta = {}> {
+export default class BundleCompiler<TemplateMeta> {
   public compilableTemplates = new ModuleLocatorMap<
     ICompilableTemplate<ProgramSymbolTable>
   >();

--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -71,6 +71,11 @@ export interface BundleCompilationResult {
    * versa.
    */
   table: ExternalModuleTable;
+
+  /**
+   * A mapping of module locators to compiled template symbol tables.
+   */
+  symbolTables: ModuleLocatorMap<ProgramSymbolTable>;
 }
 
 export interface PartialTemplateLocator<TemplateMeta> extends ModuleLocator {
@@ -157,9 +162,11 @@ export default class BundleCompiler<TemplateMeta> {
     let builder = new SimpleOpcodeBuilder();
     builder.main();
     let main = builder.commit(this.program.heap, 0);
+    let symbolTables = new ModuleLocatorMap<ProgramSymbolTable>();
 
-    this.compilableTemplates.forEach((_, locator) => {
+    this.compilableTemplates.forEach((template, locator) => {
       this.compileTemplate(locator);
+      symbolTables.set(locator, template.symbolTable);
     });
 
     let { heap, constants } = this.program;
@@ -168,7 +175,8 @@ export default class BundleCompiler<TemplateMeta> {
       main: main as Recast<Unique<"Handle">, number>,
       heap: heap.capture() as SerializedHeap,
       pool: constants.toPool(),
-      table: this.table
+      table: this.table,
+      symbolTables
     };
   }
 

--- a/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
+++ b/packages/@glimmer/bundle-compiler/lib/compiler-delegate.ts
@@ -2,7 +2,7 @@ import { ProgramSymbolTable, ComponentCapabilities } from "@glimmer/interfaces";
 import { ICompilableTemplate, CompileOptions } from "@glimmer/opcode-compiler";
 import { SerializedTemplateBlock } from "@glimmer/wire-format";
 
-import { TemplateLocator, ModuleLocator } from "./module-locators";
+import { ModuleLocator } from "./module-locators";
 
 /**
  * A CompilerDelegate helps the BundleCompiler map external references it finds
@@ -30,7 +30,7 @@ import { TemplateLocator, ModuleLocator } from "./module-locators";
  * uses this information to perform additional optimizations during the
  * compilation phase.
  */
-export default interface CompilerDelegate<Meta = {}> {
+export default interface CompilerDelegate<TemplateMeta> {
   /**
    * During compilation, the compiler will ask the delegate about each component
    * invocation found in the passed template. If the component exists in scope,
@@ -40,7 +40,7 @@ export default interface CompilerDelegate<Meta = {}> {
    */
   hasComponentInScope(
     componentName: string,
-    referrer: TemplateLocator<Meta>
+    referrer: TemplateMeta
   ): boolean;
 
   /**
@@ -52,7 +52,7 @@ export default interface CompilerDelegate<Meta = {}> {
    */
   resolveComponent(
     componentName: string,
-    referrer: TemplateLocator<Meta>
+    referrer: TemplateMeta
   ): ModuleLocator;
 
   /**
@@ -61,7 +61,7 @@ export default interface CompilerDelegate<Meta = {}> {
    * a ComponentCapabilities descriptor.
    */
   getComponentCapabilities(
-    locator: TemplateLocator<Meta>
+    locator: TemplateMeta
   ): ComponentCapabilities;
 
   /**
@@ -70,9 +70,9 @@ export default interface CompilerDelegate<Meta = {}> {
    * set of templates to compile for the bundle.
    */
   getComponentLayout(
-    locator: TemplateLocator<Meta>,
+    locator: TemplateMeta,
     block: SerializedTemplateBlock,
-    options: CompileOptions<ModuleLocator>
+    options: CompileOptions<TemplateMeta>
   ): ICompilableTemplate<ProgramSymbolTable>;
 
   /**
@@ -90,13 +90,13 @@ export default interface CompilerDelegate<Meta = {}> {
    * `hasHelperInScope` returns `false`, the compiler will treat `currentTime`
    * as a value rather than a helper.
    */
-  hasHelperInScope(helperName: string, referrer: TemplateLocator<Meta>): boolean;
+  hasHelperInScope(helperName: string, referrer: TemplateMeta): boolean;
 
   /**
    * If the delegate returns `true` from `hasHelperInScope()`, the compiler will
    * next ask the delegate to provide a module locator corresponding to the helper function.
    */
-  resolveHelper(helperName: string, referrer: TemplateLocator<Meta>): ModuleLocator;
+  resolveHelper(helperName: string, referrer: TemplateMeta): ModuleLocator;
 
   /**
    * During compilation, the compiler will ask the delegate about each element
@@ -108,14 +108,14 @@ export default interface CompilerDelegate<Meta = {}> {
    * modifier does not exist in scope, return `false`. Note that returning
    * `false` will cause the compilation process to fail.
    */
-  hasModifierInScope(modifierName: string, referrer: TemplateLocator<Meta>): boolean;
+  hasModifierInScope(modifierName: string, referrer: TemplateMeta): boolean;
 
   /**
    * If the delegate returns `true` from `hasModifierInScope()`, the compiler
    * will next ask the delegate to provide a module locator corresponding to the
    * element modifier function.
    */
-  resolveModifier(modifierName: string, referrer: TemplateLocator<Meta>): ModuleLocator;
+  resolveModifier(modifierName: string, referrer: TemplateMeta): ModuleLocator;
 
   /**
    * During compilation, the compiler will ask the delegate about each partial
@@ -132,7 +132,7 @@ export default interface CompilerDelegate<Meta = {}> {
    * return `false` from `hasPartialInScope` to disable the feature entirely.
    * Components replace all use cases for partials with better performance.
    */
-  hasPartialInScope(partialName: string, referrer: TemplateLocator<Meta>): boolean;
+  hasPartialInScope(partialName: string, referrer: TemplateMeta): boolean;
 
   /**
    * If the delegate returns `true` from `hasPartialInScope()`, the compiler
@@ -141,6 +141,6 @@ export default interface CompilerDelegate<Meta = {}> {
    */
   resolvePartial(
     partialName: string,
-    referrer: TemplateLocator<Meta>
+    referrer: TemplateMeta
   ): ModuleLocator;
 };

--- a/packages/@glimmer/bundle-compiler/lib/external-module-table.ts
+++ b/packages/@glimmer/bundle-compiler/lib/external-module-table.ts
@@ -17,4 +17,23 @@ export default class ExternalModuleTable {
 
   public vmHandleByModuleLocator = new ModuleLocatorMap<number>();
   public byVMHandle = new Map<number, ModuleLocator>();
+
+  /**
+   * Returns the handle (unique integer id) for the provided module locator. If
+   * the locator has not been seen before, a new handle is assigned. Otherwise,
+   * the same handle is always returned for a given locator.
+   */
+  public handleForModuleLocator(locator: ModuleLocator): number {
+    let { byModuleLocator, byHandle } = this;
+
+    let handle = byModuleLocator.get(locator);
+
+    if (handle === undefined) {
+      handle = byHandle.size;
+      byHandle.set(handle, locator);
+      byModuleLocator.set(locator, handle);
+    }
+
+    return handle;
+  }
 }

--- a/packages/@glimmer/bundle-compiler/test/compiler-delegate-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/compiler-delegate-test.ts
@@ -1,4 +1,4 @@
-import { BundleCompiler, TemplateLocator } from '@glimmer/bundle-compiler';
+import { BundleCompiler, ModuleLocator } from '@glimmer/bundle-compiler';
 import { ComponentCapabilities, ProgramSymbolTable } from '@glimmer/interfaces';
 import { BASIC_CAPABILITIES } from '@glimmer/test-helpers';
 import { CompilableTemplate, CompileOptions, ICompilableTemplate } from '@glimmer/opcode-compiler';
@@ -8,20 +8,34 @@ const { test } = QUnit;
 
 QUnit.module("[glimmer-bundle-compiler] CompilerDelegate");
 
+type TemplateMeta = {
+  locator: ModuleLocator;
+};
+
+function locatorFor(locator: ModuleLocator) {
+  let { module, name } = locator;
+
+  return {
+    module,
+    name,
+    meta: { locator }
+  };
+}
+
 test("correct referrer is passed during component lookup", function(assert) {
-  let inScopeReferrers: TemplateLocator[] = [];
-  let resolveComponentReferrers: TemplateLocator[] = [];
+  let inScopeReferrers: TemplateMeta[] = [];
+  let resolveComponentReferrers: TemplateMeta[] = [];
 
   // This partial implementation of CompilerDelegate tracks what referrers are
-  // passed to hasComponentInScope and resolveComponentSpecifier so that they
+  // passed to hasComponentInScope and resolveComponent so that they
   // can be verified after compilation has finished.
   class TestDelegate {
-    hasComponentInScope(_componentName: string, referrer: TemplateLocator): boolean {
+    hasComponentInScope(_componentName: string, referrer: TemplateMeta): boolean {
       inScopeReferrers.push(referrer);
       return true;
     }
 
-    resolveComponent(componentName: string, referrer: TemplateLocator): TemplateLocator {
+    resolveComponent(componentName: string, referrer: TemplateMeta): ModuleLocator {
       resolveComponentReferrers.push(referrer);
       return { module: componentName, name: 'default' };
     }
@@ -30,25 +44,25 @@ test("correct referrer is passed during component lookup", function(assert) {
       return BASIC_CAPABILITIES;
     }
 
-    getComponentLayout(_locator: TemplateLocator, block: SerializedTemplateBlock, options: CompileOptions<TemplateLocator>): ICompilableTemplate<ProgramSymbolTable> {
+    getComponentLayout(_locator: ModuleLocator, block: SerializedTemplateBlock, options: CompileOptions<TemplateMeta>): ICompilableTemplate<ProgramSymbolTable> {
       return CompilableTemplate.topLevel(block, options);
     }
   }
 
   let bundleCompiler = new BundleCompiler(new TestDelegate() as any);
 
-  bundleCompiler.add({ module: 'UserNav', name: 'default' }, '<div class="user-nav"></div>');
-  bundleCompiler.add({ module: 'Main', name: 'default' }, '<UserNav />');
-  bundleCompiler.add({ module: 'SideBar', name: 'default' }, '<UserNav />');
+  bundleCompiler.add(locatorFor({ module: 'UserNav', name: 'default' }), '<div class="user-nav"></div>');
+  bundleCompiler.add(locatorFor({ module: 'Main', name: 'default' }), '<UserNav />');
+  bundleCompiler.add(locatorFor({ module: 'SideBar', name: 'default' }), '<UserNav />');
   bundleCompiler.compile();
 
   assert.deepEqual(inScopeReferrers, [
-    { module: 'Main', name: 'default' },
-    { module: 'SideBar', name: 'default' }
+    { locator: { module: 'Main', name: 'default' } },
+    { locator: { module: 'SideBar', name: 'default' } }
   ]);
 
   assert.deepEqual(resolveComponentReferrers, [
-    { module: 'Main', name: 'default' },
-    { module: 'SideBar', name: 'default' }
+    { locator: { module: 'Main', name: 'default' } },
+    { locator: { module: 'SideBar', name: 'default' } }
   ]);
 });

--- a/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
@@ -1,12 +1,12 @@
 import { module, test, EagerTestEnvironment } from "@glimmer/test-helpers";
-import { BundleCompiler, CompilerDelegate, TemplateLocator } from "@glimmer/bundle-compiler";
+import { BundleCompiler, CompilerDelegate } from "@glimmer/bundle-compiler";
 import { RuntimeResolver, ComponentCapabilities, Option, VMHandle, Recast } from "@glimmer/interfaces";
 import { RuntimeProgram } from "@glimmer/program";
 import { LowLevelVM, NewElementBuilder, ComponentManager, MINIMAL_CAPABILITIES, ARGS, UNDEFINED_REFERENCE, PrimitiveReference } from "@glimmer/runtime";
 import { CONSTANT_TAG, VersionedPathReference, Tag } from "@glimmer/reference";
 import { Destroyable } from "@glimmer/util";
 
-class TestCompilerDelegate implements CompilerDelegate {
+class TestCompilerDelegate implements CompilerDelegate<{}> {
   hasComponentInScope(): boolean {
     return false;
   }
@@ -48,7 +48,7 @@ class TestCompilerDelegate implements CompilerDelegate {
   }
 }
 
-class SimpleResolver implements RuntimeResolver<TemplateLocator> {
+class SimpleResolver implements RuntimeResolver<{}> {
   lookupComponent(): never {
     throw new Error("Method not implemented.");
   }

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -12,9 +12,9 @@ import { CompileOptions, statementCompiler, Compilers } from './syntax';
 
 export { ICompilableTemplate };
 
-export default class CompilableTemplate<S extends SymbolTable, Specifier> implements ICompilableTemplate<S> {
-  static topLevel<Specifier>(block: SerializedTemplateBlock, options: CompileOptions<Specifier>): ICompilableTemplate<ProgramSymbolTable> {
-    return new CompilableTemplate<ProgramSymbolTable, Specifier>(
+export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> implements ICompilableTemplate<S> {
+  static topLevel<TemplateMeta>(block: SerializedTemplateBlock, options: CompileOptions<TemplateMeta>): ICompilableTemplate<ProgramSymbolTable> {
+    return new CompilableTemplate<ProgramSymbolTable, TemplateMeta>(
       block.statements,
       { block, referrer: options.referrer },
       options,
@@ -26,7 +26,7 @@ export default class CompilableTemplate<S extends SymbolTable, Specifier> implem
 
   private statementCompiler: Compilers<Statement>;
 
-  constructor(private statements: Statement[], private containingLayout: ParsedLayout, private options: CompileOptions<Specifier>, public symbolTable: S) {
+  constructor(private statements: Statement[], private containingLayout: ParsedLayout, private options: CompileOptions<TemplateMeta>, public symbolTable: S) {
     this.statementCompiler = statementCompiler();
   }
 

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -14,7 +14,7 @@ export interface EagerResolver<Locator> {
   getCapabilities(locator: Locator): ComponentCapabilities;
 }
 
-export interface EagerCompilationOptions<Specifier, R extends EagerResolver<Specifier>> {
+export interface EagerCompilationOptions<TemplateMeta, R extends EagerResolver<TemplateMeta>> {
   resolver: R;
   program: CompileTimeProgram;
   macros: Macros;
@@ -30,14 +30,14 @@ export type CompilableBlock = CompilableTemplate<BlockSymbolTable>;
 export type Primitive = undefined | null | boolean | number | string;
 
 export type ComponentArgs = [Core.Params, Core.Hash, Option<CompilableBlock>, Option<CompilableBlock>];
-export type Specifier = Opaque;
+export type TemplateMeta = Opaque;
 
 export interface ComponentBuilder {
   static(definition: number, args: ComponentArgs): void;
 }
 
-export interface ParsedLayout<Specifier = Opaque> {
+export interface ParsedLayout<TemplateMeta = Opaque> {
   id?: Option<string>;
   block: SerializedTemplateBlock;
-  referrer: Specifier;
+  referrer: TemplateMeta;
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -68,7 +68,7 @@ export interface AbstractTemplate<S extends SymbolTable = SymbolTable> {
   symbolTable: S;
 }
 
-export interface CompileTimeLookup<Locator> {
+export interface CompileTimeLookup<TemplateMeta> {
   getCapabilities(handle: number): ComponentCapabilities;
   getLayout(handle: number): Option<ICompilableTemplate<ProgramSymbolTable>>;
 
@@ -76,10 +76,10 @@ export interface CompileTimeLookup<Locator> {
   // produce any actual objects. The main use-case for producing objects is handled above,
   // with getCapabilities and getLayout, which drastically shrinks the size of the object
   // that the core interface is forced to reify.
-  lookupHelper(name: string, referrer: Locator): Option<number>;
-  lookupModifier(name: string, referrer: Locator): Option<number>;
-  lookupComponentDefinition(name: string, referrer: Locator): Option<number>;
-  lookupPartial(name: string, referrer: Locator): Option<number>;
+  lookupHelper(name: string, referrer: TemplateMeta): Option<number>;
+  lookupModifier(name: string, referrer: TemplateMeta): Option<number>;
+  lookupComponentDefinition(name: string, referrer: TemplateMeta): Option<number>;
+  lookupPartial(name: string, referrer: TemplateMeta): Option<number>;
 }
 
 export interface Blocks {
@@ -89,12 +89,12 @@ export interface Blocks {
 }
 
 export interface OpcodeBuilderConstructor {
-  new<Specifier>(program: CompileTimeProgram,
-      lookup: CompileTimeLookup<Specifier>,
+  new<TemplateMeta>(program: CompileTimeProgram,
+      lookup: CompileTimeLookup<TemplateMeta>,
       meta: Opaque,
       macros: Macros,
       containingLayout: ParsedLayout,
-      asPartial: boolean): OpcodeBuilder<Specifier>;
+      asPartial: boolean): OpcodeBuilder<TemplateMeta>;
 }
 
 export class SimpleOpcodeBuilder {
@@ -978,7 +978,7 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
 
 export default OpcodeBuilder;
 
-export class LazyOpcodeBuilder<Specifier> extends OpcodeBuilder<Specifier> {
+export class LazyOpcodeBuilder<TemplateMeta> extends OpcodeBuilder<TemplateMeta> {
   public constants: CompileTimeLazyConstants;
 
   pushBlock(block: Option<CompilableBlock>): void {
@@ -993,7 +993,7 @@ export class LazyOpcodeBuilder<Specifier> extends OpcodeBuilder<Specifier> {
     this.push(Op.CompileBlock);
   }
 
-  pushLayout(layout: Option<CompilableTemplate<ProgramSymbolTable, Specifier>>) {
+  pushLayout(layout: Option<CompilableTemplate<ProgramSymbolTable, TemplateMeta>>) {
     if (layout) {
       this.pushOther(layout);
     } else {
@@ -1020,7 +1020,7 @@ export class LazyOpcodeBuilder<Specifier> extends OpcodeBuilder<Specifier> {
   }
 }
 
-export class EagerOpcodeBuilder<Specifier> extends OpcodeBuilder<Specifier> {
+export class EagerOpcodeBuilder<TemplateMeta> extends OpcodeBuilder<TemplateMeta> {
   pushBlock(block: Option<ICompilableTemplate<BlockSymbolTable>>): void {
     let handle = block ? block.compile() as Recast<VMHandle, number> : null;
     this.primitive(handle);
@@ -1030,7 +1030,7 @@ export class EagerOpcodeBuilder<Specifier> extends OpcodeBuilder<Specifier> {
     return;
   }
 
-  pushLayout(layout: Option<CompilableTemplate<ProgramSymbolTable, Specifier>>): void {
+  pushLayout(layout: Option<CompilableTemplate<ProgramSymbolTable, TemplateMeta>>): void {
     if (layout) {
       this.primitive(layout.compile() as Recast<VMHandle, number>);
     } else {

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -16,11 +16,11 @@ import { ATTRS_BLOCK } from './syntax';
 import { DEBUG } from "@glimmer/local-debug-flags";
 import { EMPTY_ARRAY } from "@glimmer/util";
 
-export class WrappedBuilder<Specifier> implements ICompilableTemplate<ProgramSymbolTable> {
+export class WrappedBuilder<TemplateMeta> implements ICompilableTemplate<ProgramSymbolTable> {
   public symbolTable: ProgramSymbolTable;
-  private referrer: Specifier;
+  private referrer: TemplateMeta;
 
-  constructor(public options: CompileOptions<Specifier>, private layout: ParsedLayout<Specifier>, private capabilities: ComponentCapabilities) {
+  constructor(public options: CompileOptions<TemplateMeta>, private layout: ParsedLayout<TemplateMeta>, private capabilities: ComponentCapabilities) {
     let { block } = layout;
     let referrer = this.referrer = layout.referrer;
 
@@ -114,14 +114,14 @@ export class WrappedBuilder<Specifier> implements ICompilableTemplate<ProgramSym
   }
 }
 
-function blockFor<Specifier>(layout: ParsedLayout, options: CompileOptions<Specifier>): CompilableTemplate<BlockSymbolTable, Specifier> {
+function blockFor<TemplateMeta>(layout: ParsedLayout, options: CompileOptions<TemplateMeta>): CompilableTemplate<BlockSymbolTable, TemplateMeta> {
   let { block, referrer } = layout;
 
   return new CompilableTemplate(block.statements, layout, options, { referrer, parameters: EMPTY_ARRAY });
 }
 
-export class ComponentBuilder<Specifier> implements IComponentBuilder {
-  constructor(private builder: OpcodeBuilder<Specifier>) {}
+export class ComponentBuilder<TemplateMeta> implements IComponentBuilder {
+  constructor(private builder: OpcodeBuilder<TemplateMeta>) {}
 
   static(handle: number, args: ComponentArgs) {
     let [params, hash, _default, inverse] = args;

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -122,7 +122,7 @@ export class WriteOnlyConstants implements CompileTimeConstants {
   }
 }
 
-export class RuntimeConstants<Specifier> {
+export class RuntimeConstants<TemplateMeta> {
   protected strings: string[];
   protected arrays: number[][] | EMPTY_ARRAY;
   protected tables: SymbolTable[];
@@ -132,7 +132,7 @@ export class RuntimeConstants<Specifier> {
   protected floats: number[];
   protected negatives: number[];
 
-  constructor(public resolver: RuntimeResolver<Specifier>, pool: ConstantPool) {
+  constructor(public resolver: RuntimeResolver<TemplateMeta>, pool: ConstantPool) {
     this.strings = pool.strings;
     this.arrays = pool.arrays;
     this.tables = pool.tables;
@@ -194,8 +194,8 @@ export class RuntimeConstants<Specifier> {
   }
 }
 
-export class Constants<Specifier> extends WriteOnlyConstants {
-  constructor(public resolver: RuntimeResolver<Specifier>, pool?: ConstantPool) {
+export class Constants<TemplateMeta> extends WriteOnlyConstants {
+  constructor(public resolver: RuntimeResolver<TemplateMeta>, pool?: ConstantPool) {
     super();
 
     if (pool) {

--- a/packages/@glimmer/program/lib/internal.ts
+++ b/packages/@glimmer/program/lib/internal.ts
@@ -1,5 +1,5 @@
 import { Unique, RuntimeResolver as IResolver } from '@glimmer/interfaces';
 
-export type Specifier = Unique<'Specifier'>;
+export type TemplateMeta = Unique<'TemplateMeta'>;
 export type Referrer = Unique<'Referrer'>;
-export type Resolver = IResolver<Specifier>;
+export type Resolver = IResolver<TemplateMeta>;

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -198,10 +198,10 @@ export class WriteOnlyProgram implements CompileTimeProgram {
   }
 }
 
-export class RuntimeProgram<Specifier> {
+export class RuntimeProgram<TemplateMeta> {
   [key: number]: never;
 
-  static hydrate<Specifier>(rawHeap: SerializedHeap, pool: ConstantPool, resolver: RuntimeResolver<Specifier>) {
+  static hydrate<TemplateMeta>(rawHeap: SerializedHeap, pool: ConstantPool, resolver: RuntimeResolver<TemplateMeta>) {
     let heap = new Heap(rawHeap);
     let constants = new RuntimeConstants(resolver, pool);
 
@@ -210,7 +210,7 @@ export class RuntimeProgram<Specifier> {
 
   private _opcode: Opcode;
 
-  constructor(public constants: RuntimeConstants<Specifier>, public heap: Heap) {
+  constructor(public constants: RuntimeConstants<TemplateMeta>, public heap: Heap) {
     this._opcode = new Opcode(this.heap);
   }
 
@@ -220,8 +220,8 @@ export class RuntimeProgram<Specifier> {
   }
 }
 
-export class Program<Specifier> extends WriteOnlyProgram {
-  public constants: Constants<Specifier>;
+export class Program<TemplateMeta> extends WriteOnlyProgram {
+  public constants: Constants<TemplateMeta>;
 }
 
 function slice(arr: Uint16Array | number[], start: number, end: number) {

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -88,7 +88,7 @@ export interface WithDynamicTagName<Component> extends ComponentManager<Componen
   getTagName(component: Component): Option<string>;
 }
 
-export interface WithStaticLayout<ComponentInstanceState, ComponentDefinitionState, Specifier, R extends RuntimeResolver<Specifier>> extends ComponentManager<ComponentInstanceState, ComponentDefinitionState> {
+export interface WithStaticLayout<ComponentInstanceState, ComponentDefinitionState, TemplateMeta, R extends RuntimeResolver<TemplateMeta>> extends ComponentManager<ComponentInstanceState, ComponentDefinitionState> {
   getLayout(state: ComponentDefinitionState, resolver: R): Invocation;
 }
 
@@ -112,7 +112,7 @@ export function hasStaticLayout<D extends ComponentDefinitionState, I extends Co
   return manager.getCapabilities(state).dynamicLayout === false;
 }
 
-export interface WithDynamicLayout<Component, Specifier, R extends RuntimeResolver<Specifier>> extends ComponentManager<Component, Opaque> {
+export interface WithDynamicLayout<Component, TemplateMeta, R extends RuntimeResolver<TemplateMeta>> extends ComponentManager<Component, Opaque> {
   // Return the compiled layout to use for this component. This is called
   // *after* the component instance has been created, because you might
   // want to return a different layout per-instance for optimization reasons

--- a/packages/@glimmer/runtime/lib/component/resolve.ts
+++ b/packages/@glimmer/runtime/lib/component/resolve.ts
@@ -3,7 +3,7 @@ import { Option, assert } from '@glimmer/util';
 
 import { ComponentDefinition } from './interfaces';
 
-export function resolveComponent<Specifier>(resolver: RuntimeResolver<Specifier>, name: string, meta: Specifier): Option<ComponentDefinition> {
+export function resolveComponent<TemplateMeta>(resolver: RuntimeResolver<TemplateMeta>, name: string, meta: TemplateMeta): Option<ComponentDefinition> {
   let definition = resolver.lookupComponent(name, meta);
   assert(definition, `Could not find a component named "${name}"`);
   return definition as ComponentDefinition;

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -218,9 +218,9 @@ class Transaction {
   }
 }
 
-export interface CompilationOptions<Specifier, R extends RuntimeResolver<Specifier>> {
+export interface CompilationOptions<TemplateMeta, R extends RuntimeResolver<TemplateMeta>> {
   resolver: R;
-  program: Program<Specifier>;
+  program: Program<TemplateMeta>;
   macros: Macros;
   Builder: OpcodeBuilderConstructor;
 }

--- a/packages/@glimmer/runtime/lib/opcode-builder.ts
+++ b/packages/@glimmer/runtime/lib/opcode-builder.ts
@@ -11,11 +11,11 @@ import * as WireFormat from '@glimmer/wire-format';
 import { PublicVM } from './vm/append';
 import { RuntimeResolver } from "@glimmer/interfaces";
 
-export interface DynamicComponentDefinition<Specifier> {
+export interface DynamicComponentDefinition<TemplateMeta> {
   (
     vm: PublicVM,
     args: IArguments,
     meta: WireFormat.TemplateMeta,
-    resolver: RuntimeResolver<Specifier>
+    resolver: RuntimeResolver<TemplateMeta>
   ): VersionedPathReference<Option<BrandedComponentDefinition>>;
 }

--- a/packages/@glimmer/runtime/lib/references/curry-component.ts
+++ b/packages/@glimmer/runtime/lib/references/curry-component.ts
@@ -9,15 +9,15 @@ import { CurriedComponentDefinition, isCurriedComponentDefinition } from '../com
 import { resolveComponent } from '../component/resolve';
 import { UNDEFINED_REFERENCE } from '../references';
 
-export default class CurryComponentReference<Specifier> implements PathReference<Option<CurriedComponentDefinition>> {
+export default class CurryComponentReference<TemplateMeta> implements PathReference<Option<CurriedComponentDefinition>> {
   public tag: Tag;
   private lastValue: Opaque;
   private lastDefinition: Option<CurriedComponentDefinition>;
 
   constructor(
     private inner: Reference<Opaque>,
-    private resolver: RuntimeResolver<Specifier>,
-    private meta: Specifier,
+    private resolver: RuntimeResolver<TemplateMeta>,
+    private meta: TemplateMeta,
     private args: Option<ICapturedArguments>
   ) {
     this.tag = inner.tag;

--- a/packages/@glimmer/runtime/lib/template.ts
+++ b/packages/@glimmer/runtime/lib/template.ts
@@ -29,7 +29,7 @@ export interface RenderLayoutOptions {
 /**
  * Environment specific template.
  */
-export interface Template<Specifier = Opaque> {
+export interface Template<TemplateMeta = Opaque> {
   /**
    * Template identifier, if precompiled will be the id of the
    * precompiled template.
@@ -39,7 +39,7 @@ export interface Template<Specifier = Opaque> {
   /**
    * Template meta (both compile time and environment specific).
    */
-  referrer: Specifier;
+  referrer: TemplateMeta;
 
   hasEval: boolean;
 
@@ -55,7 +55,7 @@ export interface Template<Specifier = Opaque> {
   asPartial(): TopLevelSyntax;
 }
 
-export interface TemplateFactory<Specifier> {
+export interface TemplateFactory<TemplateMeta> {
   /**
    * Template identifier, if precompiled will be the id of the
    * precompiled template.
@@ -65,7 +65,7 @@ export interface TemplateFactory<Specifier> {
   /**
    * Compile time meta.
    */
-  meta: Specifier;
+  meta: TemplateMeta;
 
   /**
    * Used to create an environment specific singleton instance
@@ -73,7 +73,7 @@ export interface TemplateFactory<Specifier> {
    *
    * @param {Environment} env glimmer Environment
    */
-  create(env: TemplateOptions<Opaque>): Template<Specifier>;
+  create(env: TemplateOptions<Opaque>): Template<TemplateMeta>;
   /**
    * Used to create an environment specific singleton instance
    * of the template.
@@ -81,7 +81,7 @@ export interface TemplateFactory<Specifier> {
    * @param {Environment} env glimmer Environment
    * @param {Object} meta environment specific injections into meta
    */
-  create<U>(env: TemplateOptions<Opaque>, meta: U): Template<Specifier & U>;
+  create<U>(env: TemplateOptions<Opaque>, meta: U): Template<TemplateMeta & U>;
 }
 
 export class TemplateIterator {
@@ -98,8 +98,8 @@ let clientId = 0;
  * that handles lazy parsing the template and to create per env singletons
  * of the template.
  */
-export default function templateFactory<Specifier>(serializedTemplate: SerializedTemplateWithLazyBlock<Specifier>): TemplateFactory<Specifier>;
-export default function templateFactory<Specifier, U>(serializedTemplate: SerializedTemplateWithLazyBlock<Specifier>): TemplateFactory<Specifier & U>;
+export default function templateFactory<TemplateMeta>(serializedTemplate: SerializedTemplateWithLazyBlock<TemplateMeta>): TemplateFactory<TemplateMeta>;
+export default function templateFactory<TemplateMeta, U>(serializedTemplate: SerializedTemplateWithLazyBlock<TemplateMeta>): TemplateFactory<TemplateMeta & U>;
 export default function templateFactory({ id: templateId, meta, block }: SerializedTemplateWithLazyBlock<any>): TemplateFactory<{}> {
   let parsedBlock: SerializedTemplateBlock;
   let id = templateId || `client-${clientId++}`;
@@ -113,16 +113,16 @@ export default function templateFactory({ id: templateId, meta, block }: Seriali
   return { id, meta, create };
 }
 
-export class ScannableTemplate<Specifier = Opaque> implements Template<Specifier> {
+export class ScannableTemplate<TemplateMeta = Opaque> implements Template<TemplateMeta> {
   private layout: Option<TopLevelSyntax> = null;
   private partial: Option<TopLevelSyntax> = null;
   public symbols: string[];
   public hasEval: boolean;
   public id: string;
-  public referrer: Specifier;
+  public referrer: TemplateMeta;
   private statements: Statement[];
 
-  constructor(private options: TemplateOptions<Specifier>, private parsedLayout: ParsedLayout<Specifier>) {
+  constructor(private options: TemplateOptions<TemplateMeta>, private parsedLayout: ParsedLayout<TemplateMeta>) {
     let { block } = parsedLayout;
     this.symbols = block.symbols;
     this.hasEval = block.hasEval;
@@ -152,7 +152,7 @@ export class ScannableTemplate<Specifier = Opaque> implements Template<Specifier
   }
 }
 
-export function compilable<Specifier>(layout: ParsedLayout<Specifier>, options: TemplateOptions<Opaque>, asPartial: boolean) {
+export function compilable<TemplateMeta>(layout: ParsedLayout<TemplateMeta>, options: TemplateOptions<Opaque>, asPartial: boolean) {
   let { block, referrer } = layout;
   let { hasEval, symbols } = block;
   let compileOptions = assign({}, options, { asPartial, referrer });

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -98,13 +98,13 @@ export type IteratorResult<T> = {
   value: T;
 };
 
-export default class VM<Specifier> implements PublicVM {
+export default class VM<TemplateMeta> implements PublicVM {
   private dynamicScopeStack = new Stack<DynamicScope>();
   private scopeStack = new Stack<Scope>();
   public updatingOpcodeStack = new Stack<LinkedList<UpdatingOpcode>>();
   public cacheGroups = new Stack<Option<UpdatingOpcode>>();
   public listBlockStack = new Stack<ListBlockOpcode>();
-  public constants: RuntimeConstants<Specifier>;
+  public constants: RuntimeConstants<TemplateMeta>;
   public heap: Heap;
 
   public stack = EvaluationStack.empty();
@@ -213,8 +213,8 @@ export default class VM<Specifier> implements PublicVM {
     this.pc = this.ra;
   }
 
-  static initial<Specifier>(
-    program: RuntimeProgram<Specifier>,
+  static initial<TemplateMeta>(
+    program: RuntimeProgram<TemplateMeta>,
     env: Environment,
     self: PathReference<Opaque>,
     args: Option<ICapturedArguments>,
@@ -235,8 +235,8 @@ export default class VM<Specifier> implements PublicVM {
     return vm;
   }
 
-  static empty<Specifier>(
-    program: RuntimeProgram<Specifier>,
+  static empty<TemplateMeta>(
+    program: RuntimeProgram<TemplateMeta>,
     env: Environment,
     elementStack: ElementBuilder
   ) {
@@ -256,7 +256,7 @@ export default class VM<Specifier> implements PublicVM {
   }
 
   constructor(
-    private program: Program<Specifier>,
+    private program: Program<TemplateMeta>,
     public env: Environment,
     scope: Scope,
     dynamicScope: DynamicScope,
@@ -443,7 +443,7 @@ export default class VM<Specifier> implements PublicVM {
 
   /// EXECUTION
 
-  execute(start: VMHandle, initialize?: (vm: VM<Specifier>) => void): RenderResult {
+  execute(start: VMHandle, initialize?: (vm: VM<TemplateMeta>) => void): RenderResult {
     this.pc = this.heap.getaddr(start);
 
     if (initialize) initialize(this);

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -25,15 +25,15 @@ import { Simple, VMHandle } from '@glimmer/interfaces';
 import VM, { CapturedStack, EvaluationStack } from './append';
 import { RuntimeConstants as Constants, RuntimeProgram as Program } from "@glimmer/program";
 
-export default class UpdatingVM<Specifier = Opaque> {
+export default class UpdatingVM<TemplateMeta = Opaque> {
   public env: Environment;
   public dom: DOMChanges;
   public alwaysRevalidate: boolean;
-  public constants: Constants<Specifier>;
+  public constants: Constants<TemplateMeta>;
 
   private frameStack: Stack<UpdatingVMFrame> = new Stack<UpdatingVMFrame>();
 
-  constructor(env: Environment, program: Program<Specifier>, { alwaysRevalidate = false }) {
+  constructor(env: Environment, program: Program<TemplateMeta>, { alwaysRevalidate = false }) {
     this.env = env;
     this.constants = program.constants;
     this.dom = env.getDOM();

--- a/packages/@glimmer/test-helpers/lib/environment/component-definition.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/component-definition.ts
@@ -1,9 +1,20 @@
 import { Option } from '@glimmer/util';
 import { ProgramSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
-import { TemplateLocator } from '@glimmer/bundle-compiler';
+import { ModuleLocator, TemplateLocator } from '@glimmer/bundle-compiler';
 
 export interface TemplateMeta {
-  locator: TemplateLocator;
+  locator: ModuleLocator;
+}
+
+export function locatorFor(locator: ModuleLocator): TemplateLocator<TemplateMeta> {
+  let { module, name } = locator;
+
+  return {
+    module,
+    name,
+    kind: 'template',
+    meta: { locator }
+  };
 }
 
 export interface TestComponentDefinitionState {
@@ -15,7 +26,7 @@ export interface TestComponentDefinitionState {
   ComponentClass: any;
   type: string;
   layout: Option<number>;
-  locator?: TemplateLocator<TemplateMeta>;
+  locator: TemplateLocator<TemplateMeta>;
   template?: string;
   hasSymbolTable?: boolean;
   symbolTable?: ProgramSymbolTable;

--- a/packages/@glimmer/test-helpers/lib/environment/components/basic.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/basic.ts
@@ -9,8 +9,7 @@ import { UpdatableReference } from '@glimmer/object-reference';
 
 import LazyRuntimeResolver from '../modes/lazy/runtime-resolver';
 import EagerRuntimeResolver from '../modes/eager/runtime-resolver';
-import { TestComponentDefinitionState } from '../components';
-import { TemplateLocator } from '@glimmer/bundle-compiler';
+import { TestComponentDefinitionState, TemplateMeta } from '../components';
 
 export class BasicComponent {
   public element: Element;
@@ -48,7 +47,7 @@ export class BasicComponentManager implements WithStaticLayout<BasicComponent, T
     let { name } = state;
 
     if (resolver instanceof LazyRuntimeResolver) {
-      let compile = (source: string, options: TemplateOptions<TemplateLocator>) => {
+      let compile = (source: string, options: TemplateOptions<TemplateMeta>) => {
         let layout = createTemplate(source);
         let template = new ScannableTemplate(options, layout).asLayout();
 
@@ -67,7 +66,7 @@ export class BasicComponentManager implements WithStaticLayout<BasicComponent, T
       // compiled layout (which was provided at bundle compilation time and
       // stashed in the component definition state).
       let locator = expect(state.locator, 'component definition state should include module locator');
-      return resolver.getInvocation(locator);
+      return resolver.getInvocation({ locator });
     }
   }
 

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-curly.ts
@@ -10,7 +10,7 @@ import { Attrs, createTemplate, AttrsDiff } from '../shared';
 import LazyRuntimeResolver from '../modes/lazy/runtime-resolver';
 import EagerRuntimeResolver from '../modes/eager/runtime-resolver';
 import { TestComponentDefinitionState, TemplateMeta } from '../components';
-import { TemplateLocator } from '@glimmer/bundle-compiler';
+import { ModuleLocator } from '@glimmer/bundle-compiler';
 
 export class EmberishCurlyComponent extends GlimmerObject {
   public static positionalParams: string[] | string = [];
@@ -70,14 +70,14 @@ export const EMBERISH_CURLY_CAPABILITIES: ComponentCapabilities = {
 export interface EmberishCurlyComponentDefinitionState {
   name: string;
   ComponentClass: EmberishCurlyComponentFactory;
-  locator: TemplateLocator<TemplateMeta>;
+  locator: ModuleLocator;
   layout: Option<number>;
   symbolTable?: ProgramSymbolTable;
 }
 
 export class EmberishCurlyComponentManager implements
   WithDynamicTagName<EmberishCurlyComponent>,
-  WithDynamicLayout<EmberishCurlyComponent, TemplateLocator, LazyRuntimeResolver> {
+  WithDynamicLayout<EmberishCurlyComponent, TemplateMeta, LazyRuntimeResolver> {
 
   getCapabilities(state: TestComponentDefinitionState) {
     return state.capabilities;

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-glimmer.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-glimmer.ts
@@ -1,5 +1,5 @@
 
-import { TemplateOptions, Specifier } from "@glimmer/opcode-compiler";
+import { TemplateOptions, TemplateMeta } from "@glimmer/opcode-compiler";
 import { CapturedNamedArguments, ComponentManager, WithStaticLayout, Environment, Arguments, PrimitiveReference, ElementOperations, Bounds, ScannableTemplate, Invocation } from "@glimmer/runtime";
 import { Opaque, Option, ComponentCapabilities } from "@glimmer/interfaces";
 import { PathReference, Tag, combine, TagWrapper, DirtyableTag } from "@glimmer/reference";
@@ -12,7 +12,7 @@ import { BASIC_CAPABILITIES } from './basic';
 import { TestComponentDefinitionState } from '../components';
 import LazyRuntimeResolver from '../modes/lazy/runtime-resolver';
 import EagerRuntimeResolver from '../modes/eager/runtime-resolver';
-import { TemplateLocator } from "@glimmer/bundle-compiler";
+import { } from "@glimmer/bundle-compiler";
 
 export const EMBERISH_GLIMMER_CAPABILITIES = {
   ...BASIC_CAPABILITIES,
@@ -28,7 +28,7 @@ export interface EmberishGlimmerComponentState {
 
 export class EmberishGlimmerComponentManager
   implements ComponentManager<EmberishGlimmerComponentState, TestComponentDefinitionState>,
-             WithStaticLayout<EmberishGlimmerComponentState, TestComponentDefinitionState, Specifier, LazyRuntimeResolver> {
+             WithStaticLayout<EmberishGlimmerComponentState, TestComponentDefinitionState, TemplateMeta, LazyRuntimeResolver> {
 
   getCapabilities(state: TestComponentDefinitionState): ComponentCapabilities {
     return state.capabilities;
@@ -56,9 +56,10 @@ export class EmberishGlimmerComponentManager
     return combine([tag, dirtinessTag]);
   }
 
-  getLayout({ name, locator }: TestComponentDefinitionState, resolver: LazyRuntimeResolver | EagerRuntimeResolver): Invocation {
+  getLayout(state: TestComponentDefinitionState, resolver: LazyRuntimeResolver | EagerRuntimeResolver): Invocation {
+    let { name, locator } = state;
     if (resolver instanceof LazyRuntimeResolver) {
-      let compile = (source: string, options: TemplateOptions<TemplateLocator>) => {
+      let compile = (source: string, options: TemplateOptions<{}>) => {
         let layout = createTemplate(source);
         let template = new ScannableTemplate(options, layout).asLayout();
 
@@ -73,7 +74,7 @@ export class EmberishGlimmerComponentManager
       return resolver.compileTemplate(handle, name, compile);
     }
 
-    return resolver.getInvocation(locator!);
+    return resolver.getInvocation(locator.meta);
   }
 
   getSelf({ component }: EmberishGlimmerComponentState): PathReference<Opaque> {

--- a/packages/@glimmer/test-helpers/lib/environment/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/environment.ts
@@ -11,11 +11,11 @@ export interface TestEnvironmentOptions {
   updateOperations: IDOMChanges;
 }
 
-export default abstract class TestEnvironment<Specifier> extends Environment {
+export default abstract class TestEnvironment<TemplateMeta> extends Environment {
   public compiledLayouts: Dict<VMHandle> = dict();
 
-  protected abstract program: Program<Specifier>;
-  protected abstract resolver: RuntimeResolver<Specifier>;
+  protected abstract program: Program<TemplateMeta>;
+  protected abstract resolver: RuntimeResolver<TemplateMeta>;
 
   protocolForURL(url: string): string {
     if (typeof window === 'undefined') {

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/compiler-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/compiler-delegate.ts
@@ -1,5 +1,5 @@
 import { ICompilableTemplate, CompilableTemplate, CompileOptions } from '@glimmer/opcode-compiler';
-import { CompilerDelegate, TemplateLocator, ModuleLocator }  from '@glimmer/bundle-compiler';
+import { CompilerDelegate, ModuleLocator }  from '@glimmer/bundle-compiler';
 import { Dict } from '@glimmer/util';
 import { ProgramSymbolTable, ComponentCapabilities } from '@glimmer/interfaces';
 
@@ -8,54 +8,56 @@ import { ComponentDefinition } from '@glimmer/runtime';
 import { TestComponentDefinitionState } from "@glimmer/test-helpers";
 import { SerializedTemplateBlock } from '@glimmer/wire-format';
 
+import { TemplateMeta } from '../../components';
+
 export type ComponentDefinitionWithCapabilities = ComponentDefinition<TestComponentDefinitionState>;
 
-export default class EagerCompilerDelegate implements CompilerDelegate {
+export default class EagerCompilerDelegate implements CompilerDelegate<TemplateMeta> {
   constructor(
     private components: Dict<ComponentDefinitionWithCapabilities>,
     private modules: Modules,
   ) {}
 
-  hasComponentInScope(componentName: string, referrer: TemplateLocator): boolean {
+  hasComponentInScope(componentName: string, referrer: TemplateMeta): boolean {
     let name = this.modules.resolve(componentName, referrer, 'ui/components');
     return name ? this.modules.type(name) === 'component' : false;
   }
 
-  resolveComponent(componentName: string, referrer: TemplateLocator): ModuleLocator {
+  resolveComponent(componentName: string, referrer: TemplateMeta): ModuleLocator {
     return { module: this.modules.resolve(componentName, referrer, 'ui/components')!, name: 'default' };
   }
 
-  getComponentCapabilities(locator: TemplateLocator): ComponentCapabilities {
-    return this.components[locator.module].state.capabilities;
+  getComponentCapabilities(meta: TemplateMeta): ComponentCapabilities {
+    return this.components[meta.locator.module].state.capabilities;
   }
 
-  getComponentLayout(_: TemplateLocator, block: SerializedTemplateBlock, options: CompileOptions<TemplateLocator>): ICompilableTemplate<ProgramSymbolTable> {
+  getComponentLayout(_: TemplateMeta, block: SerializedTemplateBlock, options: CompileOptions<TemplateMeta>): ICompilableTemplate<ProgramSymbolTable> {
     return CompilableTemplate.topLevel(block, options);
   }
 
-  hasHelperInScope(helperName: string, referrer: TemplateLocator): boolean {
+  hasHelperInScope(helperName: string, referrer: TemplateMeta): boolean {
     let name = this.modules.resolve(helperName, referrer);
     return name ? this.modules.type(name) === 'helper' : false;
   }
 
-  resolveHelper(helperName: string, referrer: TemplateLocator): TemplateLocator {
+  resolveHelper(helperName: string, referrer: TemplateMeta): ModuleLocator {
     let path = this.modules.resolve(helperName, referrer);
     return { module: path!, name: 'default' };
   }
 
-  hasModifierInScope(_modifierName: string, _referrer: TemplateLocator): boolean {
+  hasModifierInScope(_modifierName: string, _referrer: TemplateMeta): boolean {
     return false;
   }
 
-  resolveModifier(_modifierName: string, _referrer: TemplateLocator): ModuleLocator {
+  resolveModifier(_modifierName: string, _referrer: TemplateMeta): ModuleLocator {
     throw new Error("Method not implemented.");
   }
 
-  hasPartialInScope(_partialName: string, _referrer: TemplateLocator): boolean {
+  hasPartialInScope(_partialName: string, _referrer: TemplateMeta): boolean {
     return false;
   }
 
-  resolvePartial(_partialName: string, _referrer: TemplateLocator): ModuleLocator {
+  resolvePartial(_partialName: string, _referrer: TemplateMeta): ModuleLocator {
     throw new Error("Method not implemented.");
   }
 }

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/modules.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/modules.ts
@@ -1,5 +1,5 @@
 import { Opaque, Option, dict, Dict, assert } from '@glimmer/util';
-import { TemplateLocator } from '@glimmer/bundle-compiler';
+import { TemplateMeta } from '../../components';
 
 export type ModuleType = 'component' | 'helper' | 'modifier' | 'partial' | 'other';
 
@@ -39,8 +39,8 @@ export class Modules {
     this.registry[name] = new Module(value, type);
   }
 
-  resolve(name: string, referrer: TemplateLocator, defaultRoot?: string): Option<string> {
-    let local = referrer.module && referrer.module.replace(/^((.*)\/)?([^\/]*)$/, `$1${name}`);
+  resolve(name: string, referrer: TemplateMeta, defaultRoot?: string): Option<string> {
+    let local = referrer.locator.module && referrer.locator.module.replace(/^((.*)\/)?([^\/]*)$/, `$1${name}`);
     if (local && this.registry[local]) {
       return local;
     } else if (defaultRoot && this.registry[`${defaultRoot}/${name}`]) {

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/runtime-resolver.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/runtime-resolver.ts
@@ -1,12 +1,12 @@
 import { RuntimeResolver, ComponentDefinition, VMHandle, Recast, ProgramSymbolTable } from '@glimmer/interfaces';
 import { Opaque, Option, expect } from '@glimmer/util';
 import { Invocation } from "@glimmer/runtime";
-import { ExternalModuleTable, TemplateLocator, ModuleLocatorMap } from '@glimmer/bundle-compiler';
+import { ExternalModuleTable, ModuleLocatorMap, ModuleLocator } from '@glimmer/bundle-compiler';
 
-import { TemplateMeta as Meta } from '../../component-definition';
+import { TemplateMeta } from '../../component-definition';
 import { Modules } from './modules';
 
-export default class EagerRuntimeResolver implements RuntimeResolver<TemplateLocator<Meta>> {
+export default class EagerRuntimeResolver implements RuntimeResolver<TemplateMeta> {
   constructor(
     private table: ExternalModuleTable,
     private modules: Modules,
@@ -21,7 +21,7 @@ export default class EagerRuntimeResolver implements RuntimeResolver<TemplateLoc
     throw new Error("Method not implemented.");
   }
 
-  lookupComponent(name: string, referrer: TemplateLocator<Meta>): Option<ComponentDefinition> {
+  lookupComponent(name: string, referrer: TemplateMeta): Option<ComponentDefinition> {
     let moduleName = this.modules.resolve(name, referrer, 'ui/components');
 
     if (!moduleName) return null;
@@ -39,7 +39,7 @@ export default class EagerRuntimeResolver implements RuntimeResolver<TemplateLoc
     return this.modules.get(module.module).get('default') as U;
   }
 
-  getInvocation(locator: TemplateLocator<Meta>): Invocation {
+  getInvocation({ locator }: TemplateMeta): Invocation {
     let handle = this.getVMHandle(locator);
     let symbolTable = expect(this.symbolTables.get(locator), `expected symbol table for module ${locator}`);
 
@@ -49,7 +49,7 @@ export default class EagerRuntimeResolver implements RuntimeResolver<TemplateLoc
     };
   }
 
-  getVMHandle(locator: TemplateLocator<Meta>): VMHandle {
+  getVMHandle(locator: ModuleLocator): VMHandle {
     let handle = expect(this.table.vmHandleByModuleLocator.get(locator), `could not find handle for module ${locator}`);
     return handle as Recast<number, VMHandle>;
   }

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/compiler-resolver.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/compiler-resolver.ts
@@ -4,9 +4,9 @@ import { assert } from '@glimmer/util';
 import { ComponentDefinition, WithStaticLayout } from '@glimmer/runtime';
 
 import RuntimeResolver from './runtime-resolver';
-import { TemplateLocator } from '@glimmer/bundle-compiler';
+import { TemplateMeta } from '../../components';
 
-export default class LazyCompilerResolver implements CompileTimeLookup<TemplateLocator> {
+export default class LazyCompilerResolver implements CompileTimeLookup<TemplateMeta> {
   constructor(private resolver: RuntimeResolver) {
   }
 
@@ -32,7 +32,7 @@ export default class LazyCompilerResolver implements CompileTimeLookup<TemplateL
       return null;
     }
 
-    let invocation = (manager as WithStaticLayout<any, any, TemplateLocator, RuntimeResolver>).getLayout(state, this.resolver);
+    let invocation = (manager as WithStaticLayout<any, any, TemplateMeta, RuntimeResolver>).getLayout(state, this.resolver);
 
     return {
       compile() { return invocation.handle; },
@@ -40,19 +40,19 @@ export default class LazyCompilerResolver implements CompileTimeLookup<TemplateL
     };
   }
 
-  lookupHelper(name: string, referrer: TemplateLocator): Option<number> {
+  lookupHelper(name: string, referrer: TemplateMeta): Option<number> {
     return this.resolver.lookupHelper(name, referrer);
   }
 
-  lookupModifier(name: string, referrer: TemplateLocator): Option<number> {
+  lookupModifier(name: string, referrer: TemplateMeta): Option<number> {
     return this.resolver.lookupModifier(name, referrer);
   }
 
-  lookupComponentDefinition(name: string, referrer: TemplateLocator): Option<number> {
+  lookupComponentDefinition(name: string, referrer: TemplateMeta): Option<number> {
     return this.resolver.lookupComponentHandle(name, referrer);
   }
 
-  lookupPartial(name: string, referrer: TemplateLocator): Option<number> {
+  lookupPartial(name: string, referrer: TemplateMeta): Option<number> {
     return this.resolver.lookupPartial(name, referrer);
   }
 }

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/environment.ts
@@ -42,14 +42,16 @@ import {
   EMBERISH_GLIMMER_CAPABILITIES,
   StaticTaglessComponentManager,
   STATIC_TAGLESS_CAPABILITIES,
-  TestComponentDefinitionState
+  TestComponentDefinitionState,
+  TemplateMeta,
+  locatorFor
 } from '../../components';
 
 import { UserHelper, HelperReference } from '../../helper';
 import { InertModifierManager } from '../../modifier';
 import TestMacros from '../../macros';
 import { Opaque } from "@glimmer/util";
-import { TemplateLocator } from "@glimmer/bundle-compiler";
+import { AnnotatedModuleLocator } from "@glimmer/bundle-compiler";
 
 const BASIC_COMPONENT_MANAGER = new BasicComponentManager();
 const EMBERISH_CURLY_COMPONENT_MANAGER = new EmberishCurlyComponentManager();
@@ -63,13 +65,13 @@ export interface TestEnvironmentOptions {
   program?: TopLevelSyntax;
 }
 
-export type TestCompilationOptions = CompilationOptions<TemplateLocator, LazyRuntimeResolver>;
+export type TestCompilationOptions = CompilationOptions<AnnotatedModuleLocator, LazyRuntimeResolver>;
 
-export default class LazyTestEnvironment extends TestEnvironment<TemplateLocator> {
+export default class LazyTestEnvironment extends TestEnvironment<AnnotatedModuleLocator> {
   public resolver = new LazyRuntimeResolver();
   protected program = new Program(new LazyConstants(this.resolver));
 
-  public compileOptions: TemplateOptions<TemplateLocator> = {
+  public compileOptions: TemplateOptions<TemplateMeta> = {
     resolver: new LazyCompilerResolver(this.resolver),
     program: this.program,
     macros: new TestMacros(),
@@ -190,6 +192,7 @@ export default class LazyTestEnvironment extends TestEnvironment<TemplateLocator
       name,
       type,
       layout,
+      locator: locatorFor({ module: name, name: 'default' }),
       capabilities,
       ComponentClass
     };

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/runtime-resolver.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/runtime-resolver.ts
@@ -4,13 +4,12 @@ import { Option, Opaque } from '@glimmer/util';
 import { Invocation } from '@glimmer/runtime';
 
 import Registry, { TypedRegistry, Lookup, LookupType } from '../../registry';
-import { TemplateLocator } from '@glimmer/bundle-compiler';
 
-export default class LazyRuntimeResolver implements RuntimeResolver<TemplateLocator> {
+export default class LazyRuntimeResolver implements RuntimeResolver<{}> {
   private handleLookup: TypedRegistry<Opaque>[] = [];
   private registry = new Registry();
 
-  private options: TemplateOptions<TemplateLocator>;
+  private options: TemplateOptions<{}>;
 
   register<K extends LookupType>(type: K, name: string, value: Lookup[K]): number {
     let registry = this.registry[type];
@@ -20,7 +19,7 @@ export default class LazyRuntimeResolver implements RuntimeResolver<TemplateLoca
     return handle;
   }
 
-  lookup(type: LookupType, name: string, _referrer?: TemplateLocator): Option<number> {
+  lookup(type: LookupType, name: string, _referrer?: {}): Option<number> {
     if (this.registry[type].hasName(name)) {
       return this.registry[type].getHandle(name);
     } else {
@@ -28,7 +27,7 @@ export default class LazyRuntimeResolver implements RuntimeResolver<TemplateLoca
     }
   }
 
-  compileTemplate(sourceHandle: number, templateName: string, create: (source: string, options: TemplateOptions<TemplateLocator>) => Invocation): Invocation {
+  compileTemplate(sourceHandle: number, templateName: string, create: (source: string, options: TemplateOptions<{}>) => Invocation): Invocation {
     let invocationHandle = this.lookup('template', templateName);
 
     if (invocationHandle) {
@@ -42,25 +41,25 @@ export default class LazyRuntimeResolver implements RuntimeResolver<TemplateLoca
     return invocation;
   }
 
-  lookupHelper(name: string, referrer?: TemplateLocator): Option<number> {
+  lookupHelper(name: string, referrer?: {}): Option<number> {
     return this.lookup('helper', name, referrer);
   }
 
-  lookupModifier(name: string, referrer?: TemplateLocator): Option<number> {
+  lookupModifier(name: string, referrer?: {}): Option<number> {
     return this.lookup('modifier', name, referrer);
   }
 
-  lookupComponent(name: string, referrer?: TemplateLocator): Option<ComponentDefinition> {
+  lookupComponent(name: string, referrer?: {}): Option<ComponentDefinition> {
     let handle = this.lookupComponentHandle(name, referrer);
     if (handle === null) return null;
     return this.resolve(handle) as ComponentDefinition;
   }
 
-  lookupComponentHandle(name: string, referrer?: TemplateLocator): Option<number> {
+  lookupComponentHandle(name: string, referrer?: {}): Option<number> {
     return this.lookup('component', name, referrer);
   }
 
-  lookupPartial(name: string, referrer?: TemplateLocator): Option<number> {
+  lookupPartial(name: string, referrer?: {}): Option<number> {
     return this.lookup('partial', name, referrer);
   }
 

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -197,10 +197,10 @@ export type SerializedTemplateBlockJSON = string;
 /**
  * A JSON object containing the SerializedTemplateBlock as JSON and TemplateMeta.
  */
-export interface SerializedTemplateWithLazyBlock<Specifier> {
+export interface SerializedTemplateWithLazyBlock<TemplateMeta> {
   id?: Option<string>;
   block: SerializedTemplateBlockJSON;
-  meta: Specifier;
+  meta: TemplateMeta;
 }
 
 /**


### PR DESCRIPTION
This PR is probably not one of the more exciting ones to come across this repository. However, it contains a critically important cleanup of some internal plumbing for how we handle the two compilations modes (lazy compilation vs. eager compilation aka the bundle compiler aka bytecode compilation).

I am going to try to explain the motivation of this change, as well as the history of how we got here, as best I can.

## In the Beginning, There Was Template Metadata

Since the very beginning, Glimmer has supported the notion of "template metadata." This was an opaque bundle of state that could be added to templates at precompilation time and would be included in the JSON output:

```js
import { precompile } from '@glimmer/compiler';
let compiled = precompile('<h1>Hello</h1>', { meta: { whatever: 'foo' } });
```

In this example, `compiled` is a string of JSON that is included in the built application and evaluated via `JSON.parse()` in the browser at runtime.

The metadata is included in the JSON, so things like the component manager have access to it when resolving components, helpers and partials. For example, in Glimmer.js, where we use Ember's Module Unification file layout scheme, the "specifier" is included in the template metadata at build time.

For example, if I have a template at `src/ui/components/MyComponent/template.hbs`, the metadata for this template would be:

```js
{
  specifier: 'template:/my-app/ui/components/MyComponent'
}
```

Inside that template, if I were to invoke another component, the name of the invoked component _as well as the referring template's metadata_ get passed to the hook that looks up components. This allows the system to support things like scoped components, because you have information about where the component was invoked from in addition to the component name.

## Enter the Bundle Compiler

As part of the effort to begin compiling templates to binary bytecode, we introduced the bundle compiler. This compiler allows you to eagerly populate a bundle with all of the known templates in an application and turn it into Glimmer bytecode. Effectively, this moves the final "stitching together" of template opcodes into a build-time concern instead of happening at runtime.

One caveat to bytecode is that it still needs to be able to refer to "live" JavaScript objects, like the JavaScript classes that make up the behavior of components. The way that we deal with this is by assigning every reference to a live object as "handle," or a unique integer ID. In bytecode mode, we exchange these handles for live objects at runtime. (We don't need this in the lazy compiler mode because we live inside the same "universe" as the live JavaScript objects and can just reference them directly.)

Because of the need to map handles on to live JavaScript objects in bytecode mode, the build tools must generate a data structure called the _external module table_. This table allows you to efficiently exchange a handle for a live object.

For example, if we have a component class called `UserProfile` that is assigned handle `0`, our external module table might look like this:

```js
import UserProfile from './src/ui/components/UserProfile/component';
export default [UserProfile];
```

Now, we can exchange the handle for the class like this:

```js
import table from './table';
let UserProfile = table[0];
```

Because we can't access live objects directly, we need some other way of recording them that can be turned into a live object later. The best way to do this in JavaScript is via the module syntax, since it's the most portable way to refer to a file across many different build tools.

Put another way, to generate the code for the external module table above, we need to provide a data structure to the build tools that contains at least two things:

1. The handle.
2. The path to the module and the name of the export.

Because of this, there was an effort to try to move the internals to use a `Specifier` to uniquely identify templates. In this case, a `Specifier` was a data structure that encoded the module path and export name.

Unfortunately, this factoring threw the baby out with the bathwater. In addition to the confusion caused by co-opting the term "specifier," which is used heavily in Glimmer.js's dependency injection system, it also conflated build time metadata with runtime metadata.

While bytecode mode allows us to resolve more things at build time, we still need to perform dynamic lookups at runtime via the `{{component}}` and `{{partial}}` helpers. In these cases, module path and export name are not necessarily the most efficient representations to use to look up components or partials.

For example, in Glimmer.js with Module Unification, everything is normalized into a specifier like `template:/my-app/ui/components/MyComponent`. If the template metadata available to us at runtime is just the module path on the filesystem, we need to either ship an *additional* map that lets us turn the module path into the appropriate specifier string, or include code for deriving the specifier string from the module path. In either case, it would be much more efficient if we could continue to do what we do in lazy mode and include just the precomputed specifier string in the referring template metadata.

Worse, encoding different metadata between the different modes means it's much harder to write shared implementations that work in both modes.

## Grand Unification

This PR attempts to address the tension between the two modes by formalizing the notion of "buildtime metadata" and "runtime metadata."

Here, runtime metadata is provided in both modes via the single abstraction of `TemplateMeta`. Buildtime metadata is provided only in the bundle compiler, where you have the need to generate an external module table and thus roundtrip through the JavaScript module system.

### Buildtime Metadata

Objects in the compiler are uniquely identified by a `ModuleLocator`. Module locators are simple data structures that map to a single module and export:

```js
{
  module: "./src/ui/components/MyComponent/component",
  name: "default"
}
```

In the `CompilerDelegate`s `resolve*` methods (e.g. `resolveComponent`), you resolve a component, helper, or partial to a unique file on disk by returning a module locator. Whether adding a template to the bundle via `add()` or resolving objects in the delegate, everything is in terms of files on disk via a module locator.

### Runtime Metadata

As before, lazy mode provides metadata available at runtime via the `meta` options passed to `precompile`:

```js
import { precompile } from '@glimmer/compiler';
let compiled = precompile('<h1>Hello</h1>', { meta: { whatever: 'foo' } });
```

In this PR, you can also provide the same metadata to the bundle compiler by using a `TemplateLocator`, a `ModuleLocator` extended to include template metadata:

```
let bundle = new BundleCompiler<TemplateMeta>();
let locator = {
  module: './src/ui/components/MyComponent/template',
  name: 'default',
  meta: {
    specifier: 'template:/my-app/ui/components/MyComponent'
  }
};
bundle.add(locator, '<h1>Hello</h1>');
```

## In Summary

Previously, the bundle compiler was conflating buildtime metadata with runtime metadata. In lazy mode, resolvers and component managers were being passed `TemplateMeta` as the `referrer`. But in eager bytecode mode, they were instead being passed the `ModuleLocator` née `Specifier`. This made it difficult to author implementations that worked across both modes, and was less efficient in many cases for performing dynamic lookup for things like the `{{component}}` helper. This PR separates buildtime metadata and runtime metadata to make it clearer what state should be passed to which hooks, and guarantees about what environments that data is available in.