### PR TITLE
fix @glimmer/compiler types

### DIFF
--- a/packages/@glimmer/compiler/lib/allocate-symbols.ts
+++ b/packages/@glimmer/compiler/lib/allocate-symbols.ts
@@ -77,7 +77,7 @@ export class SymbolAllocator
     this.symbolStack.pop();
   }
 
-  attrSplat(_op: null): OutOp<'attrSplat'> {
+  attrSplat(_op: Option<InVariable>): OutOp<'attrSplat'> {
     return ['attrSplat', this.symbols.allocateBlock('attrs')];
   }
 
@@ -127,7 +127,7 @@ export class SymbolAllocator
     return ['yield', this.symbols.allocateBlock(op)];
   }
 
-  debugger(_op: null): OutOp<'debugger'> {
+  debugger(_op: Option<InVariable[]>): OutOp<'debugger'> {
     return ['debugger', this.symbols.getEvalInfo()];
   }
 
@@ -147,7 +147,7 @@ export class SymbolAllocator
     return ['hasBlockParams', this.symbols.allocateBlock(op)];
   }
 
-  partial(_op: null): OutOp<'partial'> {
+  partial(_op: Option<InVariable[]>): OutOp<'partial'> {
     return ['partial', this.symbols.getEvalInfo()];
   }
 

--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -210,7 +210,7 @@ export default class JavaScriptCompiler
     this.push([Ops.Modifier, name, params, hash]);
   }
 
-  block([name, template, inverse]: [string, number, number]) {
+  block([name, template, inverse]: [string, number, Option<number>]) {
     let params = this.popValue<Params>();
     let hash = this.popValue<Hash>();
 
@@ -224,7 +224,7 @@ export default class JavaScriptCompiler
       'missing block in the compiler'
     );
 
-    this.push([Ops.Block, name, params, hash, blocks[template], blocks[inverse]]);
+    this.push([Ops.Block, name, params, hash, blocks[template], blocks[inverse!]]);
   }
 
   openSplattedElement(element: AST.ElementNode) {
@@ -270,19 +270,19 @@ export default class JavaScriptCompiler
     }
   }
 
-  staticAttr([name, namespace]: [string, string]) {
+  staticAttr([name, namespace]: [string, Option<string>]) {
     let value = this.popValue<Expression>();
     this.push([Ops.StaticAttr, name, value, namespace]);
   }
 
-  dynamicAttr([name, namespace]: [string, string]) {
+  dynamicAttr([name, namespace]: [string, Option<string>]) {
     let value = this.popValue<Expression>();
     this.push([Ops.DynamicAttr, name, value, namespace]);
   }
 
-  trustingAttr([name, namespace]: [string, string]) {
+  trustingAttr([name, namespace]: [string, Option<string>]) {
     let value = this.popValue<Expression>();
-    this.push([Ops.TrustingAttr, name, value, namespace]);
+    this.push([Ops.TrustingAttr, name, value, namespace!]);
   }
 
   staticArg(name: str) {
@@ -300,12 +300,12 @@ export default class JavaScriptCompiler
     this.push([Ops.Yield, to, params]);
   }
 
-  attrSplat(to: number) {
-    this.push([Ops.AttrSplat, to]);
+  attrSplat(to: Option<number>) {
+    this.push([Ops.AttrSplat, to!]);
   }
 
-  debugger(evalInfo: Core.EvalInfo) {
-    this.push([Ops.Debugger, evalInfo]);
+  debugger(evalInfo: Option<Core.EvalInfo>) {
+    this.push([Ops.Debugger, evalInfo!]);
     this.template.block.hasEval = true;
   }
 
@@ -317,9 +317,9 @@ export default class JavaScriptCompiler
     this.pushValue<Expressions.HasBlockParams>([Ops.HasBlockParams, name]);
   }
 
-  partial(evalInfo: Core.EvalInfo) {
+  partial(evalInfo: Option<Core.EvalInfo>) {
     let params = this.popValue<Params>();
-    this.push([Ops.Partial, params[0], evalInfo]);
+    this.push([Ops.Partial, params[0], evalInfo!]);
     this.template.block.hasEval = true;
   }
 


### PR DESCRIPTION
https://github.com/emberjs/ember.js/pull/16660 is failing because ember.js is using stricter tsconfig settings than glimmer-vm. For example:

```
node_modules/@glimmer/compiler/dist/types/lib/allocate-symbols.d.ts(22,5): error TS2416: Property 'attrSplat' in type 'SymbolAllocator' is not assignable to the same property in base type 'Processor<CompilerOps<string | 0>, number, CompilerOps<number>>'.
  Type '(_op: null) => Op<number, CompilerOps<number>, "attrSplat">' is not assignable to type '(operand: Option<string | 0>) => void | Op<number, CompilerOps<number>, "text" | "unknown" | "lit...'.
    Types of parameters '_op' and 'operand' are incompatible.
      Type 'Option<string | 0>' is not assignable to type 'null'.
        Type 'string' is not assignable to type 'null'.
```

Since I'm not particularly familiar with the `glimmer-vm` codebase, I'm not sure whether loosening parameter types and adding definite assignment assertions is the safest approach, but it does make the TS compiler happy when strict mode is on.