### PR TITLE
Fix bugs caused by html-safe empty strings

### DIFF
--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -161,7 +161,7 @@ export function insertHTMLBefore(this: void, useless: HTMLElement, _parent: Simp
   let last: Simple.Node | null;
 
   if (html === null || html === '') {
-    return new ConcreteBounds(parent, null, null);
+    throw new Error('Empty strings should be added as text, not HTML');
   }
 
   if (nextSibling === null) {

--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -160,15 +160,14 @@ export function insertHTMLBefore(this: void, useless: HTMLElement, _parent: Simp
   let prev = nextSibling ? nextSibling.previousSibling : parent.lastChild;
   let last: Simple.Node | null;
 
-  if (html === null || html === '') {
-    throw new Error('Empty strings should be added as text, not HTML');
-  }
+  // Add a comment instead of an empty string, so that we can keep track of it properly
+  let htmlToAdd = (html === null || html === '') ? '<!---->' : html;
 
   if (nextSibling === null) {
-    parent.insertAdjacentHTML('beforeend', html);
+    parent.insertAdjacentHTML('beforeend', htmlToAdd);
     last = parent.lastChild;
   } else if (nextSibling instanceof HTMLElement) {
-    nextSibling.insertAdjacentHTML('beforebegin', html);
+    nextSibling.insertAdjacentHTML('beforebegin', htmlToAdd);
     last = nextSibling.previousSibling;
   } else {
     // Non-element nodes do not support insertAdjacentHTML, so add an
@@ -177,7 +176,7 @@ export function insertHTMLBefore(this: void, useless: HTMLElement, _parent: Simp
     // This also protects Edge, IE and Firefox w/o the inspector open
     // from merging adjacent text nodes. See ./compat/text-node-merging-fix.ts
     parent.insertBefore(useless, nextSibling);
-    useless.insertAdjacentHTML('beforebegin', html);
+    useless.insertAdjacentHTML('beforebegin', htmlToAdd);
     last = useless.previousSibling;
     parent.removeChild(useless);
   }

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -315,12 +315,8 @@ export class NewElementBuilder implements ElementBuilder {
   }
 
   appendDynamicHTML(value: string): void {
-    if (value === '') {
-      this.appendDynamicText(value);
-    } else {
-      let bounds = this.trustedContent(value);
-      this.didAppendBounds(bounds);
-    }
+    let bounds = this.trustedContent(value);
+    this.didAppendBounds(bounds);
   }
 
   appendDynamicText(value: string): Simple.Text {

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -315,8 +315,12 @@ export class NewElementBuilder implements ElementBuilder {
   }
 
   appendDynamicHTML(value: string): void {
-    let bounds = this.trustedContent(value);
-    this.didAppendBounds(bounds);
+    if (value === '') {
+      this.appendDynamicText(value);
+    } else {
+      let bounds = this.trustedContent(value);
+      this.didAppendBounds(bounds);
+    }
   }
 
   appendDynamicText(value: string): Simple.Text {

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -628,11 +628,11 @@ module("[glimmer-runtime] Updating", hooks => {
       description: 'string containing HTML'
     }, {
       input: null,
-      expected: '<div></div>',
+      expected: '<div><!----></div>',
       description: 'null literal'
     }, {
       input: undefined,
-      expected: '<div></div>',
+      expected: '<div><!----></div>',
       description: 'undefined literal'
     }, {
       input: makeSafeString('<b>hello</b>'),
@@ -735,11 +735,11 @@ module("[glimmer-runtime] Updating", hooks => {
 
     render(template, input);
 
-    equalTokens(root, '<div>...</div>', "Initial render");
+    equalTokens(root, '<div><!---->...</div>', "Initial render");
 
     rerender();
 
-    equalTokens(root, '<div>...</div>', "no change");
+    equalTokens(root, '<div><!---->...</div>', "no change");
 
     input.value = '<b>Bold and spicy</b>';
     rerender();
@@ -749,7 +749,7 @@ module("[glimmer-runtime] Updating", hooks => {
     input.value = '';
     rerender();
 
-    equalTokens(root, '<div>...</div>', "back to empty string");
+    equalTokens(root, '<div><!---->...</div>', "back to empty string");
   });
 
   class ValueReference<T> extends ConstReference<T> {

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -731,25 +731,25 @@ module("[glimmer-runtime] Updating", hooks => {
     let input = {
       value: ''
     };
-    let template = compile('<div>{{{value}}}</div>');
+    let template = compile('<div>{{{value}}}...</div>');
 
     render(template, input);
 
-    equalTokens(root, '<div></div>', "Initial render");
+    equalTokens(root, '<div>...</div>', "Initial render");
 
     rerender();
 
-    equalTokens(root, '<div></div>', "no change");
+    equalTokens(root, '<div>...</div>', "no change");
 
     input.value = '<b>Bold and spicy</b>';
     rerender();
 
-    equalTokens(root, '<div><b>Bold and spicy</b></div>', "markup is updated");
+    equalTokens(root, '<div><b>Bold and spicy</b>...</div>', "markup is updated");
 
     input.value = '';
     rerender();
 
-    equalTokens(root, '<div></div>', "back to empty string");
+    equalTokens(root, '<div>...</div>', "back to empty string");
   });
 
   class ValueReference<T> extends ConstReference<T> {

--- a/packages/@glimmer/test-helpers/lib/suites/each.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/each.ts
@@ -195,4 +195,18 @@ export class EachSuite extends RenderTest {
     this.assertHTML('No thing Chad');
     this.assertStableNodes();
   }
+
+  @test
+  'Safe String can be removed'() {
+    this.render(`{{#each items key="@index" as |item|}}{{item}}{{/each}}`, {
+      items: [{ toHTML: () => '' }]
+    });
+
+    this.assertHTML('');
+    this.assertStableRerender();
+
+    this.rerender({ items: [''] });
+    this.assertHTML('');
+    this.assertStableNodes();
+  }
 }

--- a/packages/@glimmer/test-helpers/lib/suites/each.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/each.ts
@@ -202,7 +202,7 @@ export class EachSuite extends RenderTest {
       items: [{ toHTML: () => '' }]
     });
 
-    this.assertHTML('');
+    this.assertHTML('<!---->');
     this.assertStableRerender();
 
     this.rerender({ items: [''] });


### PR DESCRIPTION
Adding empty strings as HTML leads to difficulties keeping track of
sibling nodes. It's easier to keep track of as text.

This fixes the issues https://github.com/emberjs/ember.js/issues/14924 and https://github.com/emberjs/ember.js/issues/16314. The first one could be solved by simply removing the `if (html === null || html === '')` special case. The latter issue cannot, because it would still need to deal with a `null` last node.