### PR TITLE
Loosen path type in buildSexpr

### DIFF
--- a/packages/@glimmer/syntax/lib/builders.ts
+++ b/packages/@glimmer/syntax/lib/builders.ts
@@ -176,7 +176,7 @@ function buildText(chars?: string, loc?: AST.SourceLocation): AST.TextNode {
 // Expressions
 
 function buildSexpr(
-  path: AST.PathExpression,
+  path: BuilderPath,
   params?: AST.Expression[],
   hash?: AST.Hash,
   loc?: AST.SourceLocation


### PR DESCRIPTION
`ember-template-compiler` currently passes a raw string to `buildSexpr`, but the current typing for the `path` parameter is too restrictive. It only allows a `PathExpression`, even though a string can get converted to one via `buildPath`.