### PR TITLE
Fix property normalization

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -18,7 +18,6 @@ export { PublicVM as VM, VM as LowLevelVM, UpdatingVM, RenderResult, IteratorRes
 
 export {
   SimpleDynamicAttribute,
-  DynamicAttributeFactory,
   DynamicAttribute
 } from './lib/vm/attributes/dynamic';
 

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -15,7 +15,7 @@ import { DOMChanges, DOMTreeConstruction } from './dom/helper';
 import { PublicVM } from './vm/append';
 import { IArguments } from './vm/arguments';
 import { UNDEFINED_REFERENCE, ConditionalReference } from './references';
-import { DynamicAttributeFactory, defaultDynamicAttributes } from './vm/attributes/dynamic';
+import { DynamicAttribute, dynamicAttribute } from './vm/attributes/dynamic';
 import {
   ModifierManager, Modifier
 } from './modifier/interfaces';
@@ -284,8 +284,8 @@ export abstract class Environment {
     transaction.commit();
   }
 
-  attributeFor(element: Simple.Element, attr: string, _isTrusting: boolean, _namespace: Option<string> = null): DynamicAttributeFactory {
-    return defaultDynamicAttributes(element, attr);
+  attributeFor(element: Simple.Element, attr: string, _isTrusting: boolean, namespace: Option<string> = null): DynamicAttribute {
+    return dynamicAttribute(element, attr, namespace);
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -369,11 +369,8 @@ export class NewElementBuilder implements ElementBuilder {
 
   setDynamicAttribute(name: string, value: Opaque, trusting: boolean, namespace: Option<string>): DynamicAttribute {
     let element = this.constructing!;
-    let DynamicAttribute = this.env.attributeFor(element, name, trusting, namespace);
-    let attribute = new DynamicAttribute({ element, name, namespace: namespace || null });
-
+    let attribute = this.env.attributeFor(element, name, trusting, namespace);
     attribute.set(this, value, this.env);
-
     return attribute;
   }
 }

--- a/packages/@glimmer/runtime/test/attributes-test.ts
+++ b/packages/@glimmer/runtime/test/attributes-test.ts
@@ -451,6 +451,35 @@ export class AttributesTests extends RenderTest {
     this.assertHTML('<input list="bar" />');
     this.assertStableNodes();
   }
+
+  @test "normalizes lowercase dynamic properties correctly"() {
+    this.render('<div tiTle={{foo}} />', { foo: "bar" });
+    this.assertHTML('<div title="bar" />');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'baz' });
+    this.assertHTML('<div title="baz" />');
+    this.assertStableNodes();
+
+    this.rerender({ foo: 'bar' });
+    this.assertHTML('<div title="bar" />');
+    this.assertStableNodes();
+  }
+
+  @test "normalizes mix-case dynamic properties correctly"() {
+    this.render('<svg viewBox={{foo}} />', { foo: "0 0 100 100" });
+    this.assertHTML('<svg viewBox="0 0 100 100" />');
+    this.assertStableRerender();
+
+    this.rerender({ foo: '0 0 100 200' });
+    this.assertHTML('<svg viewBox="0 0 100 200" />');
+    this.assertStableNodes();
+
+    this.rerender({ foo: '0 0 100 100' });
+    this.assertHTML('<svg viewBox="0 0 100 100" />');
+    this.assertStableNodes();
+  }
+
 }
 
 module("Attributes Test", AttributesTests);

--- a/packages/@glimmer/runtime/test/style-warning-test.ts
+++ b/packages/@glimmer/runtime/test/style-warning-test.ts
@@ -1,6 +1,6 @@
 import { TestEnvironment, equalTokens } from "@glimmer/test-helpers";
 import { test, module } from "@glimmer/runtime/test/support";
-import { RenderResult, DynamicAttributeFactory, SimpleDynamicAttribute, ElementBuilder, clientBuilder } from "@glimmer/runtime";
+import { RenderResult, DynamicAttribute, SimpleDynamicAttribute, ElementBuilder, clientBuilder } from "@glimmer/runtime";
 import { UpdatableReference } from "@glimmer/object-reference";
 import { Option, Simple, Opaque, Template } from "@glimmer/interfaces";
 
@@ -35,9 +35,9 @@ function render(template: Template, self: any) {
 module('Style attributes', {
   beforeEach() {
     class StyleEnv extends TestEnvironment {
-      attributeFor(element: Simple.Element, attr: string, isTrusting: boolean, namespace: Option<string>): DynamicAttributeFactory {
+      attributeFor(element: Simple.Element, attr: string, isTrusting: boolean, namespace: Option<string>): DynamicAttribute {
         if (attr === 'style' && !isTrusting) {
-          return StyleAttribute;
+          return new StyleAttribute({ element, name, namespace });
         }
 
         return super.attributeFor(element, attr, isTrusting, namespace);


### PR DESCRIPTION
This fixes https://github.com/emberjs/ember.js/issues/16477 and https://github.com/emberjs/ember.js/issues/16311 by applying property name normalization.

We were already running the property normalization code, but it was only being used to choose which `DynamicAttributeFactory` would be used, the normalized property name was not available to the instances of `DynamicAttribute` and they were not using it pick the correct property to target. As a result, `<div tiTle={{foo}}>` would render as `<div>`, because we would detect correctly that a `title` prop exists, but the actual property set would be `element['tiTle'] = ...`.

To fix this without calling `normalizeProperty` twice, I refactored the boundary between `ElementBuilder` and `Environment` so that instead of returning a DynamicAttributeFactory we just return the DynamicFactory instance. The factory abstraction doesn't appear to have been buying us anything, because one-to-one every factory retrieved would be immediately instantiated anyway.

We may want to bump minors when we release this due to the Environment API change.