### PR TITLE
improve nested transaction error message

### DIFF
--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -255,7 +255,7 @@ export abstract class Environment {
   }
 
   begin() {
-    assert(!this._transaction, 'a glimmer transaction was begun, but one already exists. You may have a nested transaction');
+    assert(!this._transaction, 'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.');
     this._transaction = new Transaction();
   }
 

--- a/packages/@glimmer/runtime/test/env-test.ts
+++ b/packages/@glimmer/runtime/test/env-test.ts
@@ -5,7 +5,7 @@ QUnit.module('env');
 QUnit.test('assert against nested transactions', assert => {
   let env = new TestEnvironment();
   env.begin();
-  assert.throws(() => env.begin(), 'a glimmer transaction was begun, but one already exists. You may have a nested transaction');
+  assert.throws(() => env.begin(), 'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.');
 });
 
 QUnit.test('ensure commit cleans up when it can', assert => {


### PR DESCRIPTION
fixes https://github.com/glimmerjs/glimmer-vm/issues/755

**before**

`a glimmer transaction was begun, but one already exists. Please check your console for the stack trace of any prior exceptions.`

**after**

`A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.`