### PR TITLE
Restore Node tests

### DIFF
--- a/bin/run-node-tests.js
+++ b/bin/run-node-tests.js
@@ -8,6 +8,16 @@ const EMBER_BIN = 'ember';
 const QUNIT_BIN = 'qunit';
 const NODE_TEST_GLOB = '@glimmer/{node,bundle-compiler}/test/**/*node-test.js';
 
+// With the TAP reporter, testem swallows any errors generated while running
+// this script that are not in TAP format and does not treat non-zero exit codes
+// as a test failure. This handler ensures that any non-zero exits emit a
+// TAP-compatible bail out message.
+process.on('exit', (code) => {
+  if (code !== 0) {
+    console.log('Bail out! Non-zero exit code ' + code);
+  }
+});
+
 // When running inside `ember test`, we already have a build we can use.
 if ('EMBER_CLI_TEST_OUTPUT' in process.env) {
   process.chdir(process.env.EMBER_CLI_TEST_OUTPUT);

--- a/build/broccoli/build-packages.js
+++ b/build/broccoli/build-packages.js
@@ -158,7 +158,7 @@ function transpileCommonJS(pkgName, esVersion, tree) {
         envFlags: {
           source: '@glimmer/local-debug-flags',
           flags: {
-            DEVMODE: false,
+            DEVMODE: process.env.EMBER_ENV !== 'production',
             DEBUG: false
           }
         },

--- a/packages/@glimmer/node/test/node-dom-helper-node-test.ts
+++ b/packages/@glimmer/node/test/node-dom-helper-node-test.ts
@@ -3,17 +3,17 @@ import {
   test,
   rawModule,
   NodeLazyRenderDelegate,
-  SSRSuite,
   NodeEagerRenderDelegate,
   SSRComponentSuite,
   blockStack,
   strip,
+  AbstractNodeTest,
 } from '@glimmer/test-helpers';
 import { NodeDOMTreeConstruction, serializeBuilder } from '..';
 import { precompile } from '@glimmer/compiler';
 import { Environment, Cursor } from '@glimmer/runtime';
 
-class DOMHelperTests extends SSRSuite {
+class DOMHelperTests extends AbstractNodeTest {
   @test
   'can instantiate NodeDOMTreeConstruction without a document'() {
     // this emulates what happens in Ember when using `App.visit('/', { shouldRender: false });`
@@ -80,8 +80,9 @@ class SerializedDOMHelperTests extends DOMHelperTests {
 
   @test
   'Null literals do not have representation in DOM'() {
+    let b = blockStack();
     this.render('{{null}}');
-    this.assertHTML('<!--% %-->');
+    this.assertHTML(strip`${b(1)}<!--% %-->${b(1)}`);
   }
 
   @test

--- a/packages/@glimmer/object/package.json
+++ b/packages/@glimmer/object/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/object",
   "dependencies": {
     "@glimmer/object-reference": "^0.34.6",
+    "@glimmer/reference": "^0.34.6",
     "@glimmer/util": "^0.34.6"
   },
   "devDependencies": {

--- a/packages/@glimmer/opcode-compiler/index.ts
+++ b/packages/@glimmer/opcode-compiler/index.ts
@@ -2,9 +2,9 @@ export * from './lib/interfaces';
 
 export { ATTRS_BLOCK, CompileOptions, Macros } from './lib/syntax';
 
-export * from './lib/lazy';
-export * from './lib/compile';
-export * from './lib/compiler';
+export { LazyCompilerOptions, LazyCompiler } from './lib/lazy';
+export { compile } from './lib/compile';
+export { AbstractCompiler, AnyAbstractCompiler, debugCompiler } from './lib/compiler';
 
 export { CompilableBlock, CompilableProgram } from './lib/compilable-template';
 

--- a/packages/@glimmer/opcode-compiler/lib/compile.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compile.ts
@@ -1,5 +1,5 @@
 import { statementCompiler } from './syntax';
-import { debug, AnyAbstractCompiler } from './compiler';
+import { debugCompiler, AnyAbstractCompiler } from './compiler';
 import { OpcodeBuilder } from './opcode-builder';
 import { Statement } from '@glimmer/wire-format';
 import { Compiler, Recast } from '@glimmer/interfaces';
@@ -19,7 +19,10 @@ export function compile<Locator>(
   let handle = builder.commit();
 
   if (DEBUG) {
-    debug(compiler as Recast<Compiler<OpcodeBuilder<Locator>>, AnyAbstractCompiler>, handle);
+    debugCompiler(
+      compiler as Recast<Compiler<OpcodeBuilder<Locator>>, AnyAbstractCompiler>,
+      handle
+    );
   }
 
   return handle;

--- a/packages/@glimmer/opcode-compiler/lib/compiler.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compiler.ts
@@ -147,10 +147,10 @@ export abstract class AbstractCompiler<
   abstract builderFor(containingLayout: LayoutWithContext<Opaque>): Builder;
 }
 
-export let debug: (compiler: AnyAbstractCompiler, handle: number) => void;
+export let debugCompiler: (compiler: AnyAbstractCompiler, handle: number) => void;
 
 if (DEBUG) {
-  debug = (compiler: AnyAbstractCompiler, handle: number) => {
+  debugCompiler = (compiler: AnyAbstractCompiler, handle: number) => {
     let { heap } = compiler['program'];
     let start = heap.getaddr(handle);
     let end = start + heap.sizeof(handle);

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -11,7 +11,7 @@ import {
 
 import { ComponentArgs, ComponentBuilder as IComponentBuilder } from './interfaces';
 
-import { debug, AnyAbstractCompiler } from './compiler';
+import { debugCompiler, AnyAbstractCompiler } from './compiler';
 import { CompilableBlock as CompilableBlockInstance } from './compilable-template';
 import { OpcodeBuilder } from './opcode-builder';
 import { ATTRS_BLOCK } from './syntax';
@@ -102,7 +102,10 @@ export class WrappedBuilder<Locator> implements CompilableProgram {
     let handle = b.commit();
 
     if (DEBUG) {
-      debug(compiler as Recast<Compiler<OpcodeBuilder<Locator>>, AnyAbstractCompiler>, handle);
+      debugCompiler(
+        compiler as Recast<Compiler<OpcodeBuilder<Locator>>, AnyAbstractCompiler>,
+        handle
+      );
     }
 
     return (this.compiled = handle);

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -14,6 +14,7 @@
     "@glimmer/vm": "^0.34.6"
   },
   "devDependencies": {
+    "@glimmer/local-debug-flags": "^0.34.6",
     "@glimmer/object": "^0.34.6",
     "@glimmer/object-reference": "^0.34.6",
     "@glimmer/opcode-compiler": "^0.34.6",

--- a/packages/@glimmer/test-helpers/index.ts
+++ b/packages/@glimmer/test-helpers/index.ts
@@ -42,6 +42,7 @@ export {
   default as TestEnvironment,
 } from './lib/environment/modes/lazy/environment';
 export {
+  AbstractNodeTest,
   NodeLazyRenderDelegate,
   NodeEagerRenderDelegate,
 } from './lib/environment/modes/ssr/environment';


### PR DESCRIPTION
Testem swallows non-zero exit codes and other error messages with the TAP reporter enabled. The Node.js tests have not been running for a few months because of this.

This PR traps process exit from the test runner, and prints a TAP-compatible "Bail out" message if it detects a non-zero exit code. With this message present, errors starting up the test runner are now reported as test failures.

I also fixed several other bugs that were preventing the CommonJS versions of the packages from working. There are a handful of remaining tests related to rehydration failing. I'm not sure how they were ever intended to work. Maybe @chadhietala can take a look at these.