### PR TITLE
Encode component capabilities using bitmasks

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -84,3 +84,4 @@ export { normalizeProperty } from './lib/dom/props';
 export { ElementBuilder, NewElementBuilder, ElementOperations, clientBuilder } from './lib/vm/element-builder';
 export { rehydrationBuilder, RehydrateBuilder } from './lib/vm/rehydrate-builder';
 export { default as Bounds, ConcreteBounds, Cursor } from './lib/bounds';
+export { capabilityFlagsFrom, hasCapability, Capability } from './lib/capabilities';

--- a/packages/@glimmer/runtime/lib/capabilities.ts
+++ b/packages/@glimmer/runtime/lib/capabilities.ts
@@ -1,0 +1,31 @@
+import { ComponentCapabilities, Unique, Recast } from "@glimmer/interfaces";
+import { check, CheckNumber } from "@glimmer/debug";
+
+export type CapabilityFlags = Unique<"CapabilityFlag">;
+
+export const enum Capability {
+  DynamicLayout = 0b000001,
+  DynamicTag    = 0b000010,
+  PrepareArgs   = 0b000100,
+  CreateArgs    = 0b001000,
+  AttributeHook = 0b010000,
+  ElementHook   = 0b100000
+}
+
+/**
+ * Converts a ComponentCapabilities object into a 32-bit integer representation.
+ */
+export function capabilityFlagsFrom(capabilities: ComponentCapabilities): CapabilityFlags {
+  return (0 |
+    (capabilities.dynamicLayout ? Capability.DynamicLayout : 0) |
+    (capabilities.dynamicTag ? Capability.DynamicTag : 0) |
+    (capabilities.prepareArgs ? Capability.PrepareArgs : 0) |
+    (capabilities.createArgs ? Capability.CreateArgs : 0) |
+    (capabilities.attributeHook ? Capability.AttributeHook : 0) |
+    (capabilities.elementHook ? Capability.ElementHook : 0)) as Recast<number, CapabilityFlags>;
+}
+
+export function hasCapability(capabilities: CapabilityFlags, capability: Capability): boolean {
+  check(capabilities, CheckNumber);
+  return !!((capabilities as Recast<CapabilityFlags, number>) & capability);
+}

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -172,7 +172,7 @@ APPEND_OPCODES.add(Op.ResolveDynamicComponent, (vm, { op1: _meta }) => {
 
 APPEND_OPCODES.add(Op.PushDynamicComponentInstance, (vm) => {
   let { stack } = vm;
-  const definition = stack.pop<ComponentDefinition>();
+  let definition = stack.pop<ComponentDefinition>();
 
   let capabilities, manager;
 
@@ -443,8 +443,8 @@ APPEND_OPCODES.add(Op.Main, (vm, { op1: register }) => {
   let definition = vm.stack.pop<ComponentDefinition>();
   let invocation = vm.stack.pop<Invocation>();
 
-  const { manager } = definition;
-  const capabilities = capabilityFlagsFrom(manager.getCapabilities(definition.state));
+  let { manager } = definition;
+  let capabilities = capabilityFlagsFrom(manager.getCapabilities(definition.state));
 
   let state: PopulatedComponentInstance = {
     definition,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -7,7 +7,8 @@ import {
   ProgramSymbolTable,
   ComponentInstanceState,
   ComponentDefinitionState,
-  Recast
+  Recast,
+  RuntimeResolver
 } from '@glimmer/interfaces';
 import {
   CONSTANT_TAG,
@@ -33,16 +34,16 @@ import { UpdatingVM, VM } from '../../vm';
 import { Arguments, IArguments } from '../../vm/arguments';
 import { IsCurriedComponentDefinitionReference } from './content';
 import { UpdateDynamicAttributeOpcode } from './dom';
-import { ComponentManager, Component } from '../../internal-interfaces';
+import { Component } from '../../internal-interfaces';
 import { resolveComponent } from "../../component/resolve";
 import {
-  hasDynamicLayout,
-  hasStaticLayout,
   WithDynamicTagName,
   WithElementHook,
   ComponentDefinition,
   InternalComponentManager,
-  Invocation
+  Invocation,
+  WithDynamicLayout,
+  WithStaticLayout
 } from '../../component/interfaces';
 import {
   CurriedComponentDefinition,
@@ -50,6 +51,7 @@ import {
 } from '../../component/curried-component';
 import CurryComponentReference from '../../references/curry-component';
 import ClassListReference from '../../references/class-list';
+import { capabilityFlagsFrom, Capability, hasCapability, CapabilityFlags } from '../../capabilities';
 import {
   CheckReference,
   CheckArguments,
@@ -73,6 +75,7 @@ export const ARGS = new Arguments();
 export interface ComponentInstance {
   definition: ComponentDefinition;
   manager: InternalComponentManager;
+  capabilities: CapabilityFlags;
   state: ComponentInstanceState;
   handle: number;
   table: ProgramSymbolTable;
@@ -81,6 +84,7 @@ export interface ComponentInstance {
 export interface InitialComponentInstance {
   definition: PartialComponentDefinition;
   manager: Option<InternalComponentManager>;
+  capabilities: Option<CapabilityFlags>;
   state: null;
   handle: Option<VMHandle>;
   table: Option<ProgramSymbolTable>;
@@ -89,8 +93,9 @@ export interface InitialComponentInstance {
 export interface PopulatedComponentInstance {
   definition: ComponentDefinition;
   manager: InternalComponentManager;
+  capabilities: CapabilityFlags;
   state: null;
-  handle: Option<number>;
+  handle: Option<VMHandle>;
   table: Option<ProgramSymbolTable>;
 }
 
@@ -125,7 +130,18 @@ APPEND_OPCODES.add(Op.PushComponentDefinition, (vm, { op1: handle }) => {
   assert(!!definition, `Missing component for ${handle}`);
 
   let { manager } = definition;
-  vm.stack.push({ definition, manager, state: null, handle: null, table: null });
+  let capabilities = capabilityFlagsFrom(manager.getCapabilities(definition.state));
+
+  let instance: InitialComponentInstance = {
+    definition,
+    manager,
+    capabilities,
+    state: null,
+    handle: null,
+    table: null
+  };
+
+  vm.stack.push(instance);
 
   expectStackChange(vm.stack, 1, 'PushComponentDefinition');
 });
@@ -156,8 +172,18 @@ APPEND_OPCODES.add(Op.ResolveDynamicComponent, (vm, { op1: _meta }) => {
 
 APPEND_OPCODES.add(Op.PushDynamicComponentInstance, (vm) => {
   let { stack } = vm;
-  let definition = stack.pop();
-  stack.push({ definition, manager: null, state: null, handle: null, table: null });
+  const definition = stack.pop<ComponentDefinition>();
+
+  let capabilities, manager;
+
+  if (isCurriedComponentDefinition(definition)) {
+    manager = capabilities = null;
+  } else {
+    manager = definition.manager;
+    capabilities = capabilityFlagsFrom(manager.getCapabilities(definition.state));
+  }
+
+  stack.push({ definition, capabilities, manager, state: null, handle: null, table: null });
   expectStackChange(vm.stack, 0, 'PushDynamicComponentInstance');
 });
 
@@ -204,25 +230,20 @@ APPEND_OPCODES.add(Op.CaptureArgs, vm => {
 
 APPEND_OPCODES.add(Op.PrepareArgs, (vm, { op1: _state }) => {
   let stack = vm.stack;
-  let instance = vm.fetchValue<InitialComponentInstance>(_state);
+  let instance = vm.fetchValue<ComponentInstance>(_state);
+  let args = check(stack.pop(), CheckInstanceof(Arguments));
 
   let { definition } = instance;
 
-  let args: Arguments;
-
   if (isCurriedComponentDefinition(definition)) {
     assert(!definition.manager, "If the component definition was curried, we don't yet have a manager");
-
-    args = check(stack.pop(), CheckInstanceof(Arguments));
-    definition = instance.definition = definition.unwrap(args);
-  } else {
-    args = check(stack.pop(), CheckInstanceof(Arguments));
+    definition = resolveCurriedComponentDefinition(instance, definition, args);
   }
 
-  let { manager, state } = definition as ComponentDefinition;
-  instance.manager = definition.manager;
+  let { manager, state } = definition;
+  let capabilities = instance.capabilities;
 
-  if (manager.getCapabilities(state).prepareArgs !== true) {
+  if (hasCapability(capabilities, Capability.PrepareArgs) !== true) {
     stack.push(args);
     return;
   }
@@ -258,16 +279,31 @@ APPEND_OPCODES.add(Op.PrepareArgs, (vm, { op1: _state }) => {
   stack.push(args);
 });
 
+function resolveCurriedComponentDefinition(instance: ComponentInstance, definition: CurriedComponentDefinition, args: Arguments): ComponentDefinition {
+  let unwrappedDefinition = instance.definition = definition.unwrap(args);
+  let { manager, state } = unwrappedDefinition;
+
+  assert(instance.manager === null, "component instance manager should not be populated yet");
+  assert(instance.capabilities === null, "component instance manager should not be populated yet");
+
+  instance.manager = manager;
+  instance.capabilities = capabilityFlagsFrom(manager.getCapabilities(state));
+
+  return unwrappedDefinition;
+}
+
 APPEND_OPCODES.add(Op.CreateComponent, (vm, { op1: flags, op2: _state }) => {
   let dynamicScope = vm.dynamicScope();
 
   let instance = vm.fetchValue<PopulatedComponentInstance>(_state);
   let { definition, manager } = instance;
 
+  let capabilities = instance.capabilities = capabilityFlagsFrom(manager.getCapabilities(definition.state));
+
   let hasDefaultBlock = flags & 1;
   let args: Option<IArguments> = null;
 
-  if (manager.getCapabilities(definition.state).createArgs) {
+  if (hasCapability(capabilities, Capability.CreateArgs)) {
     args = check(vm.stack.peek(), CheckArguments);
   }
 
@@ -369,7 +405,7 @@ APPEND_OPCODES.add(Op.GetComponentTagName, (vm, { op1: _state }) => {
   let { definition, state } = check(vm.fetchValue(_state), CheckComponentInstance);
   let { manager } = definition;
 
-  vm.stack.push((manager as Recast<ComponentManager, WithDynamicTagName<Component>>).getTagName(state));
+  vm.stack.push((manager as Recast<InternalComponentManager, WithDynamicTagName<Component>>).getTagName(state));
 });
 
 // Dynamic Invocation Only
@@ -378,14 +414,14 @@ APPEND_OPCODES.add(Op.GetComponentLayout, (vm, { op1: _state }) => {
   let { manager, definition } = instance;
   let { constants: { resolver }, stack } = vm;
 
-  let { state: instanceState } = instance;
+  let { state: instanceState, capabilities } = instance;
   let { state: definitionState } = definition;
 
   let invoke: { handle: number, symbolTable: ProgramSymbolTable };
 
-  if (hasStaticLayout(definitionState, manager)) {
+  if (hasStaticLayout(capabilities, manager)) {
     invoke = manager.getLayout(definitionState, resolver);
-  } else if (hasDynamicLayout(definitionState, manager)) {
+  } else if (hasDynamicLayout(capabilities, manager)) {
     invoke = manager.getDynamicLayout(instanceState, resolver);
   } else {
     throw unreachable();
@@ -395,15 +431,27 @@ APPEND_OPCODES.add(Op.GetComponentLayout, (vm, { op1: _state }) => {
   stack.push(invoke.handle);
 });
 
+function hasStaticLayout(capabilities: CapabilityFlags, _manager: InternalComponentManager): _manager is WithStaticLayout<ComponentInstanceState, ComponentDefinitionState, Opaque, RuntimeResolver<Opaque>> {
+  return hasCapability(capabilities, Capability.DynamicLayout) === false;
+}
+
+function hasDynamicLayout(capabilities: CapabilityFlags, _manager: InternalComponentManager): _manager is WithDynamicLayout<ComponentInstanceState, Opaque, RuntimeResolver<Opaque>> {
+  return hasCapability(capabilities, Capability.DynamicLayout) === true;
+}
+
 APPEND_OPCODES.add(Op.Main, (vm, { op1: register }) => {
   let definition = vm.stack.pop<ComponentDefinition>();
   let invocation = vm.stack.pop<Invocation>();
 
+  const { manager } = definition;
+  const capabilities = capabilityFlagsFrom(manager.getCapabilities(definition.state));
+
   let state: PopulatedComponentInstance = {
     definition,
-    manager: definition.manager,
+    manager,
+    capabilities,
     state: null,
-    handle: invocation.handle,
+    handle: invocation.handle as Recast<number, VMHandle>,
     table: invocation.symbolTable
   };
 
@@ -503,7 +551,7 @@ export class UpdateComponentOpcode extends UpdatingOpcode {
   constructor(
     public tag: Tag,
     private component: Component,
-    private manager: ComponentManager,
+    private manager: InternalComponentManager,
     private dynamicScope: DynamicScope,
   ) {
     super();
@@ -521,7 +569,7 @@ export class DidUpdateLayoutOpcode extends UpdatingOpcode {
   public tag: Tag = CONSTANT_TAG;
 
   constructor(
-    private manager: ComponentManager,
+    private manager: InternalComponentManager,
     private component: Component,
     private bounds: Bounds,
   ) {

--- a/packages/@glimmer/runtime/test/capabilities-test.ts
+++ b/packages/@glimmer/runtime/test/capabilities-test.ts
@@ -1,0 +1,50 @@
+import { capabilityFlagsFrom, hasCapability, Capability } from '..';
+
+QUnit.module('Capabilities Bitmaps');
+
+QUnit.test('encodes a capabilities object into a bitmap', assert => {
+  assert.equal(capabilityFlagsFrom({
+    dynamicLayout: false,
+    dynamicTag: false,
+    prepareArgs: false,
+    createArgs: false,
+    attributeHook: false,
+    elementHook: false
+  }), 0b000000, 'empty capabilities');
+
+  assert.equal(capabilityFlagsFrom({
+    dynamicLayout: true,
+    dynamicTag: true,
+    prepareArgs: true,
+    createArgs: true,
+    attributeHook: true,
+    elementHook: true
+  }), 0b111111, 'all capabilities');
+
+  assert.equal(capabilityFlagsFrom({
+    dynamicLayout: true,
+    dynamicTag: false,
+    prepareArgs: true,
+    createArgs: false,
+    attributeHook: false,
+    elementHook: true
+  }), 0b100101, 'random sample');
+});
+
+QUnit.test('allows querying bitmap for a capability', assert => {
+  let capabilities = capabilityFlagsFrom({
+    dynamicLayout: true,
+    dynamicTag: false,
+    prepareArgs: true,
+    createArgs: false,
+    attributeHook: false,
+    elementHook: true
+  });
+
+  assert.strictEqual(true, hasCapability(capabilities, Capability.DynamicLayout));
+  assert.strictEqual(false, hasCapability(capabilities, Capability.DynamicTag));
+  assert.strictEqual(true, hasCapability(capabilities, Capability.PrepareArgs));
+  assert.strictEqual(false, hasCapability(capabilities, Capability.CreateArgs));
+  assert.strictEqual(false, hasCapability(capabilities, Capability.AttributeHook));
+  assert.strictEqual(true, hasCapability(capabilities, Capability.ElementHook));
+});

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -306,7 +306,7 @@ OPCODE_METADATA(Op.PushComponentDefinition, {
 });
 
 OPCODE_METADATA(Op.PushCurriedComponent, {
-  name: 'PushDynamicComponentManager'
+  name: 'PushCurriedComponent'
 });
 
 OPCODE_METADATA(Op.PushArgs, {
@@ -432,13 +432,13 @@ OPCODE_METADATA(Op.DynamicContent, {
 });
 
 OPCODE_METADATA(Op.ResolveDynamicComponent, {
-  name: 'ResolveDynamicComponentManager',
+  name: 'ResolveDynamicComponent',
   ops: [Serializable('meta')],
   operands: 1
 });
 
 OPCODE_METADATA(Op.PushDynamicComponentInstance, {
-  name: 'PushDynamicComponentManager'
+  name: 'PushDynamicComponentInstance'
 });
 
 OPCODE_METADATA(Op.OpenElement, {


### PR DESCRIPTION
Glimmer has the concept of "capabilities," which are per-component features that can be turned on or off and allow the VM to perform both compile-time and run-time optimizations.

Previously, we represented capabilities as a JavaScript object, where each capability was a property whose value was either true or false. This works, but introduces difficulties when interoperating with WebAssembly, which doesn't understand JavaScript objects natively.

This commit introduces a serialization of the `ComponentCapabilities` object into a 32-bit integer, where each capability is represented as a single bit. Note that this change is purely internal to the VM at the moment; component managers still return a JavaScript object from `getComponentCapabilities`.

As an additional optimization, this commit also caches a component's capabilities on the `ComponentInstance` object. Although capabilities were intended to be immutable over the lifetime of a component, we never cached capabilities and opcodes retrieved them from the component manager as needed.