### PR TITLE
Refine Dynamic Component Invocations

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -342,8 +342,16 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
     this.push(Op.PushComponentDefinition, this.constants.handle(handle));
   }
 
-  pushDynamicComponentManager(referrer: Locator) {
-    this.push(Op.PushDynamicComponentManager, this.constants.serializable(referrer));
+  pushCurriedComponent() {
+    this.push(Op.PushCurriedComponent);
+  }
+
+  pushDynamicComponentInstance() {
+    this.push(Op.PushDynamicComponentInstance);
+  }
+
+  resolveDynamicComponent(referrer: Locator) {
+    this.push(Op.ResolveDynamicComponent, this.constants.serializable(referrer));
   }
 
   staticComponentHelper(tag: string, hash: WireFormat.Core.Hash, template: Option<CompilableBlock>) {
@@ -751,7 +759,10 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
 
     this.jumpUnless('ELSE');
 
-    this.pushDynamicComponentManager(this.referrer);
+    this.pushCurriedComponent();
+
+    this.pushDynamicComponentInstance();
+
     this.invokeComponent(null, null, null, false, null, null);
 
     this.exit();
@@ -941,7 +952,10 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
 
     this.jumpUnless('ELSE');
 
-    this.pushDynamicComponentManager(this.referrer);
+    this.resolveDynamicComponent(this.referrer);
+
+    this.pushDynamicComponentInstance();
+
     this.invokeComponent(null, params, hash, synthetic, block, inverse);
 
     this.label('ELSE');

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -134,9 +134,8 @@ APPEND_OPCODES.add(Op.PushComponentDefinition, (vm, { op1: handle }) => {
   expectStackChange(vm.stack, 1, 'PushComponentDefinition');
 });
 
-APPEND_OPCODES.add(Op.PushDynamicComponentManager, (vm, { op1: _meta }) => {
+APPEND_OPCODES.add(Op.ResolveDynamicComponent, (vm, { op1: _meta }) => {
   let stack = vm.stack;
-
   let component = check(stack.pop(), CheckPathReference).value();
   let definition: ComponentDefinition | CurriedComponentDefinition;
 
@@ -152,9 +151,32 @@ APPEND_OPCODES.add(Op.PushDynamicComponentManager, (vm, { op1: _meta }) => {
     throw unreachable();
   }
 
-  stack.push({ definition, manager: null, state: null, handle: null, table: null });
+  stack.push(definition);
+  expectStackChange(vm.stack, 0, 'ResolveDynamicComponent');
+});
 
-  expectStackChange(vm.stack, 0, 'PushDynamicComponentManager');
+APPEND_OPCODES.add(Op.PushDynamicComponentInstance, (vm) => {
+  let { stack } = vm;
+  let definition = stack.pop();
+  stack.push({ definition, manager: null, state: null, handle: null, table: null });
+  expectStackChange(vm.stack, 0, 'PushDynamicComponentInstance');
+});
+
+APPEND_OPCODES.add(Op.PushCurriedComponent, (vm, { op1: _meta }) => {
+  let stack = vm.stack;
+
+  let component = check(stack.pop(), CheckPathReference).value();
+  let definition: CurriedComponentDefinition;
+
+  if (isCurriedComponentDefinition(component)) {
+    definition = component;
+  } else {
+    throw unreachable();
+  }
+
+  stack.push(definition);
+
+  expectStackChange(vm.stack, 0, 'PushCurriedComponent');
 });
 
 APPEND_OPCODES.add(Op.PushArgs, (vm, { op1: _names, op2: flags }) => {

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -305,10 +305,8 @@ OPCODE_METADATA(Op.PushComponentDefinition, {
   stackChange: 1,
 });
 
-OPCODE_METADATA(Op.PushDynamicComponentManager, {
-  name: 'PushDynamicComponentManager',
-  ops: [Serializable('meta')],
-  operands: 1
+OPCODE_METADATA(Op.PushCurriedComponent, {
+  name: 'PushDynamicComponentManager'
 });
 
 OPCODE_METADATA(Op.PushArgs, {
@@ -427,6 +425,16 @@ OPCODE_METADATA(Op.DynamicContent, {
   ops: [Bool('trusting')],
   operands: 1,
   stackChange: -1
+});
+
+OPCODE_METADATA(Op.ResolveDynamicComponent, {
+  name: 'ResolveDynamicComponentManager',
+  ops: [Serializable('meta')],
+  operands: 1
+});
+
+OPCODE_METADATA(Op.PushDynamicComponentInstance, {
+  name: 'PushDynamicComponentManager'
 });
 
 OPCODE_METADATA(Op.OpenElement, {

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -698,16 +698,41 @@ export const enum Op {
 
   /**
    * Operation:
-   *   Push an appropriate component manager onto the stack from
-   *   a runtime-resolved component definition.
+   *   Pushes the ComponentInstance onto the stack that is
+   *   used during the invoke.
    *
    * Format:
-   *   (PushDynamicComponentManager templateMeta:#TemplateMeta)
+   *   (PushDynamicComponentInstance)
+   * Operand Stack:
+   *   ..., ComponentDefinition →
+   *   ..., { ComponentDefinition, manager: null, layout: null, state: null, handle: null, table: null }
+   */
+
+  PushDynamicComponentInstance,
+
+  /**
+   * Operation:
+   *   Pushes a curried component definition on to the stack
+   *
+   * Format:
+   *   (PushCurriedComponent)
    * Operand Stack:
    *   ..., VersionedPathReference<Opaque> →
-   *   ..., { ComponentDefinition, ComponentManager }
+   *   ..., ComponentDefinition
    */
-  PushDynamicComponentManager,
+  PushCurriedComponent,
+
+  /**
+   * Operation:
+   *   Push a resolved component definition onto the stack
+   *
+   * Format:
+   *   (ResolveDynamicComponent templateMeta:#TemplateMeta)
+   * Operand Stack:
+   *   ..., VersionedPathReference<Opaque> →
+   *   ..., ComponentDefinition
+   */
+  ResolveDynamicComponent,
 
   /**
    * Operation: Push a user representation of args onto the stack.


### PR DESCRIPTION
This fixes an issue where we were eagerly serializing `TemplateMeta` for the append of a closed over component. This is because we had an overly generic `PushDynamicComponentManager` that was being used to resolve and/or pushing the definition for the actual invoke. This PR introduces 2 new opcodes: one to deal with resolving the definition and one for simply pushing a pre-resolved curried component.