### PR TITLE
Parser should strip leading newline from <pre> and <textarea>

### DIFF
--- a/packages/@glimmer/syntax/lib/parser.ts
+++ b/packages/@glimmer/syntax/lib/parser.ts
@@ -50,6 +50,7 @@ export abstract class Parser {
   abstract finishData(): void;
   abstract tagOpen(): void;
   abstract beginData(): void;
+  abstract appendLeadingNewlineToData(): void;
   abstract appendToData(char: string): void;
   abstract beginStartTag(): void;
   abstract appendToTagName(char: string): void;

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -60,6 +60,20 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     };
   }
 
+  appendLeadingNewlineToData() {
+    let currentElement = this.currentElement();
+    if (currentElement.type === 'ElementNode') {
+      let tag = currentElement.tag.toLowerCase();
+      if (tag === 'pre' || tag === 'textarea') {
+        // A newline immediately following a <pre> or <textarea> start
+        // tag must be dropped, per
+        // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+        return;
+      }
+    }
+    this.appendToData('\n');
+  }
+
   appendToData(char: string) {
     this.currentData.chars += char;
   }

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -476,3 +476,33 @@ test("Handlebars decorator block should error", function(assert) {
     parse("{{#* foo}}{{/foo}}");
   }, new Error(`Handlebars decorator blocks are not supported: "{{#* foo" at L1:C0`));
 });
+
+// https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+test("strips leading newline from <pre> data", function() {
+  let ast = parse("<pre>\nhello</pre>");
+  astEqual(ast, b.program([
+    b.element("pre", [], [], [
+      b.text("hello")
+    ])
+  ]));
+});
+
+// https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+test("strips leading newline from <PRE> data", function() {
+  let ast = parse("<PRE>\nhello</PRE>");
+  astEqual(ast, b.program([
+    b.element("PRE", [], [], [
+      b.text("hello")
+    ])
+  ]));
+});
+
+// https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+test("strips leading newline from <textarea> data", function() {
+  let ast = parse("<textarea>\nhello</textarea>");
+  astEqual(ast, b.program([
+    b.element("textarea", [], [], [
+      b.text("hello")
+    ])
+  ]));
+});


### PR DESCRIPTION
This accompanies https://github.com/tildeio/simple-html-tokenizer/pull/59 and won't pass CI until that is released.

tl;dr this closes a gap in our parser's spec compliance, details in the simple-html-tokenizer PR.