### PR TITLE
Expose isSerializationFirstNode and SERIALIZATION_FIRST_NODE_STRING

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -4,7 +4,7 @@ import { Environment } from '../environment';
 import Bounds, { bounds, Cursor } from '../bounds';
 import { Simple, Option, Opaque } from "@glimmer/interfaces";
 import { DynamicContentWrapper } from './content/dynamic';
-import { expect, assert, Stack } from "@glimmer/util";
+import { expect, assert, Stack, isSerializationFirstNode, SERIALIZATION_FIRST_NODE_STRING} from "@glimmer/util";
 import { SVG_NAMESPACE } from '../dom/helper';
 
 export class RehydratingCursor extends Cursor {
@@ -31,11 +31,11 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     let node = this.currentCursor!.element.firstChild;
 
     while (node !== null) {
-      if (isComment(node) && node.nodeValue === '%+b:0%') { break; }
+      if (isComment(node) && isSerializationFirstNode(node)) { break; }
       node = node.nextSibling;
     }
 
-    assert(node, 'Must have opening comment <!--%+b:0%--> for rehydration.');
+    assert(node, `Must have opening comment <!--${SERIALIZATION_FIRST_NODE_STRING}--> for rehydration.`);
     this.candidate = node;
   }
 

--- a/packages/@glimmer/util/index.ts
+++ b/packages/@glimmer/util/index.ts
@@ -8,6 +8,8 @@ export { default as assert } from './lib/assert';
 export { assign, fillNulls } from './lib/object-utils';
 export { ensureGuid, initializeGuid, HasGuid } from './lib/guid';
 
+export { isSerializationFirstNode, SERIALIZATION_FIRST_NODE_STRING } from './lib/is-serialization-first-node';
+
 export { Stack, Dict, Set, DictSet, dict } from './lib/collections';
 export { EMPTY_SLICE, LinkedList, LinkedListNode, ListNode, CloneableListNode, ListSlice, Slice } from './lib/list-utils';
 export { EMPTY_ARRAY } from './lib/array-utils';

--- a/packages/@glimmer/util/lib/is-serialization-first-node.ts
+++ b/packages/@glimmer/util/lib/is-serialization-first-node.ts
@@ -1,0 +1,7 @@
+import { Simple } from '@glimmer/interfaces';
+
+export const SERIALIZATION_FIRST_NODE_STRING = '%+b:0%';
+
+export function isSerializationFirstNode(node: Simple.Node): boolean {
+  return node.nodeValue === SERIALIZATION_FIRST_NODE_STRING;
+};


### PR DESCRIPTION
This exposes a mechanicsm that can be used in all the places in ember.js
/ fastboot and anywhere it might be necessary to determine whether or
not a given node is the first serialization node.  Which is useful to
ensure that the actual format can change without affecting the other
libaries who will be able to use this instead of a magic string.

The rationale for this PR can be found in greater detail at the issue
below:
https://github.com/glimmerjs/glimmer-vm/issues/787