### PR TITLE
Add failing rehydration test when additional content exists.

### DIFF
--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -31,8 +31,8 @@ class AbstractRehydrationTests extends InitialRenderSuite {
   protected delegate: RehydrationDelegate;
   protected serverOutput: Option<string>;
 
-  renderServerSide(template: string | ComponentBlueprint, context: Dict<Opaque>): void {
-    this.serverOutput = this.delegate.renderServerSide(template as string, context, () => this.takeSnapshot());
+  renderServerSide(template: string | ComponentBlueprint, context: Dict<Opaque>, element: Element | undefined = undefined): void {
+    this.serverOutput = this.delegate.renderServerSide(template as string, context, () => this.takeSnapshot(), element);
     this.element.innerHTML = this.serverOutput;
   }
 
@@ -53,6 +53,20 @@ class AbstractRehydrationTests extends InitialRenderSuite {
 }
 
 class Rehydration extends AbstractRehydrationTests {
+
+  @test "rehydrates into element with pre-existing content"() {
+    let rootElement = this.delegate.clientEnv.getAppendOperations().createElement('div') as HTMLDivElement;
+    let extraContent = this.delegate.clientEnv.getAppendOperations().createElement('noscript') as HTMLElement;
+    rootElement.appendChild(extraContent);
+
+    let template = '<div>Hi!</div>';
+    this.renderServerSide(template, {}, rootElement);
+    this.assertServerOutput('<noscript></noscript><div>Hi!</div>');
+    this.renderClientSide(template, {});
+    this.assertHTML('<noscript></noscript><div>Hi!</div>');
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertStableNodes();
+  }
 
   @test "table with omitted tbody"() {
     let template = '<table><tr><td>standards</td></tr></table>';

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -551,9 +551,9 @@ export class RehydrationDelegate implements RenderDelegate {
     return serializeBuilder(env, cursor);
   }
 
-  renderServerSide(template: string, context: Dict<Opaque>, takeSnapshot: () => void): string {
+  renderServerSide(template: string, context: Dict<Opaque>, takeSnapshot: () => void, element: Element | undefined = undefined): string {
     let env = this.serverEnv;
-    let element = env.getAppendOperations().createElement("div") as HTMLDivElement;
+    element = element || env.getAppendOperations().createElement("div") as HTMLDivElement;
     let cursor = { element, nextSibling: null };
     // Emulate server-side render
     renderTemplate(template,


### PR DESCRIPTION
In an Ember app that is rendered via Fastboot, the SSR'ed content is placed wherever `{{content-for "body"}}` is in the applications `app/index.html` (notably FastBoot does not support using an alternative `rootElement` to `body` at the moment). The test being added here emulates that situation (by having some not uncommon content before where the SSR'ed content will be serialized).

Currently, the rehydration DOM builder _requires_ that the `rootElement.firstChild` is the serialize DOM builder generated comment node and throws the following error if the comment node is not found as the `.firstChild`:

```
Error: Must have opening comment <!--%+b:0%--> for rehydration.
    at Object.debugAssert [as assert] (http://localhost:49153/tests/assets/glimmer-vm.js:21754:15)
    at DebugRehydrationBuilder.RehydrateBuilder (http://localhost:49153/tests/assets/glimmer-vm.js:13150:14)
    at new DebugRehydrationBuilder (http://localhost:49153/tests/assets/glimmer-vm.js:16990:74)
    at Function.forInitialRender (http://localhost:49153/tests/assets/glimmer-vm.js:11553:23)
    at debugRehydration (http://localhost:49153/tests/assets/glimmer-vm.js:17015:36)
    at RehydrationDelegate.getElementBuilder (http://localhost:49153/tests/assets/glimmer-vm.js:17526:20)
    at RehydrationDelegate.renderServerSide (http://localhost:49153/tests/assets/glimmer-vm.js:17536:67)
    at Rehydration.renderServerSide (http://localhost:49153/tests/assets/tests.js:6103:47)
    at Rehydration.rehydratesIntoElementWithPreExistingContent [as rehydrates into element with pre-existing content] (http://localhost:49153/tests/assets/tests.js:6148:18)
    at Object.<anonymous> (http://localhost:49153/tests/assets/glimmer-vm.js:17692:33)
```

Generally speaking, I would assume the solution to this would be to either:

1. Allow the cursor provided to the rehydration builder to use `nextSibling` to help it understand where to start from.
2. Instruct the rehydration builder to iterate through the direct children of the root element until it finds the expected comment block and only throwing an error if it is not found.

I vaguely prefer option 2 above, but I think both are reasonable...