### PR TITLE
Compile Guarded Append Into Std. Lib

### DIFF
--- a/packages/@glimmer/opcode-compiler/index.ts
+++ b/packages/@glimmer/opcode-compiler/index.ts
@@ -14,7 +14,8 @@ export {
   EagerOpcodeBuilder,
   OpcodeBuilder,
   OpcodeBuilderConstructor,
-  SimpleOpcodeBuilder
+  SimpleOpcodeBuilder,
+  STDLib
 } from './lib/opcode-builder';
 
 export {

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -8,6 +8,7 @@ import { DEBUG } from '@glimmer/local-debug-flags';
 import { debugSlice } from './debug';
 import { CompilableTemplate as ICompilableTemplate, ParsedLayout } from './interfaces';
 import { CompileOptions, statementCompiler, Compilers } from './syntax';
+import { STDLib } from './opcode-builder';
 
 export { ICompilableTemplate };
 
@@ -31,7 +32,7 @@ export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> imp
     this.statementCompiler = statementCompiler();
   }
 
-  compile(): number {
+  compile(stdLib?: STDLib): number {
     let { compiled } = this;
     if (compiled !== null) return compiled;
 
@@ -45,7 +46,7 @@ export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> imp
     let { referrer } = containingLayout;
     let { program, resolver, macros, asPartial, Builder } = options;
 
-    let builder = new Builder(program, resolver, referrer, macros, containingLayout, asPartial);
+    let builder = new Builder(program, resolver, referrer, macros, containingLayout, asPartial, stdLib);
 
     for (let i = 0; i < statements.length; i++) {
       this.statementCompiler.compile(statements[i], builder);

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -8,6 +8,7 @@ import {
 } from '@glimmer/interfaces';
 import { Core, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { Macros } from './syntax';
+import { STDLib } from './opcode-builder';
 
 export interface EagerResolver<Locator> {
   getCapabilities(locator: Locator): ComponentCapabilities;
@@ -21,7 +22,7 @@ export interface EagerCompilationOptions<TemplateMeta, R extends EagerResolver<T
 
 export interface CompilableTemplate<S extends SymbolTable> {
   symbolTable: S;
-  compile(): number;
+  compile(stdLib?: STDLib): number;
 }
 
 export const PLACEHOLDER_HANDLE = -1;

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -202,7 +202,9 @@ export function statementCompiler() {
         builder.guardedAppend(value, false);
       } else {
         builder.expr(value);
-        builder.dynamicContent(false);
+        builder.primitive(false);
+        builder.load(Register.t0);
+        builder.dynamicContent();
       }
     }
   });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -137,11 +137,14 @@ APPEND_OPCODES.add(Op.PushComponentDefinition, (vm, { op1: handle }) => {
 APPEND_OPCODES.add(Op.ResolveDynamicComponent, (vm, { op1: _meta }) => {
   let stack = vm.stack;
   let component = check(stack.pop(), CheckPathReference).value();
+  let meta = vm.constants.getSerializable(_meta);
+
+  vm.loadValue(Register.t1, null); // Clear the temp register
+
   let definition: ComponentDefinition | CurriedComponentDefinition;
 
   if (typeof component === 'string') {
-    let { constants, constants: { resolver } } = vm;
-    let meta = constants.getSerializable<TemplateMeta>(_meta);
+    let { constants: { resolver } } = vm;
     let resolvedDefinition = resolveComponent(resolver, component, meta);
 
     definition = expect(resolvedDefinition, `Could not find a component named "${component}"`);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -1,5 +1,5 @@
 import { isConst, Reference, Tag, VersionedReference } from '@glimmer/reference';
-import { Op } from '@glimmer/vm';
+import { Op, Register } from '@glimmer/vm';
 import { check, expectStackChange } from '@glimmer/debug';
 import { Opaque } from '@glimmer/util';
 
@@ -20,8 +20,10 @@ export class IsCurriedComponentDefinitionReference extends ConditionalReference 
   }
 }
 
-APPEND_OPCODES.add(Op.DynamicContent, (vm, { op1: isTrusting }) => {
+APPEND_OPCODES.add(Op.DynamicContent, (vm) => {
   let reference = check(vm.stack.pop(), CheckPathReference);
+  let isTrusting = vm.fetchValue(Register.t0);
+
   let value = reference.value();
   let content: DynamicContentWrapper;
 
@@ -35,6 +37,7 @@ APPEND_OPCODES.add(Op.DynamicContent, (vm, { op1: isTrusting }) => {
     vm.updateWith(new UpdateDynamicContentOpcode(reference, content));
   }
 
+  vm.loadValue(Register.t0, null);
   expectStackChange(vm.stack, -1, 'DynamicContent');
 });
 

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -423,7 +423,7 @@ OPCODE_METADATA(Op.Comment, {
 OPCODE_METADATA(Op.DynamicContent, {
   name: 'DynamicContent',
   ops: [Bool('trusting')],
-  operands: 1,
+  operands: 0,
   stackChange: -1
 });
 


### PR DESCRIPTION
This is the start of the work to compile standard library functions or procedures into a while known space prior to entering the compilation of user-defined templates.

Today we compile all the builtin language constructs inline when ever we are compiling a template in either eager or lazy compilation. This means that even though the semantics for what builtins cannot change we compile the same code for those constructs every time we encounter them.

```hbs
{{#if foo}}
  Hello
{{else}}
  Bye
{{/if}}

{{#if baz}}
  Day
{{else}}
  Night
{{/if}}
```

In the example above we are using 2 `{{if}}` statements which will result in [this compilation](https://github.com/glimmerjs/glimmer-vm/blob/master/packages/@glimmer/opcode-compiler/lib/syntax.ts#L458-L510) happening 2 times. This ends up compiling into about ~160 bytes, but is expressed in about ~90 bytes in the template. We would like that to not be the case.

Since the Glimmer VM models component invocations as function calls all the infrastructure is available to compile these builtins into a well known space in the heap and simply treat them like functions. For instance one could view the previous example as the corollary in JavaScript.

```ts
if (foo) {
  return 'Hello';
} else {
  return 'Bye';
}

if (baz) {
  return 'Day';
} else {
  return 'Night';
}
```

We can re-write the above as the following:

```ts
cond(foo, 'Hello', 'Bye');
cond(baz, 'Day', 'Night');

function cond(pred, alt, cons) {
  if (pred) {
   return alt;
  } else {
   return cons;
  }
}
```

As you can see the refactored code re-uses the conditional construct and replaces it with a call to `cond`. From the VMs point of view it no longer needs to emit opcodes for the conditional inline but rather load the stack and/or registers and `goto` wherever `cond` is defined.

So the idea is that in Glimmer a user writes their templates in a declarative manner, but at build time we do some more optimized compilation. Instead compiling the user's templates first we would instead compile the standard library functions and then compile the user-defined templates.  As we come across usage of builtin syntax we simply emit the instructions to load the stack and registries and invoke the standard library functions. We feel like doing this for a handful of builtin constructs will yield a decent size reduction in the compiled output.

This PR targets one of the last places where we have ambiguity in the Handlebars syntax. When a layout `{{yield}}`s a value we loose the identity of the value. For instance:

```hbs
<A as |bar|>
  {{bar}}
</A>
```

Without looking at `A`'s layout we have no idea if `{{bar}}` is a value or a curried component. This forces us into compiling into something like the following:

```hbs
<A as |bar|>
  {{#if (isComponent bar)}}
    {{component bar}}
  {{else}}
    {{append bar}}
  {{/if}}
</A>
```

This is currently emitted for any curly where there could be some ambiguity. While we want to arrive at some static syntax for using curried components, this PR helps remove the hidden cost of emitting all the code inline for these ambiguous cases and instead compiles it into the following:

```hbs
<A as |bar|>
  {{guarded-append bar}}
</A>
```

This will invoke a virtualized layout (function) that looks like the following.

```hbs
{{#if (isComponent val)}}
  {{component val}}
{{else}}
  {{append bar}}
{{/if}}
```

We need to do an analysis of where we will get the biggest bang for our buck. If the amount of operations for preparing the stack and calling a builtin function are greater than inlining the builtin there really isn't a good reason to complicate the system an thus we should continue
inlining.