### PR TITLE
Fix astEqual assertion

### DIFF
--- a/packages/@glimmer/syntax/test/support.ts
+++ b/packages/@glimmer/syntax/test/support.ts
@@ -14,7 +14,7 @@ function normalizeNode(obj: AST.Node | Array<AST.Node>): AST.Node | Array<AST.No
       for (let i = 0; i < keys.length; i++) {
         let key = keys[i];
         if (key === 'loc') continue;
-        newObj[key] = key;
+        newObj[key] = normalizeNode(obj[key]);
       }
     }
     return newObj;


### PR DESCRIPTION
The astEqual assertion was silently not really asserting deep equality, because normalizeNode was normalizing everything into

```
{ type: "type", body: "body" }
```

etc.

This PR restores complete checking, and miraculously no tests were failing despite this assertion not really running for quite a while.

I noticed this bug because I tried to write a failing test that refused to fail.