### PR TITLE
[BUGFIX] Support Number.MAX_SAFE_INTEGER

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -1,14 +1,6 @@
 import { WriteOnlyConstants } from "@glimmer/program";
 
 export default class DebugConstants extends WriteOnlyConstants {
-  getFloat(value: number): number {
-    return this.floats[value];
-  }
-
-  getNegative(value: number): number {
-    return this.negatives[value];
-  }
-
   getString(value: number): string {
     return this.strings[value];
   }

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -38,8 +38,7 @@ export interface CompileTimeConstants {
   array(values: number[]): number;
   handle(locator: Opaque): number;
   serializable(value: Opaque): number;
-  float(value: number): number;
-  negative(value: number): number;
+  number(value: number): number;
 }
 
 export interface CompileTimeLazyConstants extends CompileTimeConstants {

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -12,8 +12,7 @@ import { Primitive } from "@glimmer/debug";
 import { PrimitiveType } from "@glimmer/program";
 
 export interface DebugConstants {
-  getFloat(value: number): number;
-  getNegative(value: number): number;
+  getNumber(value: number): number;
   getString(value: number): string;
   getStringArray(value: number): string[];
   getArray(value: number): number[];
@@ -143,7 +142,7 @@ function decodePrimitive(primitive: number, constants: DebugConstants): Primitiv
     case PrimitiveType.NUMBER:
       return value;
     case PrimitiveType.FLOAT:
-      return constants.getFloat(value);
+      return constants.getNumber(value);
     case PrimitiveType.STRING:
       return constants.getString(value);
     case PrimitiveType.BOOLEAN_OR_VOID:
@@ -154,7 +153,7 @@ function decodePrimitive(primitive: number, constants: DebugConstants): Primitiv
         case 3: return undefined;
       }
     case PrimitiveType.NEGATIVE:
-      return constants.getNegative(value);
+      return constants.getNumber(value);
     default:
       throw unreachable();
   }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -557,11 +557,11 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
           if (_primitive as number > -1) {
             primitive = _primitive as number;
           } else {
-            primitive = this.negative(_primitive as number);
+            primitive = this.constants.number(_primitive as number);
             type = PrimitiveType.NEGATIVE;
           }
         } else {
-          primitive = this.float(_primitive as number);
+          primitive = this.constants.number(_primitive as number);
           type = PrimitiveType.FLOAT;
         }
         break;
@@ -586,15 +586,16 @@ export abstract class OpcodeBuilder<Locator> extends SimpleOpcodeBuilder {
         throw new Error('Invalid primitive passed to pushPrimitive');
     }
 
-    this.push(Op.Primitive, primitive << 3 | type);
+    let immediate = this.sizeImmediate(primitive << 3 | type, primitive);
+    this.push(Op.Primitive, immediate);
   }
 
-  float(num: number): number {
-    return this.constants.float(num);
-  }
+  sizeImmediate(shifted: number, primitive: number) {
+    if (shifted >= OpcodeSize.MAX_SIZE || shifted < 0) {
+      return this.constants.number(primitive) << 3 | PrimitiveType.BIG_NUM;
+    }
 
-  negative(num: number): number {
-    return this.constants.negative(num);
+    return shifted;
   }
 
   pushPrimitiveReference(primitive: Primitive) {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -41,7 +41,7 @@ APPEND_OPCODES.add(Op.Primitive, (vm, { op1: primitive }) => {
       stack.push(value);
       break;
     case PrimitiveType.FLOAT:
-      stack.push(vm.constants.getFloat(value));
+      stack.push(vm.constants.getNumber(value));
       break;
     case PrimitiveType.STRING:
       stack.push(vm.constants.getString(value));
@@ -50,7 +50,10 @@ APPEND_OPCODES.add(Op.Primitive, (vm, { op1: primitive }) => {
       stack.pushEncodedImmediate(primitive);
       break;
     case PrimitiveType.NEGATIVE:
-      stack.push(vm.constants.getNegative(value));
+      stack.push(vm.constants.getNumber(value));
+      break;
+    case PrimitiveType.BIG_NUM:
+      stack.push(vm.constants.getNumber(value));
       break;
   }
 });

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -39,8 +39,7 @@ export type IteratorResult<T> = {
 
 export interface Constants<T> {
   resolver: RuntimeResolver<T>;
-  getFloat(value: number): number;
-  getNegative(value: number): number;
+  getNumber(value: number): number;
   getString(handle: number): string;
   getStringArray(value: number): string[];
   getArray(value: number): number[];

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -197,7 +197,7 @@ function isImmediate(value: Opaque): value is number | boolean | null | undefine
       let abs = Math.abs(value as number);
 
       // too big
-      if (abs & HI) return false;
+      if (abs > HI) return false;
 
       return true;
     default:

--- a/packages/@glimmer/test-helpers/lib/suites/initial-render.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/initial-render.ts
@@ -840,6 +840,13 @@ export class InitialRenderSuite extends RenderTest {
     this.assertStableRerender();
   }
 
+  @test "Large numeric literals (Number.MAX_SAFE_INTEGER)"() {
+    this.registerHelper('testing', ([id]) => id);
+    this.render('<div>{{testing 9007199254740991}}</div>');
+    this.assertHTML('<div>9007199254740991</div>');
+    this.assertStableRerender();
+  }
+
   @test "Constant float numbers can render"() {
     this.registerHelper('testing', ([id]) => id);
     this.render('<div>{{testing 0.123}}</div>');


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/16269.

Prior to this fix we would hard error if operands exceeded 16-bits. This was due to the fact that the program is 16-bit aligned. However, we don't have to take this nuclear option. Instead we can just serialize these larger numbers into the constants pool and reify them properly at runtime. This means you are free to use number literals up to `Number.MAX_SAFE_INTEGER`.