### PR TITLE
Static Component Helper & Interning Serializables

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -39,6 +39,6 @@ export default class DebugConstants extends WriteOnlyConstants {
   }
 
   getSerializable<T>(s: number): T {
-    return JSON.parse(this.serializables[s]) as T;
+    return JSON.parse(this.strings[s]) as T;
   }
 }

--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -39,6 +39,6 @@ export default class DebugConstants extends WriteOnlyConstants {
   }
 
   getSerializable<T>(s: number): T {
-    return this.serializables[s] as T;
+    return JSON.parse(this.serializables[s]) as T;
   }
 }

--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -1,5 +1,4 @@
 import { WriteOnlyConstants } from "@glimmer/program";
-import { SymbolTable } from "@glimmer/interfaces";
 
 export default class DebugConstants extends WriteOnlyConstants {
   getFloat(value: number): number {
@@ -28,10 +27,6 @@ export default class DebugConstants extends WriteOnlyConstants {
 
   getArray(value: number): number[] {
     return (this.arrays as number[][])[value];
-  }
-
-  getSymbolTable<T extends SymbolTable>(value: number): T {
-    return this.tables[value] as T;
   }
 
   resolveHandle<T>(s: number): T {

--- a/packages/@glimmer/bundle-compiler/test/emberish-components-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/emberish-components-test.ts
@@ -1,3 +1,29 @@
-import { rawModule, EmberishComponentTests, EagerRenderDelegate } from "@glimmer/test-helpers";
+import { EmberishGlimmerComponent rawModule, EmberishComponentTests, EagerRenderDelegate, test } from "@glimmer/test-helpers";
 
-rawModule('[Bundle Compiler] Emberish Components', EmberishComponentTests, EagerRenderDelegate, { componentModule: true });
+class BundleCompilerEmberTests extends EmberishComponentTests {
+  @test({ kind: 'glimmer' })
+  "should only serialize a single locator"() {
+    this.registerComponent('Glimmer', 'A', '{{component "B" foo=@bar}} {{component "B" foo=2}} {{component "B" foo=3}}');
+    this.registerComponent('Glimmer', 'B', 'B {{@foo}}');
+    this.render('<A @bar={{1}} /> {{component "B" foo=4}}');
+    this.assert.equal(this.delegate.constants!.toPool().serializables.length, 1);
+    this.assert.deepEqual(this.delegate.constants!.toPool().serializables[0], JSON.stringify({ locator: { module: 'ui/components/B', name: 'default' } }));
+    this.assertHTML('B 1 B 2 B 3 B 4');
+    this.assertStableRerender();
+  }
+
+  @test({ kind: 'glimmer' })
+  "should not serialize if there are no args"() {
+    class B extends EmberishGlimmerComponent {
+      bar = 1;
+    }
+    this.registerComponent('Glimmer', 'A', '{{component "B"}}');
+    this.registerComponent('Glimmer', 'B', 'B {{bar}}', B);
+    this.render('<A /> {{component "B"}}');
+    this.assert.equal(this.delegate.constants!.toPool().serializables.length, 0);
+    this.assertHTML('B 1 B 1');
+    this.assertStableRerender();
+  }
+}
+
+rawModule('[Bundle Compiler] Emberish Components', BundleCompilerEmberTests, EagerRenderDelegate, { componentModule: true });

--- a/packages/@glimmer/bundle-compiler/test/emberish-components-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/emberish-components-test.ts
@@ -1,4 +1,4 @@
-import { EmberishGlimmerComponent rawModule, EmberishComponentTests, EagerRenderDelegate, test } from "@glimmer/test-helpers";
+import { EmberishGlimmerComponent, rawModule, EmberishComponentTests, EagerRenderDelegate, test } from "@glimmer/test-helpers";
 
 class BundleCompilerEmberTests extends EmberishComponentTests {
   @test({ kind: 'glimmer' })
@@ -6,8 +6,19 @@ class BundleCompilerEmberTests extends EmberishComponentTests {
     this.registerComponent('Glimmer', 'A', '{{component "B" foo=@bar}} {{component "B" foo=2}} {{component "B" foo=3}}');
     this.registerComponent('Glimmer', 'B', 'B {{@foo}}');
     this.render('<A @bar={{1}} /> {{component "B" foo=4}}');
-    this.assert.equal(this.delegate.constants!.toPool().serializables.length, 1);
-    this.assert.deepEqual(this.delegate.constants!.toPool().serializables[0], JSON.stringify({ locator: { module: 'ui/components/B', name: 'default' } }));
+    let locator = JSON.stringify({ locator: { module: 'ui/components/B', name: 'default' } });
+    let { strings } = this.delegate.constants!.toPool();
+    this.assert.ok(strings.indexOf(locator) > 0);
+
+    let uniq: string[] = [];
+    strings.forEach((str) => {
+      if (str === locator) {
+        uniq.push(str);
+      }
+    });
+
+    this.assert.equal(uniq.length, 1);
+
     this.assertHTML('B 1 B 2 B 3 B 4');
     this.assertStableRerender();
   }
@@ -20,7 +31,9 @@ class BundleCompilerEmberTests extends EmberishComponentTests {
     this.registerComponent('Glimmer', 'A', '{{component "B"}}');
     this.registerComponent('Glimmer', 'B', 'B {{bar}}', B);
     this.render('<A /> {{component "B"}}');
-    this.assert.equal(this.delegate.constants!.toPool().serializables.length, 0);
+    let locator = JSON.stringify({ locator: { module: 'ui/components/B', name: 'default' } });
+    let { strings } = this.delegate.constants!.toPool();
+    this.assert.equal(strings.indexOf(locator), -1);
     this.assertHTML('B 1 B 1');
     this.assertStableRerender();
   }

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -36,7 +36,6 @@ export interface CompileTimeConstants {
   string(value: string): number;
   stringArray(strings: string[]): number;
   array(values: number[]): number;
-  table(t: SymbolTable): number;
   handle(locator: Opaque): number;
   serializable(value: Opaque): number;
   float(value: number): number;

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -3,7 +3,6 @@ import {
   CompileTimeConstants,
   Option,
   Opaque,
-  SymbolTable,
   Recast
 } from '@glimmer/interfaces';
 import { METADATA, Op, Register } from '@glimmer/vm';
@@ -18,7 +17,6 @@ export interface DebugConstants {
   getString(value: number): string;
   getStringArray(value: number): string[];
   getArray(value: number): number[];
-  getSymbolTable<T extends SymbolTable>(value: number): T;
   getSerializable<T>(s: number): T;
   resolveHandle<T>(s: number): T;
 }
@@ -124,9 +122,6 @@ export function debug(c: DebugConstants, op: Op, ...operands: number[]): [string
         break;
       case 'register':
         out[operand.name] = Register[op];
-        break;
-      case 'table':
-        out[operand.name] = c.getSymbolTable(op);
         break;
       case 'serializable':
         out[operand.name] = c.getSerializable(op);

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -346,6 +346,26 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
     this.push(Op.PushDynamicComponentManager, this.constants.serializable(referrer));
   }
 
+  staticComponentHelper(tag: string, hash: WireFormat.Core.Hash, template: Option<CompilableBlock>) {
+    let handle = this.resolver.lookupComponentDefinition(tag, this.referrer);
+    if (handle) {
+      let capabilities = this.resolver.getCapabilities(handle);
+      if (capabilities.dynamicLayout === false) {
+        if (hash) {
+          for (let i = 0; i < hash.length; i = i + 2) {
+            hash[i][0] = `@${hash[i][0]}`;
+          }
+        }
+        let layout = this.resolver.getLayout(handle)!;
+        this.pushComponentDefinition(handle);
+        this.invokeStaticComponent(capabilities, layout, null, null, hash, false, template && template);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   // partial
 
   invokePartial(referrer: Locator, symbols: string[], evalInfo: number[]) {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -977,7 +977,7 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
 
   pushSymbolTable(table: Option<SymbolTable>): void {
     if (table) {
-      let constant = this.constants.table(table);
+      let constant = this.constants.serializable(table);
       this.push(Op.PushSymbolTable, constant);
     } else {
       this.primitive(null);

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -99,7 +99,6 @@ export function statementCompiler() {
 
   STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
     let [, tag, _attrs, args, block] = sexp;
-
     let { resolver, referrer } = builder;
     let handle = resolver.lookupComponentDefinition(tag, referrer);
 
@@ -766,12 +765,24 @@ export function populateBuiltins(blocks: Blocks = new Blocks(), inlines: Inlines
   blocks.add('component', (_params, hash, template, inverse, builder) => {
     assert(_params && _params.length, 'SYNTAX ERROR: #component requires at least one argument');
 
+    let tag = _params[0];
+    if (typeof tag === 'string') {
+      let returned = builder.staticComponentHelper(_params[0] as string, hash, template);
+      if (returned) return;
+    }
+
     let [definition, ...params] = _params!;
     builder.dynamicComponent(definition, params, hash, true, template, inverse);
   });
 
   inlines.add('component', (_name, _params, hash, builder) => {
     assert(_params && _params.length, 'SYNTAX ERROR: component helper requires at least one argument');
+
+    let tag =_params && _params[0];
+    if (typeof tag === 'string') {
+      let returned = builder.staticComponentHelper(tag as string, hash, null);
+      if (returned) return true;
+    }
 
     let [definition, ...params] = _params!;
     builder.dynamicComponent(definition, params, hash, true, null, null);

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -11,7 +11,7 @@ export interface ConstantPool {
   arrays: number[][] | EMPTY_ARRAY;
   tables: SymbolTable[];
   handles: number[];
-  serializables: Opaque[];
+  serializables: string[];
   floats: number[];
   negatives: number[];
 }
@@ -31,7 +31,7 @@ export class WriteOnlyConstants implements CompileTimeConstants {
   protected arrays: number[][] | EMPTY_ARRAY = [WELL_KNOW_EMPTY_ARRAY];
   protected tables: SymbolTable[] = [];
   protected handles: number[] = [];
-  protected serializables: Opaque[] = [];
+  protected serializables: string[] = [];
   protected resolved: Opaque[] = [];
   protected floats: number[] = [];
   protected negatives: number[] = [];
@@ -105,13 +105,13 @@ export class WriteOnlyConstants implements CompileTimeConstants {
   }
 
   serializable(value: Opaque): number {
-    let index = this.serializables.indexOf(value);
-
+    let str = JSON.stringify(value);
+    let index = this.serializables.indexOf(str);
     if (index > -1) {
       return index;
     }
 
-    return this.serializables.push(value) - 1;
+    return this.serializables.push(str) - 1;
   }
 
   toPool(): ConstantPool {
@@ -132,7 +132,7 @@ export class RuntimeConstants<TemplateMeta> {
   protected arrays: number[][] | EMPTY_ARRAY;
   protected tables: SymbolTable[];
   protected handles: number[];
-  protected serializables: Opaque[];
+  protected serializables: string[];
   protected resolved: Opaque[];
   protected floats: number[];
   protected negatives: number[];
@@ -194,7 +194,8 @@ export class RuntimeConstants<TemplateMeta> {
   }
 
   getSerializable<T>(s: number): T {
-    return this.serializables[s] as T;
+
+    return JSON.parse(this.serializables[s]) as T;
   }
 }
 
@@ -259,12 +260,27 @@ export class Constants<TemplateMeta> extends WriteOnlyConstants {
   }
 
   getSerializable<T>(s: number): T {
-    return this.serializables[s] as T;
+    return JSON.parse(this.serializables[s]) as T;
   }
 }
 
 export class LazyConstants extends Constants<Opaque> {
   private others: Opaque[] = [];
+  protected meta: Opaque[] = [];
+
+  serializable(value: Opaque): number {
+    let index = this.meta.indexOf(value);
+
+    if (index > -1) {
+      return index;
+    }
+
+    return this.meta.push(value) - 1;
+  }
+
+  getSerializable<T>(s: number): T {
+    return this.meta[s] as T;
+  }
 
   getOther<T>(value: number): T {
     return this.others[value - 1] as T;

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -11,7 +11,6 @@ export interface ConstantPool {
   arrays: number[][] | EMPTY_ARRAY;
   tables: SymbolTable[];
   handles: number[];
-  serializables: string[];
   floats: number[];
   negatives: number[];
 }
@@ -31,7 +30,6 @@ export class WriteOnlyConstants implements CompileTimeConstants {
   protected arrays: number[][] | EMPTY_ARRAY = [WELL_KNOW_EMPTY_ARRAY];
   protected tables: SymbolTable[] = [];
   protected handles: number[] = [];
-  protected serializables: string[] = [];
   protected resolved: Opaque[] = [];
   protected floats: number[] = [];
   protected negatives: number[] = [];
@@ -106,12 +104,12 @@ export class WriteOnlyConstants implements CompileTimeConstants {
 
   serializable(value: Opaque): number {
     let str = JSON.stringify(value);
-    let index = this.serializables.indexOf(str);
+    let index = this.strings.indexOf(str);
     if (index > -1) {
       return index;
     }
 
-    return this.serializables.push(str) - 1;
+    return this.strings.push(str) - 1;
   }
 
   toPool(): ConstantPool {
@@ -120,7 +118,6 @@ export class WriteOnlyConstants implements CompileTimeConstants {
       arrays: this.arrays,
       tables: this.tables,
       handles: this.handles,
-      serializables: this.serializables,
       floats: this.floats,
       negatives: this.negatives
     };
@@ -132,7 +129,6 @@ export class RuntimeConstants<TemplateMeta> {
   protected arrays: number[][] | EMPTY_ARRAY;
   protected tables: SymbolTable[];
   protected handles: number[];
-  protected serializables: string[];
   protected resolved: Opaque[];
   protected floats: number[];
   protected negatives: number[];
@@ -142,7 +138,6 @@ export class RuntimeConstants<TemplateMeta> {
     this.arrays = pool.arrays;
     this.tables = pool.tables;
     this.handles = pool.handles;
-    this.serializables = pool.serializables;
     this.floats = pool.floats;
     this.negatives = pool.negatives;
     this.resolved = this.handles.map(() => UNRESOLVED);
@@ -195,7 +190,7 @@ export class RuntimeConstants<TemplateMeta> {
 
   getSerializable<T>(s: number): T {
 
-    return JSON.parse(this.serializables[s]) as T;
+    return JSON.parse(this.strings[s]) as T;
   }
 }
 
@@ -208,7 +203,6 @@ export class Constants<TemplateMeta> extends WriteOnlyConstants {
       this.arrays = pool.arrays;
       this.tables = pool.tables;
       this.handles = pool.handles;
-      this.serializables = pool.serializables;
       this.floats = pool.floats;
       this.negatives = pool.negatives;
       this.resolved = this.handles.map(() => UNRESOLVED);
@@ -260,26 +254,26 @@ export class Constants<TemplateMeta> extends WriteOnlyConstants {
   }
 
   getSerializable<T>(s: number): T {
-    return JSON.parse(this.serializables[s]) as T;
+    return JSON.parse(this.strings[s]) as T;
   }
 }
 
 export class LazyConstants extends Constants<Opaque> {
   private others: Opaque[] = [];
-  protected meta: Opaque[] = [];
+  protected serializables: Opaque[] = [];
 
   serializable(value: Opaque): number {
-    let index = this.meta.indexOf(value);
+    let index = this.serializables.indexOf(value);
 
     if (index > -1) {
       return index;
     }
 
-    return this.meta.push(value) - 1;
+    return this.serializables.push(value) - 1;
   }
 
   getSerializable<T>(s: number): T {
-    return this.meta[s] as T;
+    return this.serializables[s] as T;
   }
 
   getOther<T>(value: number): T {

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -9,7 +9,6 @@ export type EMPTY_ARRAY = Array<ReadonlyArray<never>>;
 export interface ConstantPool {
   strings: string[];
   arrays: number[][] | EMPTY_ARRAY;
-  tables: SymbolTable[];
   handles: number[];
   floats: number[];
   negatives: number[];
@@ -82,16 +81,6 @@ export class WriteOnlyConstants implements CompileTimeConstants {
     return (this.arrays as number[][]).push(values) - 1;
   }
 
-  table(t: SymbolTable): number {
-    let index = this.tables.indexOf(t);
-
-    if (index > -1) {
-      return index;
-    }
-
-    return this.tables.push(t) - 1;
-  }
-
   handle(handle: number): number {
     let index = this.handles.indexOf(handle);
     if (index > -1) {
@@ -116,7 +105,6 @@ export class WriteOnlyConstants implements CompileTimeConstants {
     return {
       strings: this.strings,
       arrays: this.arrays,
-      tables: this.tables,
       handles: this.handles,
       floats: this.floats,
       negatives: this.negatives
@@ -127,7 +115,6 @@ export class WriteOnlyConstants implements CompileTimeConstants {
 export class RuntimeConstants<TemplateMeta> {
   protected strings: string[];
   protected arrays: number[][] | EMPTY_ARRAY;
-  protected tables: SymbolTable[];
   protected handles: number[];
   protected resolved: Opaque[];
   protected floats: number[];
@@ -136,7 +123,6 @@ export class RuntimeConstants<TemplateMeta> {
   constructor(public resolver: RuntimeResolver<TemplateMeta>, pool: ConstantPool) {
     this.strings = pool.strings;
     this.arrays = pool.arrays;
-    this.tables = pool.tables;
     this.handles = pool.handles;
     this.floats = pool.floats;
     this.negatives = pool.negatives;
@@ -173,10 +159,6 @@ export class RuntimeConstants<TemplateMeta> {
     return (this.arrays as number[][])[value];
   }
 
-  getSymbolTable<T extends SymbolTable>(value: number): T {
-    return this.tables[value] as T;
-  }
-
   resolveHandle<T>(index: number): T {
     let resolved = this.resolved[index];
 
@@ -201,7 +183,6 @@ export class Constants<TemplateMeta> extends WriteOnlyConstants {
     if (pool) {
       this.strings = pool.strings;
       this.arrays = pool.arrays;
-      this.tables = pool.tables;
       this.handles = pool.handles;
       this.floats = pool.floats;
       this.negatives = pool.negatives;
@@ -236,10 +217,6 @@ export class Constants<TemplateMeta> extends WriteOnlyConstants {
 
   getArray(value: number): number[] {
     return (this.arrays as number[][])[value];
-  }
-
-  getSymbolTable<T extends SymbolTable>(value: number): T {
-    return this.tables[value] as T;
   }
 
   resolveHandle<T>(index: number): T {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -109,7 +109,7 @@ APPEND_OPCODES.add(Op.Exit, vm => {
 
 APPEND_OPCODES.add(Op.PushSymbolTable, (vm, { op1: _table }) => {
   let stack = vm.stack;
-  stack.push(vm.constants.getSymbolTable(_table));
+  stack.push(vm.constants.getSerializable(_table));
 });
 
 APPEND_OPCODES.add(Op.PushBlockScope, (vm) => {

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -71,6 +71,7 @@ export default class EagerRenderDelegate implements RenderDelegate {
   protected compileTimeModules = new Modules();
   protected components: Dict<ComponentDefinition<TestComponentDefinitionState>> = {};
   protected symbolTables = new ModuleLocatorMap<ProgramSymbolTable, ModuleLocator>();
+  public constants: DebugConstants;
 
   constructor(env: Environment) {
     this.env = env || new EagerTestEnvironment();
@@ -137,7 +138,8 @@ export default class EagerRenderDelegate implements RenderDelegate {
   renderTemplate(template: string, context: Dict<Opaque>, element: HTMLElement): RenderResult {
     let macros = new TestMacros();
     let delegate: EagerCompilerDelegate = new EagerCompilerDelegate(this.components, this.modules);
-    let program = new WriteOnlyProgram(new DebugConstants());
+    this.constants = new DebugConstants();
+    let program = new WriteOnlyProgram(this.constants);
     let compiler = new BundleCompiler(delegate, { macros, program });
 
     let locator = locatorFor({ module: 'ui/components/main', name: 'default' });
@@ -168,7 +170,6 @@ export default class EagerRenderDelegate implements RenderDelegate {
         symbolTable = wrapped.symbolTable;
       } else {
         block = compiler.add(locator, expect(state.template, 'expected component definition state to have template'));
-
         symbolTable = {
           hasEval: block.hasEval,
           symbols: block.symbols,

--- a/packages/@glimmer/test-helpers/lib/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/render-delegate.ts
@@ -4,8 +4,10 @@ import { Dict, Opaque } from '@glimmer/util';
 import { ComponentKind, ComponentTypes } from './render-test';
 import { UserHelper } from './environment/helper';
 import { BasicReference } from '@glimmer/reference';
+import { DebugConstants } from "@glimmer/bundle-compiler";
 
 export default interface RenderDelegate {
+  constants?: DebugConstants;
   getInitialElement(): HTMLElement;
   registerComponent<K extends ComponentKind, L extends ComponentKind>(type: K, testType: L, name: string, layout: string, Class?: ComponentTypes[K]): void;
   registerHelper(name: string, helper: UserHelper): void;

--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -32,6 +32,30 @@ export class EmberishComponentTests extends RenderTest {
   }
 
   @test({ kind: 'glimmer' })
+  "Static block component helper"() {
+    this.registerComponent('Glimmer', 'A', 'A {{#component "B" arg1=@one}}{{/component}}');
+    this.registerComponent('Glimmer', 'B', 'B {{@arg1}}');
+    this.render('<A @one={{arg}} />', { arg: 1 });
+    this.assertHTML('A B 1');
+    this.assertStableRerender();
+    this.rerender({arg: 2 });
+    this.assertHTML('A B 2');
+    this.assertStableNodes();
+  }
+
+  @test({ kind: 'glimmer' })
+  "Static inline component helper"() {
+    this.registerComponent('Glimmer', 'A', 'A {{component "B" arg1=@one}}');
+    this.registerComponent('Glimmer', 'B', 'B {{@arg1}}');
+    this.render('<A @one={{arg}} />', { arg: 1 });
+    this.assertHTML('A B 1');
+    this.assertStableRerender();
+    this.rerender({arg: 2 });
+    this.assertHTML('A B 2');
+    this.assertStableNodes();
+  }
+
+  @test({ kind: 'glimmer' })
   "top level in-element"() {
     this.registerComponent('Glimmer', 'Foo', '<Bar data-bar={{@childName}} @data={{@data}} />');
     this.registerComponent('Glimmer', 'Bar', '<div ...attributes>Hello World</div>');


### PR DESCRIPTION
Prior to these changes `{{component}}` invocations with a `StringLiteral` were treated as a dynamic invocation. This meant we would have to perform more work than required to invoke the component. This involved things resolving the component name at runtime, which in this case is completely unnecessary. When we are compiling we can infer the static invoke and resynthesize the invocation. For instance:

```hbs
{{component "A" foo=bar}}
```
to 

```hbs
<A @foo={{bar}} />
```

This also interns the "serializables" in constant pool for "eager mode" to make sure we have a more compact data segment. There still is a larger issue here and that is any `@` reference is a guarded append. This means we can not infer if the argument is going to evaluate as a `CurriedComponent` so we eagerly push the containing layout's symbol table into `serializables`.