### PR TITLE
[WIP] Transform component helper with static name

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -346,6 +346,26 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
     this.push(Op.PushDynamicComponentManager, this.constants.serializable(referrer));
   }
 
+  staticComponentHelper(tag: string, hash: WireFormat.Core.Hash, template: Option<CompilableBlock>) {
+    let handle = this.resolver.lookupComponentDefinition(tag, this.referrer);
+    if (handle) {
+      let capabilities = this.resolver.getCapabilities(handle);
+      if (capabilities.dynamicLayout === false) {
+        if (hash) {
+          for (let i = 0; i < hash.length; i = i + 2) {
+            hash[i][0] = `@${hash[i][0]}`;
+          }
+        }
+        let layout = this.resolver.getLayout(handle)!;
+        this.pushComponentDefinition(handle);
+        this.invokeStaticComponent(capabilities, layout, null, null, hash, false, template && template);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   // partial
 
   invokePartial(referrer: Locator, symbols: string[], evalInfo: number[]) {

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -99,7 +99,6 @@ export function statementCompiler() {
 
   STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
     let [, tag, _attrs, args, block] = sexp;
-
     let { resolver, referrer } = builder;
     let handle = resolver.lookupComponentDefinition(tag, referrer);
 
@@ -766,12 +765,24 @@ export function populateBuiltins(blocks: Blocks = new Blocks(), inlines: Inlines
   blocks.add('component', (_params, hash, template, inverse, builder) => {
     assert(_params && _params.length, 'SYNTAX ERROR: #component requires at least one argument');
 
+    let tag = _params[0];
+    if (typeof tag === 'string') {
+      let returned = builder.staticComponentHelper(_params[0] as string, hash, template);
+      if (returned) return;
+    }
+
     let [definition, ...params] = _params!;
     builder.dynamicComponent(definition, params, hash, true, template, inverse);
   });
 
   inlines.add('component', (_name, _params, hash, builder) => {
     assert(_params && _params.length, 'SYNTAX ERROR: component helper requires at least one argument');
+
+    let tag =_params && _params[0];
+    if (typeof tag === 'string') {
+      let returned = builder.staticComponentHelper(tag as string, hash, null);
+      if (returned) return true;
+    }
 
     let [definition, ...params] = _params!;
     builder.dynamicComponent(definition, params, hash, true, null, null);

--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -32,6 +32,30 @@ export class EmberishComponentTests extends RenderTest {
   }
 
   @test({ kind: 'glimmer' })
+  "Static block component helper are treated as static invokes"() {
+    this.registerComponent('Glimmer', 'A', 'A {{#component "B" arg1=@one}}{{/component}}');
+    this.registerComponent('Glimmer', 'B', 'B {{@arg1}}');
+    this.render('<A @one={{arg}} />', { arg: 1 });
+    this.assertHTML('A B 1');
+    this.assertStableRerender();
+    this.rerender({arg: 2 });
+    this.assertHTML('A B 2');
+    this.assertStableNodes();
+  }
+
+  @test({ kind: 'glimmer' })
+  "Static inline component helper are treated as static invokes"() {
+    this.registerComponent('Glimmer', 'A', 'A {{component "B" arg1=@one}}');
+    this.registerComponent('Glimmer', 'B', 'B {{@arg1}}');
+    this.render('<A @one={{arg}} />', { arg: 1 });
+    this.assertHTML('A B 1');
+    this.assertStableRerender();
+    this.rerender({arg: 2 });
+    this.assertHTML('A B 2');
+    this.assertStableNodes();
+  }
+
+  @test({ kind: 'glimmer' })
   "top level in-element"() {
     this.registerComponent('Glimmer', 'Foo', '<Bar data-bar={{@childName}} @data={{@data}} />');
     this.registerComponent('Glimmer', 'Bar', '<div ...attributes>Hello World</div>');


### PR DESCRIPTION
Prior to these changes `{{component}}` invocations with a `StringLiteral` were treated as a dynamic invocation. This meant we would have to perform more work than required to invoke the component. This involved things resolving the component name at runtime, which in this case is completely unnecessary. When we are compiling we can infer the static invoke and resynthesize the invocation. For instance:

```hbs
{{component "A" foo=bar}}
```
to 

```hbs
<A @foo={{bar}} />
```