### PR TITLE
Fix has-block-params in prod mode

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -86,8 +86,10 @@ APPEND_OPCODES.add(Op.HasBlock, (vm, { op1: _block }) => {
 
 APPEND_OPCODES.add(Op.HasBlockParams, (vm) => {
   // FIXME(mmun): should only need to push the symbol table
-  check(vm.stack.pop(), CheckOption(CheckOr(CheckHandle, CheckCompilableBlock)));
-  check(vm.stack.pop(), CheckOption(CheckScope));
+  let block = vm.stack.pop();
+  let scope = vm.stack.pop();
+  check(block, CheckOption(CheckOr(CheckHandle, CheckCompilableBlock)));
+  check(scope, CheckOption(CheckScope));
   let table = check(vm.stack.pop(), CheckOption(CheckBlockSymbolTable));
 
   assert(table === null || (table && typeof table === 'object' && Array.isArray(table.parameters)), stackAssert('Option<BlockSymbolTable>', table));


### PR DESCRIPTION
In prod mode, check(expr, ...) is completely stripped out if not returned or assigned. In has-block-params (and only has-block-params), check() was passed an expression that had important side effects (stack
pops) which was being stripped out in production.

We should probably be testing Glimmer against prod builds, or change the check() macro to handle this case better.