### PR TITLE
Fix failing test rehydration initial content PR

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -30,13 +30,13 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
 
     let node = this.currentCursor!.element.firstChild;
 
-    while (node) {
-      if (node && isComment(node) && node.nodeValue === '%+b:0%') { break; }
+    while (node !== null) {
+      if (isComment(node) && node.nodeValue === '%+b:0%') { break; }
       node = node.nextSibling;
     }
 
-    this.candidate = node;
     assert(node, 'Must have opening comment <!--%+b:0%--> for rehydration.');
+    this.candidate = node;
   }
 
   get currentCursor(): Option<RehydratingCursor> {

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -27,8 +27,16 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
   constructor(env: Environment, parentNode: Simple.Element, nextSibling: Option<Simple.Node>) {
     super(env, parentNode, nextSibling);
     if (nextSibling) throw new Error("Rehydration with nextSibling not supported");
-    this.candidate = this.currentCursor!.element.firstChild;
-    assert(this.candidate && isComment(this.candidate) && this.candidate.nodeValue === '%+b:0%', 'Must have opening comment <!--%+b:0%--> for rehydration.');
+
+    let node = this.currentCursor!.element.firstChild;
+
+    while (node) {
+      if (node && isComment(node) && node.nodeValue === '%+b:0%') { break; }
+      node = node.nextSibling;
+    }
+
+    this.candidate = node;
+    assert(node, 'Must have opening comment <!--%+b:0%--> for rehydration.');
   }
 
   get currentCursor(): Option<RehydratingCursor> {

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -46,6 +46,11 @@ class AbstractRehydrationTests extends InitialRenderSuite {
     this.assert.equal(clearedNodes.length, nodes, 'cleared nodes');
   }
 
+  assertExactServerOutput(..._expected: Content[]) {
+    let output = expect(this.serverOutput, 'must renderServerSide before calling assertServerOutput');
+    equalTokens(output, content([..._expected]));
+  }
+
   assertServerOutput(..._expected: Content[]) {
     let output = expect(this.serverOutput, 'must renderServerSide before calling assertServerOutput');
     equalTokens(output, content([OPEN, ..._expected, CLOSE]));
@@ -62,8 +67,7 @@ class Rehydration extends AbstractRehydrationTests {
     let noScriptString = '<noscript></noscript>';
     let template = '<div>Hi!</div>';
     this.renderServerSide(template, {}, rootElement);
-    let output = expect(this.serverOutput, 'must renderServerSide before calling assertServerOutput');
-    equalTokens(output, content([noScriptString, OPEN, ...template, CLOSE]));
+    this.assertExactServerOutput(content([noScriptString, OPEN, ...template, CLOSE]));
     this.renderClientSide(template, {});
     this.assertHTML('<noscript></noscript><div>Hi!</div>');
     this.assertRehydrationStats({ nodesRemoved: 0 });

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -52,8 +52,7 @@ class AbstractRehydrationTests extends InitialRenderSuite {
   }
 
   assertServerOutput(..._expected: Content[]) {
-    let output = expect(this.serverOutput, 'must renderServerSide before calling assertServerOutput');
-    equalTokens(output, content([OPEN, ..._expected, CLOSE]));
+    this.assertExactServerOutput(content([OPEN, ..._expected, CLOSE]));
   }
 }
 

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -31,8 +31,8 @@ class AbstractRehydrationTests extends InitialRenderSuite {
   protected delegate: RehydrationDelegate;
   protected serverOutput: Option<string>;
 
-  renderServerSide(template: string | ComponentBlueprint, context: Dict<Opaque>): void {
-    this.serverOutput = this.delegate.renderServerSide(template as string, context, () => this.takeSnapshot());
+  renderServerSide(template: string | ComponentBlueprint, context: Dict<Opaque>, element: Element | undefined = undefined): void {
+    this.serverOutput = this.delegate.renderServerSide(template as string, context, () => this.takeSnapshot(), element);
     this.element.innerHTML = this.serverOutput;
   }
 
@@ -53,6 +53,20 @@ class AbstractRehydrationTests extends InitialRenderSuite {
 }
 
 class Rehydration extends AbstractRehydrationTests {
+
+  @test "rehydrates into element with pre-existing content"() {
+    let rootElement = this.delegate.clientEnv.getAppendOperations().createElement('div') as HTMLDivElement;
+    let extraContent = this.delegate.clientEnv.getAppendOperations().createElement('noscript') as HTMLElement;
+    rootElement.appendChild(extraContent);
+
+    let template = '<div>Hi!</div>';
+    this.renderServerSide(template, {}, rootElement);
+    this.assertServerOutput('<noscript></noscript><div>Hi!</div>');
+    this.renderClientSide(template, {});
+    this.assertHTML('<noscript></noscript><div>Hi!</div>');
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertStableNodes();
+  }
 
   @test "table with omitted tbody"() {
     let template = '<table><tr><td>standards</td></tr></table>';

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -55,13 +55,15 @@ class AbstractRehydrationTests extends InitialRenderSuite {
 class Rehydration extends AbstractRehydrationTests {
 
   @test "rehydrates into element with pre-existing content"() {
-    let rootElement = this.delegate.clientEnv.getAppendOperations().createElement('div') as HTMLDivElement;
-    let extraContent = this.delegate.clientEnv.getAppendOperations().createElement('noscript') as HTMLElement;
+    let rootElement = this.delegate.serverEnv.getAppendOperations().createElement('div') as HTMLDivElement;
+    let extraContent = this.delegate.serverEnv.getAppendOperations().createElement('noscript') as HTMLElement;
     rootElement.appendChild(extraContent);
 
+    let noScriptString = '<noscript></noscript>';
     let template = '<div>Hi!</div>';
     this.renderServerSide(template, {}, rootElement);
-    this.assertServerOutput('<noscript></noscript><div>Hi!</div>');
+    let output = expect(this.serverOutput, 'must renderServerSide before calling assertServerOutput');
+    equalTokens(output, content([noScriptString, OPEN, ...template, CLOSE]));
     this.renderClientSide(template, {});
     this.assertHTML('<noscript></noscript><div>Hi!</div>');
     this.assertRehydrationStats({ nodesRemoved: 0 });

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -46,9 +46,9 @@ class AbstractRehydrationTests extends InitialRenderSuite {
     this.assert.equal(clearedNodes.length, nodes, 'cleared nodes');
   }
 
-  assertExactServerOutput(..._expected: Content[]) {
+  assertExactServerOutput(_expected: string) {
     let output = expect(this.serverOutput, 'must renderServerSide before calling assertServerOutput');
-    equalTokens(output, content([..._expected]));
+    equalTokens(output, _expected);
   }
 
   assertServerOutput(..._expected: Content[]) {

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -551,9 +551,9 @@ export class RehydrationDelegate implements RenderDelegate {
     return serializeBuilder(env, cursor);
   }
 
-  renderServerSide(template: string, context: Dict<Opaque>, takeSnapshot: () => void): string {
+  renderServerSide(template: string, context: Dict<Opaque>, takeSnapshot: () => void, element: Element | undefined = undefined): string {
     let env = this.serverEnv;
-    let element = env.getAppendOperations().createElement("div") as HTMLDivElement;
+    element = element || env.getAppendOperations().createElement("div") as HTMLDivElement;
     let cursor = { element, nextSibling: null };
     // Emulate server-side render
     renderTemplate(template,


### PR DESCRIPTION
This is my attempt to implement solution 2 from this PR: 

https://github.com/glimmerjs/glimmer-vm/pull/780

Larger goal:

This is part of an arching plan to introduce Glimmer's
rehydration/serializtion modes to Ember proper.

There are 4 PR's that are all interwoven, of which, this is one.

- [ ] Glimmer.js: glimmerjs/glimmer-vm#783 (comment)
- [ ] Ember.js: emberjs/ember.js#16227
- [ ] Fastboot: ember-fastboot/fastboot#185
- [ ] EmberCLI Fastboot: ember-fastboot/ember-cli-fastboot#580

In order of need to land they are:

Glimmer.js:
glimmerjs/glimmer-vm#783 (comment)

This resolves a rather intimate API problem. Glimmer-vm expects a very
specific comment node to exist to know whether or not the rehydration
element builder can do it's job properly. If it is not found on the
first node from rootElement it throws.

In fastboot however we are certain that there will already be existant
elements in the way that will happen before rendered content.

This PR just iterates through the nodes until it finds the expected
comment node. And only throws if it never finds one.

Ember.js:
emberjs/ember.js#16227

This PR modifies the visit API to allow a private _renderMode to be
set to either serialize or rehydrate. In SSR environments the
assumption (as it is here in this fastboot PR) is that we'll set the
visit API to serialize mode which ensures glimmer-vm's serialize element
builder is used to build the API.

The serialize element builder ensures that we have the necessary fidelty
to rehydrate correctly and is mandatory input for rehydration.

Fastboot:
ember-fastboot/fastboot#185

This allows enviroment variable to set _renderMode to be used in Visit
API. Fastboot must send content to browser made with the serialization
element builder to ensure rehydration can be sucessful.

EmberCLI Fastboot:
ember-fastboot/ember-cli-fastboot#580

Finally this does the fun part of disabling the current
clear-double-render instance-initializer

We first check to ensure we are in a non-fastboot environment. Then we
ensure that we can find the expected comment node from glimmer-vm's
serialize element builder. This ensures that this change will only
effect peoeple who use ember-cli-fastboot with the serialized output
from the currently experimental fastboot setup

Then we ensure ApplicationInstance#_bootSync specifies the rehydrate
_renderMode.

This is done in _bootSync this way because visit is currently not used
to boot ember applications. And we must instead set bootOptions this
way instead.

We also remove the markings for fastboot-body-start and
fastboot-body-end to ensure clear-double render instance-initializer
is never called.