### PR TITLE
Fix bytecode recursive component invocation

### DIFF
--- a/packages/@glimmer/encoder/lib/encoder.ts
+++ b/packages/@glimmer/encoder/lib/encoder.ts
@@ -6,11 +6,13 @@ export const TYPE_SIZE        = 0b11111111;
 export const TYPE_MASK        = 0b0000000011111111;
 export const OPERAND_LEN_MASK = 0b0000001100000000;
 
+export type Operand = number | (() => number);
+
 export class InstructionEncoder {
-  constructor(public buffer: number[]) {}
+  constructor(public buffer: Operand[]) {}
   typePos = 0;
   size = 0;
-  encode(type: Op, ...operands: number[]) {
+  encode(type: Op, ...operands: Operand[]) {
     if (type > TYPE_SIZE) {
       throw new Error(`Opcode type over 8-bits. Got ${type}.`);
     }
@@ -20,7 +22,7 @@ export class InstructionEncoder {
     this.typePos = this.buffer.length - 1;
 
     operands.forEach(op => {
-      if (op > MAX_SIZE) {
+      if (typeof op === 'number' && op > MAX_SIZE) {
         throw new Error(`Operand over 16-bits. Got ${op}.`);
       }
       this.buffer.push(op);

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -14,6 +14,7 @@ export type VMHandle = Unique<"Handle">;
 
 export interface CompileTimeHeap {
   push(name: /* TODO: Op */ number, op1?: number, op2?: number, op3?: number): void;
+  pushPlaceholder(valueFunc: () => number): void;
   malloc(): VMHandle;
   finishMalloc(handle: VMHandle, scopeSize: number): void;
 

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -2,7 +2,8 @@ import {
   Option,
   SymbolTable,
   ProgramSymbolTable,
-  VMHandle
+  VMHandle,
+  Recast
 } from '@glimmer/interfaces';
 import { Statement, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { DEBUG } from '@glimmer/local-debug-flags';
@@ -11,6 +12,8 @@ import { CompilableTemplate as ICompilableTemplate, ParsedLayout } from './inter
 import { CompileOptions, statementCompiler, Compilers } from './syntax';
 
 export { ICompilableTemplate };
+
+export const PLACEHOLDER_HANDLE: VMHandle = -1 as Recast<number, VMHandle>;
 
 export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> implements ICompilableTemplate<S> {
   static topLevel<TemplateMeta>(block: SerializedTemplateBlock, options: CompileOptions<TemplateMeta>): ICompilableTemplate<ProgramSymbolTable> {
@@ -33,6 +36,12 @@ export default class CompilableTemplate<S extends SymbolTable, TemplateMeta> imp
   compile(): VMHandle {
     let { compiled } = this;
     if (compiled !== null) return compiled;
+
+    // Track that compilation has started but not yet finished by temporarily
+    // using a placeholder handle. In eager compilation mode, where compile()
+    // may be called recursively, we use this as a signal that the handle cannot
+    // be known synchronously and must be linked lazily.
+    this.compiled = PLACEHOLDER_HANDLE;
 
     let { options, statements, containingLayout } = this;
     let { referrer } = containingLayout;

--- a/packages/@glimmer/opcode-compiler/lib/interfaces.ts
+++ b/packages/@glimmer/opcode-compiler/lib/interfaces.ts
@@ -5,7 +5,8 @@ import {
   Option,
   BlockSymbolTable,
   ComponentCapabilities,
-  CompileTimeProgram
+  CompileTimeProgram,
+  Recast
 } from '@glimmer/interfaces';
 import { Core, SerializedTemplateBlock } from '@glimmer/wire-format';
 import { Macros } from './syntax';
@@ -24,6 +25,8 @@ export interface CompilableTemplate<S extends SymbolTable> {
   symbolTable: S;
   compile(): VMHandle;
 }
+
+export const PLACEHOLDER_HANDLE: VMHandle = -1 as Recast<number, VMHandle>;
 
 export type CompilableBlock = CompilableTemplate<BlockSymbolTable>;
 

--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -50,6 +50,29 @@ export class EmberishComponentTests extends RenderTest {
     assertEmberishElement(el.firstChild as HTMLElement, 'div', { 'data-bar': 'Bar' }, 'Hello World');
   }
 
+  @test({ kind: 'glimmer' })
+  "recursive component invocation"() {
+    let counter = 0;
+
+    class RecursiveInvoker extends EmberishGlimmerComponent {
+      id: number;
+
+      get showChildren() {
+        return this.id < 3;
+      }
+
+      constructor(...args: any[]) {
+        super(...args);
+        this.id = ++counter;
+      }
+    }
+
+    this.registerComponent('Glimmer', 'RecursiveInvoker', '{{id}}{{#if showChildren}}<RecursiveInvoker />{{/if}}', RecursiveInvoker);
+
+    this.render('<RecursiveInvoker />');
+    this.assertHTML('123<!---->');
+  }
+
   @test
   "non-block without properties"() {
     this.render({


### PR DESCRIPTION
Currently, recursive invocation of components is failing when the program is compiled as bytecode. The compiler will crash due to a stack overflow because it tries to recursively assign handles to the still-compiling `CompilableTemplate`.

The compilable template's `compile()` method, which generates a unique handle for each component, guards on the existence of the handle to know whether compilation has already happened. Unfortunately, recursive operations like this cause a bit of a Catch 22 situation. We need the opcode and operands to know how much space to malloc on the heap (and thus assign a VM handle), but we don't know what VM handle to emit as the operand because the malloc hasn't happened yet.

This PR introduces the ability to push placeholder values on to the heap, in addition to normal primitive numbers. Placeholder values increment the current offset like normal, but record the position of the placeholder value and additionally store a value-producing function.

When compilation of the program finishes (as signalled by a call to `capture()`), a final pass (or "linking" step, if you will) occurs, where placeholder values are replaced by the real value, as produced by invoking the originally-passed function.