### PR TITLE
Serialized format renaming

### DIFF
--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -53,7 +53,7 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
     if (string === '') {
       return this.__appendComment('%empty%') as any as Simple.Text;
     } else if (current && current.nodeType === TEXT_NODE) {
-      this.__appendComment('%sep%');
+      this.__appendComment('%|%');
     }
 
     return super.__appendText(string);

--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -20,14 +20,14 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
 
   __openBlock(): void {
     let depth = this.serializeBlockDepth++;
-    this.__appendComment(`%+block:${depth}%`);
+    this.__appendComment(`%+b:${depth}%`);
 
     super.__openBlock();
   }
 
   __closeBlock(): void {
     super.__closeBlock();
-    this.__appendComment(`%-block:${--this.serializeBlockDepth}%`);
+    this.__appendComment(`%-b:${--this.serializeBlockDepth}%`);
   }
 
   __appendHTML(html: string): Bounds {
@@ -69,7 +69,6 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
   }
 
   openElement(tag: string) {
-
     if (tag === 'tr') {
       if (this.element.tagName !== 'TBODY') {
         this.openElement('tbody');

--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -51,7 +51,7 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
     let current = currentNode(this);
 
     if (string === '') {
-      return this.__appendComment('%empty%') as any as Simple.Text;
+      return this.__appendComment('% %') as any as Simple.Text;
     } else if (current && current.nodeType === TEXT_NODE) {
       this.__appendComment('%|%');
     }

--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -32,7 +32,7 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
 
   __appendHTML(html: string): Bounds {
     // Do we need to run the html tokenizer here?
-    let first = this.__appendComment('%glimmer%');
+    let first = this.__appendComment('%glmr%');
     if (this.element.tagName === 'TABLE') {
       let openIndex = html.indexOf('<');
       if (openIndex > -1) {
@@ -43,7 +43,7 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
       }
     }
     super.__appendHTML(html);
-    let last = this.__appendComment('%glimmer%');
+    let last = this.__appendComment('%glmr%');
     return new ConcreteBounds(this.element, first, last);
   }
 

--- a/packages/@glimmer/node/test/node-dom-helper-node-test.ts
+++ b/packages/@glimmer/node/test/node-dom-helper-node-test.ts
@@ -53,9 +53,9 @@ class SerializedDOMHelperTests extends DOMHelperTests {
     this.assertHTML(strip`
       <div>
         ${b(1)}
-        <!--%glimmer%-->
+        <!--%glmr%-->
         <strong>hello</strong>
-        <!--%glimmer%-->
+        <!--%glmr%-->
         ${b(1)}
       </div>
     `);
@@ -67,9 +67,9 @@ class SerializedDOMHelperTests extends DOMHelperTests {
     let b = blockStack();
     this.assertHTML(strip`
       ${b(1)}
-      <!--%glimmer%-->
+      <!--%glmr%-->
       <span>hi</span>
-      <!--%glimmer%-->
+      <!--%glmr%-->
       ${b(1)}
     `);
   }

--- a/packages/@glimmer/node/test/node-dom-helper-node-test.ts
+++ b/packages/@glimmer/node/test/node-dom-helper-node-test.ts
@@ -76,7 +76,7 @@ class SerializedDOMHelperTests extends DOMHelperTests {
 
   @test 'Null literals do not have representation in DOM'() {
     this.render('{{null}}');
-    this.assertHTML('<!--%empty%-->');
+    this.assertHTML('<!--% %-->');
   }
 
   @test "Elements inside a yielded block"() {

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -408,7 +408,7 @@ function isMarker(node: Simple.Node): boolean {
 }
 
 function isSeparator(node: Simple.Node): boolean {
-  return node.nodeType === 8 && node.nodeValue === '%sep%';
+  return node.nodeType === 8 && node.nodeValue === '%|%';
 }
 
 function isEmpty(node: Simple.Node): boolean {

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -412,7 +412,7 @@ function isSeparator(node: Simple.Node): boolean {
 }
 
 function isEmpty(node: Simple.Node): boolean {
-  return node.nodeType === 8 && node.nodeValue === '%empty%';
+  return node.nodeType === 8 && node.nodeValue === '% %';
 }
 function isSameNodeType(candidate: Simple.Element, tag: string) {
   if (candidate.namespaceURI === SVG_NAMESPACE) {

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -28,7 +28,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     super(env, parentNode, nextSibling);
     if (nextSibling) throw new Error("Rehydration with nextSibling not supported");
     this.candidate = this.currentCursor!.element.firstChild;
-    assert(this.candidate && isComment(this.candidate) && this.candidate.nodeValue === '%+block:0%', 'Must have opening comment <!--%+block:0%--> for rehydration.');
+    assert(this.candidate && isComment(this.candidate) && this.candidate.nodeValue === '%+b:0%', 'Must have opening comment <!--%+b:0%--> for rehydration.');
   }
 
   get currentCursor(): Option<RehydratingCursor> {
@@ -55,13 +55,13 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       if (currentCursor.candidate) {
         /**
          * <div>   <---------------  currentCursor.element
-         *   <!--%+block:1%-->
+         *   <!--%+b:1%-->
          *   <div> <---------------  currentCursor.candidate -> cursor.element
-         *     <!--%+block:2%--> <-  currentCursor.candidate.firstChild -> cursor.candidate
+         *     <!--%+b:2%--> <-  currentCursor.candidate.firstChild -> cursor.candidate
          *     Foo
-         *     <!--%-block:2%-->
+         *     <!--%-b:2%-->
          *   </div>
-         *   <!--%-block:1%-->  <--  becomes currentCursor.candidate
+         *   <!--%-b:1%-->  <--  becomes currentCursor.candidate
          */
 
         // where to rehydrate from if we are in rehydration mode
@@ -380,7 +380,7 @@ function isComment(node: Simple.Node): node is Simple.Comment {
 }
 
 function getOpenBlockDepth(node: Simple.Comment): Option<number> {
-  let boundsDepth = node.nodeValue!.match(/^%\+block:(\d+)%$/);
+  let boundsDepth = node.nodeValue!.match(/^%\+b:(\d+)%$/);
 
   if (boundsDepth && boundsDepth[1]) {
     return Number(boundsDepth[1] as string);
@@ -390,7 +390,7 @@ function getOpenBlockDepth(node: Simple.Comment): Option<number> {
 }
 
 function getCloseBlockDepth(node: Simple.Comment): Option<number> {
-  let boundsDepth = node.nodeValue!.match(/^%\-block:(\d+)%$/);
+  let boundsDepth = node.nodeValue!.match(/^%\-b:(\d+)%$/);
 
   if (boundsDepth && boundsDepth[1]) {
     return Number(boundsDepth[1] as string);

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -404,7 +404,7 @@ function isElement(node: Simple.Node): node is Simple.Element {
 }
 
 function isMarker(node: Simple.Node): boolean {
-  return node.nodeType === 8 && node.nodeValue === '%glimmer%';
+  return node.nodeType === 8 && node.nodeValue === '%glmr%';
 }
 
 function isSeparator(node: Simple.Node): boolean {

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -86,7 +86,7 @@ class Rehydration extends AbstractRehydrationTests {
     // Just repairs the value of the text node
     this.assertRehydrationStats({ nodesRemoved: 0 });
 
-    // TODO: handle %empty% in the testing DSL
+    // TODO: handle % % in the testing DSL
     // this.assertStableNodes();
     this.assertStableRerender();
   }
@@ -566,7 +566,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
     });
     let b = blockStack();
     let id = this.testType === 'Dynamic' ? 3 : 2;
-    this.assertServerComponent(`Hello ${b(id)}<!--%empty%-->${b(id)}`);
+    this.assertServerComponent(`Hello ${b(id)}<!--% %-->${b(id)}`);
 
     this.renderClientSide({
       layout

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -105,7 +105,7 @@ class Rehydration extends AbstractRehydrationTests {
   @test "extra nodes at the end"() {
     let template = "{{#if admin}}<div>hi admin</div>{{else}}<div>HAXOR{{stopHaxing}}</div>{{/if}}";
     this.renderServerSide(template, { admin: false, stopHaxing: 'stahp' });
-    this.assertServerOutput(OPEN, "<div>HAXOR<!--%sep%-->stahp</div>", CLOSE);
+    this.assertServerOutput(OPEN, "<div>HAXOR<!--%|%-->stahp</div>", CLOSE);
 
     this.renderClientSide(template, { admin: true });
     this.assertRehydrationStats({ nodesRemoved: 1 });
@@ -528,7 +528,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
       layout,
       template
     }, { name: 'Filewatcher' });
-    this.assertServerComponent(`Hello <!--%sep%-->Filewatcher`);
+    this.assertServerComponent(`Hello <!--%|%-->Filewatcher`);
 
     this.renderClientSide({
       layout,
@@ -547,7 +547,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
       layout,
       template
     });
-    this.assertServerComponent(`Hello <!--%sep%-->Filewatcher`);
+    this.assertServerComponent(`Hello <!--%|%-->Filewatcher`);
 
     this.renderClientSide({
       layout,
@@ -604,7 +604,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
       this.assert.ok(this.element.querySelector('.ember-view'));
       this.assert.equal(this.element.textContent, 'Hello World');
     } else {
-      this.assertServerComponent(`${b(2)}Hello <!--%sep%-->World${b(2)}`);
+      this.assertServerComponent(`${b(2)}Hello <!--%|%-->World${b(2)}`);
     }
 
     this.renderClientSide({
@@ -644,7 +644,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
       this.assert.ok(this.element.querySelector('.ember-view'));
       this.assert.equal(this.element.textContent, 'Hello World');
     } else {
-      this.assertServerComponent(`${b(2)}Hello <!--%sep%-->World${b(2)}`);
+      this.assertServerComponent(`${b(2)}Hello <!--%|%-->World${b(2)}`);
     }
 
     if (this.testType === 'Dynamic' || this.testType === 'Curly') {

--- a/packages/@glimmer/test-helpers/lib/helpers.ts
+++ b/packages/@glimmer/test-helpers/lib/helpers.ts
@@ -288,12 +288,12 @@ export function blockStack() {
 
   return (id: number) => {
     if (stack.indexOf(id) > -1) {
-      let close = `<!--%-block:${id}%-->`;
+      let close = `<!--%-b:${id}%-->`;
       stack.pop();
       return close;
     } else {
       stack.push(id);
-      return `<!--%+block:${id}%-->`;
+      return `<!--%+b:${id}%-->`;
     }
   };
 }

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -23,7 +23,7 @@ import { debugRehydration } from "./environment/modes/rehydration/debug-builder"
 export const OPEN: { marker: "open-block" } = { marker: "open-block" };
 export const CLOSE: { marker: "close-block" } = { marker: "close-block" };
 export const SEP: { marker: "sep" } = { marker: "sep" };
-export const EMPTY: { marker: "empty" } = { marker: "empty" };
+export const EMPTY: { marker: " " } = { marker: " " };
 export const GLIMMER_TEST_COMPONENT = "TestComponent";
 const CURLY_TEST_COMPONENT = "test-component";
 

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -22,7 +22,7 @@ import { debugRehydration } from "./environment/modes/rehydration/debug-builder"
 
 export const OPEN: { marker: "open-block" } = { marker: "open-block" };
 export const CLOSE: { marker: "close-block" } = { marker: "close-block" };
-export const SEP: { marker: "sep" } = { marker: "sep" };
+export const SEP: { marker: "|" } = { marker: "|" };
 export const EMPTY: { marker: " " } = { marker: " " };
 export const GLIMMER_TEST_COMPONENT = "TestComponent";
 const CURLY_TEST_COMPONENT = "test-component";

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -928,9 +928,9 @@ export function content(list: Content[]): string {
     if (typeof item === 'string') {
       out.push(item);
     } else if (item.marker === 'open-block') {
-      out.push(`<!--%+block:${depth++}%-->`);
+      out.push(`<!--%+b:${depth++}%-->`);
     } else if (item.marker === 'close-block') {
-      out.push(`<!--%-block:${--depth}%-->`);
+      out.push(`<!--%-b:${--depth}%-->`);
     } else {
       out.push(`<!--%${item.marker}%-->`);
     }

--- a/packages/@glimmer/test-helpers/test/i-n-u-r-test.ts
+++ b/packages/@glimmer/test-helpers/test/i-n-u-r-test.ts
@@ -46,9 +46,9 @@ QUnit.test("Can take nested snapshots", assert => {
 
 QUnit.test("Can take nested snapshots of serialized blocks", assert => {
   let div = document.createElement("div");
-  let open = document.createComment("<!--%+block:0%-->");
+  let open = document.createComment("<!--%+b:0%-->");
   let text = document.createTextNode("Foo");
-  let close = document.createComment("<!--%-block:0%-->");
+  let close = document.createComment("<!--%-b:0%-->");
   div.appendChild(open);
   div.appendChild(text);
   div.appendChild(close);


### PR DESCRIPTION
This renames the special comments in the SerializeBuilder to values that are much more terse. In a real application this shaved 10KB off of the produced HTML (218KB -> 208KB).