### PR TITLE
Move ARGs instance to VM.

### DIFF
--- a/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
+++ b/packages/@glimmer/bundle-compiler/test/entry-point-test.ts
@@ -2,7 +2,7 @@ import { module, test, EagerTestEnvironment } from "@glimmer/test-helpers";
 import { BundleCompiler, CompilerDelegate } from "@glimmer/bundle-compiler";
 import { RuntimeResolver, ComponentCapabilities, Option } from "@glimmer/interfaces";
 import { RuntimeProgram } from "@glimmer/program";
-import { LowLevelVM, NewElementBuilder, ComponentManager, MINIMAL_CAPABILITIES, ARGS, UNDEFINED_REFERENCE, PrimitiveReference } from "@glimmer/runtime";
+import { LowLevelVM, NewElementBuilder, ComponentManager, MINIMAL_CAPABILITIES, UNDEFINED_REFERENCE, PrimitiveReference } from "@glimmer/runtime";
 import { CONSTANT_TAG, VersionedPathReference, Tag } from "@glimmer/reference";
 import { Destroyable } from "@glimmer/util";
 
@@ -131,8 +131,8 @@ export class EntryPointTest {
 
     // @title="hello renderComponent"
     vm.stack.push(PrimitiveReference.create('hello renderComponent'));
-    ARGS.setup(vm.stack, ['@title'], ['main', 'else', 'attrs'], 0, false);
-    vm.stack.push(ARGS);
+    vm.args.setup(vm.stack, ['@title'], ['main', 'else', 'attrs'], 0, false);
+    vm.stack.push(vm.args);
 
     // Setup `main()` by pushing an invocation and definition onto the stack
     vm.stack.push({ handle: title, symbolTable: { hasEval: false, symbols: titleBlock.symbols, referrer: null } });

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -61,10 +61,6 @@ export {
 } from './lib/component/curried-component';
 
 export {
-  ARGS
-} from './lib/compiled/opcodes/component';
-
-export {
   ModifierManager,
   Modifier
 } from './lib/modifier/interfaces';

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -60,8 +60,6 @@ import {
   CheckFinishedComponentInstance
 } from './-debug-strip';
 
-export const ARGS = new Arguments();
-
 /**
  * The VM creates a new ComponentInstance data structure for every component
  * invocation it encounters.
@@ -226,14 +224,14 @@ APPEND_OPCODES.add(Op.PushArgs, (vm, { op1: _names, op2: flags }) => {
   if (flags & 0b0010) blockNames.push('else');
   if (flags & 0b0001) blockNames.push('attrs');
 
-  ARGS.setup(stack, names, blockNames, positionalCount, !!synthetic);
-  stack.push(ARGS);
+  vm.args.setup(stack, names, blockNames, positionalCount, !!synthetic);
+  stack.push(vm.args);
 });
 
 APPEND_OPCODES.add(Op.PushEmptyArgs, vm => {
   let { stack } = vm;
 
-  stack.push(ARGS.empty(stack));
+  stack.push(vm.args.empty(stack));
 });
 
 APPEND_OPCODES.add(Op.CaptureArgs, vm => {

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -8,6 +8,7 @@ import LowLevelVM, { Program } from './low-level';
 import { VMState, ListBlockOpcode, TryOpcode, BlockOpcode, Runtime } from './update';
 import RenderResult from './render-result';
 import EvaluationStack from './stack';
+import { Arguments } from "./arguments";
 
 import {
   APPEND_OPCODES,
@@ -62,6 +63,7 @@ export default class VM<T> implements PublicVM {
   public listBlockStack = new Stack<ListBlockOpcode>();
   public constants: Constants<T>;
   public heap: Heap;
+  public args: Arguments;
 
   get stack(): EvaluationStack {
     return this.inner.stack as EvaluationStack;
@@ -225,6 +227,7 @@ export default class VM<T> implements PublicVM {
     this.elementStack = elementStack;
     this.scopeStack.push(scope);
     this.dynamicScopeStack.push(dynamicScope);
+    this.args = new Arguments();
     this.inner = new LowLevelVM(EvaluationStack.empty(), this.heap, runtime.program, {
       debugBefore: (opcode: Opcode): DebugState => {
         return APPEND_OPCODES.debugBefore(this, opcode, opcode.type);

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -84,7 +84,7 @@ export interface ICapturedNamedArguments extends VersionedPathReference<Dict<Opa
 }
 
 export class Arguments implements IArguments {
-  private stack: EvaluationStack = null as any;
+  private stack: EvaluationStack | null = null;
   public positional = new PositionalArguments();
   public named = new NamedArguments();
   public blocks = new BlockArguments();
@@ -145,8 +145,9 @@ export class Arguments implements IArguments {
   }
 
   realloc(offset: number) {
-    if (offset > 0) {
-      let { positional, named, stack } = this;
+    let { stack } = this;
+    if (offset > 0 && stack !== null) {
+      let { positional, named } = this;
       let newBase = positional.base + offset;
       let length = positional.length + named.length;
 
@@ -173,7 +174,7 @@ export class Arguments implements IArguments {
 
   clear(): void {
     let { stack, length } = this;
-    stack.pop(length);
+    if (length > 0 && stack !== null) stack.pop(length);
   }
 }
 


### PR DESCRIPTION
Since it isn't just a view of the stack it also a cache of the view of the stack, this allows the cache to be garbage collected with the VM.