### PR TITLE
[BUGFIX] Fix void element printing

### DIFF
--- a/packages/@glimmer/syntax/lib/builders.ts
+++ b/packages/@glimmer/syntax/lib/builders.ts
@@ -4,6 +4,7 @@ import { Option } from '@glimmer/interfaces';
 // Statements
 
 export type BuilderPath = string | AST.PathExpression;
+export type TagDescriptor = string | { name: string; selfClosing: boolean };
 
 function buildMustache(
   path: BuilderPath | AST.Literal,
@@ -111,14 +112,14 @@ function buildConcat(
 // Nodes
 
 function buildElement(
-  tag: string,
+  tag: TagDescriptor,
   attributes?: AST.AttrNode[],
   modifiers?: AST.ElementModifierStatement[],
   children?: AST.Statement[],
   loc?: AST.SourceLocation
 ): AST.ElementNode;
 function buildElement(
-  tag: string,
+  tag: TagDescriptor,
   attributes?: AST.AttrNode[],
   modifiers?: AST.ElementModifierStatement[],
   children?: AST.Statement[],
@@ -127,7 +128,7 @@ function buildElement(
 ): AST.ElementNode;
 
 function buildElement(
-  tag: string,
+  tag: TagDescriptor,
   attributes?: AST.AttrNode[],
   modifiers?: AST.ElementModifierStatement[],
   children?: AST.Statement[],
@@ -140,9 +141,17 @@ function buildElement(
     comments = [];
   }
 
+  // this is used for backwards compat, prior to `selfClosing` being part of the ElementNode AST
+  let selfClosing = false;
+  if (typeof tag === 'object') {
+    selfClosing = tag.selfClosing;
+    tag = tag.name;
+  }
+
   return {
     type: 'ElementNode',
     tag: tag || '',
+    selfClosing: selfClosing,
     attributes: attributes || [],
     blockParams: [],
     modifiers: modifiers || [],

--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -1,5 +1,6 @@
 import { Option } from '@glimmer/interfaces';
 import * as HBS from '../types/nodes';
+import { voidMap } from '../parser/tokenizer-event-handlers';
 
 function unreachable(): never {
   throw new Error('unreachable');
@@ -33,9 +34,18 @@ export default function build(ast: HBS.Node): string {
       if (ast.comments.length) {
         output.push(' ', buildEach(ast.comments).join(' '));
       }
-      output.push('>');
-      output.push.apply(output, buildEach(ast.children));
-      output.push('</', ast.tag, '>');
+
+      if (voidMap[ast.tag]) {
+        if (ast.selfClosing) {
+          output.push(' /');
+        }
+
+        output.push('>');
+      } else {
+        output.push('>');
+        output.push.apply(output, buildEach(ast.children));
+        output.push('</', ast.tag, '>');
+      }
       break;
     case 'AttrNode':
       output.push(ast.name, '=');

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -11,7 +11,7 @@ import Walker from '../traversal/walker';
 import * as handlebars from 'handlebars';
 import { assign } from '@glimmer/util';
 
-const voidMap: {
+export const voidMap: {
   [tagName: string]: boolean;
 } = Object.create(null);
 
@@ -120,10 +120,9 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
   }
 
   finishStartTag() {
-    let { name, attributes, modifiers, comments } = this.currentStartTag;
-
+    let { name, attributes, modifiers, comments, selfClosing } = this.currentStartTag;
     let loc = b.loc(this.tagOpenLine, this.tagOpenColumn);
-    let element = b.element(name, attributes, modifiers, [], comments, loc);
+    let element = b.element({ name, selfClosing }, attributes, modifiers, [], comments, loc);
     this.elementStack.push(element);
   }
 

--- a/packages/@glimmer/syntax/lib/types/nodes.ts
+++ b/packages/@glimmer/syntax/lib/types/nodes.ts
@@ -96,6 +96,7 @@ export interface MustacheCommentStatement extends BaseNode {
 export interface ElementNode extends BaseNode {
   type: 'ElementNode';
   tag: string;
+  selfClosing: boolean;
   attributes: AttrNode[];
   blockParams: string[];
   modifiers: ElementModifierStatement[];

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -108,3 +108,11 @@ test('Handlebars comment: in ElementNode children', function() {
 test('Handlebars in handlebar comment', function() {
   printEqual('{{!-- {{foo-bar}} --}}');
 });
+
+test('Void elements', function() {
+  printEqual('<br>');
+});
+
+test('Void elements self closing', function() {
+  printEqual('<br />');
+});

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -13,7 +13,7 @@ test('a simple piece of content', function() {
 
 test('self-closed element', function() {
   let t = '<g />';
-  astEqual(t, b.program([b.element('g')]));
+  astEqual(t, b.program([b.element({ name: 'g', selfClosing: true })]));
 });
 
 test('elements can have empty attributes', function() {


### PR DESCRIPTION
This PR fixes an issue where output from the printer was not actually valid HTML.
For instance preprocessing `<br>` and then printing would emit `<br></br>`, upon
parsing this the template compiler would emit an "invalid end tag" error.

This PR fixes this by propigating the `selfClosing` property from the tokenizer
into the `ElementNode`. To make sure that the syntax builder is back compat, I've
allowed the `elementNode` builder to optionally take a `TagDescriptor`, which
encapsulates the tag name and if it was authored as `selfClosing`.