### PR TITLE
add failing test for accessing form attribute

### DIFF
--- a/packages/@glimmer/runtime/lib/dom/props.ts
+++ b/packages/@glimmer/runtime/lib/dom/props.ts
@@ -65,7 +65,8 @@ const ATTR_OVERRIDES = {
   LABEL:    { form: true },
   FIELDSET: { form: true },
   LEGEND:   { form: true },
-  OBJECT:   { form: true }
+  OBJECT:   { form: true },
+  BUTTON:   { form: true }
 };
 
 function preferAttr(tagName: string, propName: string) {

--- a/packages/@glimmer/runtime/test/attributes-test.ts
+++ b/packages/@glimmer/runtime/test/attributes-test.ts
@@ -159,6 +159,12 @@ export class AttributesTests extends RenderTest {
     this.assertStableRerender();
   }
 
+  @test "can read the form attribute"() {
+    this.render('<button form="gnargnar" />');
+    this.assert.equal(this.readDOMAttr('form'), 'gnargnar');
+    this.assertStableRerender();
+  }
+
   @test "handles null input values"() {
     this.render('<input value={{isNull}} />', { isNull: null});
     this.assert.equal(this.readDOMAttr('value'), '');


### PR DESCRIPTION
Attempting to add a failing test that reproduces the problem I'm seeing in https://github.com/emberjs/ember.js/issues/16385

Any insight into if this is the right direction and _where_ I might look in order to fix this would be much appreciated.  It seems like [this code](https://github.com/Dhaulagiri/glimmer-vm/blob/a9fb9ebe35df3e01dfc9b8672aa5cb1d22f00ecf/packages/%40glimmer/runtime/lib/dom/props.ts#L18-L24) is relevant but I'm still trying to learn the codebase.

Fixes https://github.com/emberjs/ember.js/issues/16385