### PR TITLE
Remove redundant OpenElementWithOperations opcode

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -429,10 +429,6 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
     this.push(Op.OpenElement, this.constants.string(tag));
   }
 
-  openElementWithOperations(tag: string) {
-    this.push(Op.OpenElementWithOperations, this.constants.string(tag));
-  }
-
   openDynamicElement() {
     this.push(Op.OpenDynamicElement);
   }

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -94,7 +94,7 @@ export function statementCompiler() {
   STATEMENTS.add(Ops.OpenSplattedElement, (sexp: S.SplatElement, builder) => {
     builder.setComponentAttrs(true);
     builder.putComponentOperations();
-    builder.openElementWithOperations(sexp[1]);
+    builder.openPrimitiveElement(sexp[1]);
   });
 
   STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
@@ -225,7 +225,7 @@ export function statementCompiler() {
 
   CLIENT_SIDE.add(ClientSide.Ops.OpenComponentElement, (sexp: ClientSide.OpenComponentElement, builder) => {
     builder.putComponentOperations();
-    builder.openElementWithOperations(sexp[2]);
+    builder.openPrimitiveElement(sexp[2]);
   });
 
   CLIENT_SIDE.add(ClientSide.Ops.DidCreateElement, (_sexp: ClientSide.DidCreateElement, builder) => {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -23,11 +23,6 @@ APPEND_OPCODES.add(Op.Text, (vm, { op1: text }) => {
   vm.elements().appendText(vm.constants.getString(text));
 });
 
-APPEND_OPCODES.add(Op.OpenElementWithOperations, (vm, { op1: tag }) => {
-  let tagName = vm.constants.getString(tag);
-  vm.elements().openElement(tagName);
-});
-
 APPEND_OPCODES.add(Op.Comment, (vm, { op1: text }) => {
   vm.elements().appendComment(vm.constants.getString(text));
 });

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -447,12 +447,6 @@ OPCODE_METADATA(Op.OpenElement, {
   operands: 1
 });
 
-OPCODE_METADATA(Op.OpenElementWithOperations, {
-  name: 'OpenElementWithOperations',
-  ops: [Str('tag')],
-  operands: 1
-});
-
 OPCODE_METADATA(Op.OpenDynamicElement, {
   name: 'OpenDynamicElement',
   stackChange: -1

--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -312,18 +312,6 @@ export const enum Op {
 
   /**
    * Operation:
-   *   Open a new Element named `tag` with special operations provided
-   *   on the stack.
-   * Format:
-   *   (OpenElementWithOperations tag:#string)
-   * Operand Stack:
-   *   ..., ElementOperations →
-   *   ...
-   */
-  OpenElementWithOperations,
-
-  /**
-   * Operation:
    *   Open a new Element with a name on the stack and with special
    *   operations provided on the stack.
    * Format:


### PR DESCRIPTION
Over time, the special behavior of this opcode was broken out into other opcodes, and now it is semantically identical to the standard OpenElement opcode.