### PR TITLE
Fix nested currying.

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -1039,6 +1039,7 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
 
     this.pushFrame();
     this.compileArgs(params, hash, null, synthetic);
+    this.push(Op.CaptureArgs);
     this.expr(definition);
     this.push(Op.CurryComponent, this.constants.serializable(referrer));
     this.popFrame();

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
@@ -1,7 +1,7 @@
 
-import { Checker, CheckInstanceof, CheckFunction, CheckInterface, CheckOpaque, CheckBlockSymbolTable, CheckProgramSymbolTable, CheckHandle, wrap } from "@glimmer/debug";
+import { Checker, CheckInstanceof, CheckFunction, CheckInterface, CheckOpaque, CheckBlockSymbolTable, CheckProgramSymbolTable, CheckHandle, wrap, CheckNumber } from "@glimmer/debug";
 import { Tag, TagWrapper, VersionedPathReference, Reference } from "@glimmer/reference";
-import { Arguments } from '../../vm/arguments';
+import { Arguments, ICapturedArguments, CapturedPositionalArguments, CapturedNamedArguments } from '../../vm/arguments';
 import { ComponentInstance } from './component';
 import { ComponentManager } from '../../internal-interfaces';
 import { Scope } from '../../environment';
@@ -17,6 +17,14 @@ export const CheckReference: Checker<Reference> =
   CheckInterface({ tag: CheckTag, value: CheckFunction });
 
 export const CheckArguments = wrap(() => CheckInstanceof(Arguments));
+export const CheckCapturedArguments: Checker<ICapturedArguments> =
+  CheckInterface({
+    tag: CheckTag,
+    length: CheckNumber,
+    positional: CheckInstanceof(CapturedPositionalArguments),
+    named: CheckInstanceof(CapturedNamedArguments)
+  });
+
 export const CheckScope = wrap(() => CheckInstanceof(Scope));
 
 export const CheckComponentManager: Checker<ComponentManager> =

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -244,7 +244,7 @@ export class PositionalArguments implements IPositionalArguments {
   }
 }
 
-class CapturedPositionalArguments implements ICapturedPositionalArguments {
+export class CapturedPositionalArguments implements ICapturedPositionalArguments {
   static empty(): CapturedPositionalArguments {
     return new CapturedPositionalArguments(CONSTANT_TAG, EMPTY_ARRAY, 0);
   }
@@ -411,7 +411,7 @@ export class NamedArguments implements INamedArguments {
   }
 }
 
-class CapturedNamedArguments implements ICapturedNamedArguments {
+export class CapturedNamedArguments implements ICapturedNamedArguments {
   public length: number;
   private _map: Option<Dict<VersionedPathReference<Opaque>>>;
 

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -1062,6 +1062,44 @@ QUnit.test('component helper can curry arguments', () => {
   `);
 });
 
+QUnit.test('component helper: currying works inline', () => {
+  let FooBarComponent = EmberishCurlyComponent.extend();
+
+  FooBarComponent.reopenClass({
+    positionalParams: ["one", "two", "three", "four", "five", "six"]
+  });
+
+  env.registerEmberishCurlyComponent('foo-bar', FooBarComponent as any, stripTight`
+    1. [{{one}}]
+    2. [{{two}}]
+    3. [{{three}}]
+    4. [{{four}}]
+    5. [{{five}}]
+    6. [{{six}}]
+  `);
+
+  appendViewFor(
+    stripTight`
+      {{component (component (component 'foo-bar' foo.first foo.second) 'inner 1') 'invocation 1' 'invocation 2'}}
+    `,
+    {
+      foo: {
+        first: 'outer 1',
+        second: 'outer 2'
+      }
+    }
+  );
+
+  assertText(stripTight`
+    1. [outer 1]
+    2. [outer 2]
+    3. [inner 1]
+    4. [invocation 1]
+    5. [invocation 2]
+    6. []
+  `);
+});
+
 module("Emberish Component - ids");
 
 QUnit.test('emberish component should have unique IDs', assert => {

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -322,6 +322,10 @@ OPCODE_METADATA(Op.PrepareArgs, {
   skipCheck: true
 });
 
+OPCODE_METADATA(Op.CaptureArgs, {
+  name: 'CaptureArgs'
+});
+
 OPCODE_METADATA(Op.CreateComponent, {
   name: 'CreateComponent',
   ops: [I32('flags'), Register('state')],

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -782,6 +782,17 @@ export const enum Op {
   PrepareArgs,
 
   /**
+   * Operation: ...
+   * Format:
+   *   (CaptureArgs)
+   *
+   * Operand Stack:
+   *   ..., Arguments  →
+   *   ..., CapturedArguments
+   */
+  CaptureArgs,
+
+  /**
    * Operation: Create the component and push it onto the stack.
    * Format:
    *   (CreateComponent flags:u32 state:register)

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -782,13 +782,20 @@ export const enum Op {
   PrepareArgs,
 
   /**
-   * Operation: ...
+   * Operation: Replaces Arguments on the stack with CapturedArguments
    * Format:
    *   (CaptureArgs)
    *
    * Operand Stack:
    *   ..., Arguments  →
    *   ..., CapturedArguments
+   *
+   * Description:
+   * The Arguments object is mutated in place because it is usually consumed immediately
+   * after being pushed on to the stack. In some situations, such as with curried components,
+   * information about more than one Argument may need to exist on the stack at once. In those
+   * cases, the CaptureArgs instruction pops an Arguments object off the stack and replaces it
+   * with the immutable CapturedArgs snapshot.
    */
   CaptureArgs,
 


### PR DESCRIPTION
Given the following template:

```hbs
{{component (component (component 'foo-bar' 'one') 'two')}}
```

We expect that `foo-bar` receives two positional params: `'one'` and `'two'`.

Prior to the changes made here the _actual_ result was `'one'` and `'one'`. :scream:

The underlying issue here is that the `OpcodeBuilder#curryComponent` building assumes that when it calls `this.pushArgs` _nothing_ else will mutate those args before the `Ops.CurryComponent` is ran. Unfortunately, when we have nested invocations, the processing of the nested `(component` invocation ends up modifying the global shared `ARGS` so that when the outer `(component`'s `Op.CurryComponent` is ran, the contents of `ARGS` is _wrong_.

The fix (as implemented here) is that we push a new `CaptureArgs` opcode so that any arbitrary levels of nested `(component` invocations all end up with the correct set of captured args.

---

A joint @tomdale / @rwjblue production...