### PR TITLE
Fix debug logging not to crash when a null block is pushed.

### DIFF
--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -97,7 +97,11 @@ export class AppendOpcodes {
       /* tslint:disable */
       console.log('%c -> pc: %d, ra: %d, fp: %d, sp: %d, s0: %O, s1: %O, t0: %O, t1: %O, v0: %O', 'color: orange', vm['pc'], vm['ra'], vm['fp'], vm['sp'], vm['s0'], vm['s1'], vm['t0'], vm['t1'], vm['v0']);
       console.log('%c -> eval stack', 'color: red', vm.stack.toArray());
-      console.log('%c -> scope', 'color: green', vm.scope()['slots'].map(s => s && s['value'] ? s['value']() : s));
+      if (vm['scopeStack'].current === null) {
+        console.log('%c -> scope', 'color: green', "null");
+      } else {
+        console.log('%c -> scope', 'color: green', vm.scope()['slots'].map(s => s && s['value'] ? s['value']() : s));
+      }
       console.log('%c -> elements', 'color: blue', vm.elements()['cursorStack']['stack'].map((c: any) => c.element));
       /* tslint:enable */
     }


### PR DESCRIPTION
The CompileBlock opcode does a stack.pushNull() when there is no block.