### PR TITLE
Allow null for iterable keys

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/lists.ts
@@ -7,7 +7,7 @@ import {
 } from '@glimmer/reference';
 import { APPEND_OPCODES } from '../../opcodes';
 import { CheckPathReference } from './-debug-strip';
-import { check, CheckString, expectStackChange, CheckInstanceof } from "@glimmer/debug";
+import { check, expectStackChange, CheckInstanceof } from "@glimmer/debug";
 
 class IterablePresenceReference implements Reference<boolean> {
   public tag: Tag;
@@ -27,7 +27,7 @@ APPEND_OPCODES.add(Op.PutIterator, vm => {
   let stack = vm.stack;
   let listRef = check(stack.pop(), CheckPathReference);
   let key = check(stack.pop(), CheckPathReference);
-  let iterable = vm.env.iterableFor(listRef, check(key.value(), CheckString));
+  let iterable = vm.env.iterableFor(listRef, key.value());
   let iterator = new ReferenceIterator(iterable);
 
   stack.push(iterator);

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -244,7 +244,7 @@ export abstract class Environment {
     return new ConditionalReference(reference);
   }
 
-  abstract iterableFor(reference: Reference, key: string): OpaqueIterable;
+  abstract iterableFor(reference: Reference, key: Opaque): OpaqueIterable;
   abstract protocolForURL(s: string): string;
 
   getAppendOperations(): DOMTreeConstruction { return this.appendOperations; }

--- a/packages/@glimmer/test-helpers/lib/environment/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/environment.ts
@@ -1,6 +1,5 @@
 import { Environment, DOMTreeConstruction, IDOMChanges, PrimitiveReference, ConditionalReference } from '@glimmer/runtime';
 import { dict } from '@glimmer/util';
-import { check, CheckString } from '@glimmer/debug';
 import { Dict, RuntimeResolver, Opaque, VMHandle } from '@glimmer/interfaces';
 import { Program } from '@glimmer/program';
 import { Reference, isConst, OpaqueIterable } from '@glimmer/reference';
@@ -39,7 +38,6 @@ export default abstract class TestEnvironment<TemplateMeta> extends Environment 
 
   iterableFor(ref: Reference<Opaque>, keyPath: string): OpaqueIterable {
     let keyFor: KeyFor<Opaque>;
-    check(keyPath, CheckString);
 
     if (!keyPath) {
       throw new Error('Must specify a key for #each');

--- a/packages/@glimmer/test-helpers/lib/environment/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/environment.ts
@@ -1,5 +1,6 @@
 import { Environment, DOMTreeConstruction, IDOMChanges, PrimitiveReference, ConditionalReference } from '@glimmer/runtime';
 import { dict } from '@glimmer/util';
+import { check, CheckString } from '@glimmer/debug';
 import { Dict, RuntimeResolver, Opaque, VMHandle } from '@glimmer/interfaces';
 import { Program } from '@glimmer/program';
 import { Reference, isConst, OpaqueIterable } from '@glimmer/reference';
@@ -38,6 +39,7 @@ export default abstract class TestEnvironment<TemplateMeta> extends Environment 
 
   iterableFor(ref: Reference<Opaque>, keyPath: string): OpaqueIterable {
     let keyFor: KeyFor<Opaque>;
+    check(keyPath, CheckString);
 
     if (!keyPath) {
       throw new Error('Must specify a key for #each');


### PR DESCRIPTION
Ember does not require a key for the `{{#each}}` helper, so allow null
and do the check in the environment's `iterableFor`.