### PR TITLE
Update simple-html-tokenizer to ^0.5.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-plugin-debug-macros": "^0.1.11",
     "handlebars": "^4.0.6",
     "simple-dom": "^0.3.0",
-    "simple-html-tokenizer": "^0.5.1"
+    "simple-html-tokenizer": "^0.5.3"
   },
   "devDependencies": {
     "@glimmer/build": "^0.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6774,9 +6774,9 @@ simple-fmt@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-fmt/-/simple-fmt-0.1.0.tgz#191bf566a59e6530482cb25ab53b4a8dc85c3a6b"
 
-simple-html-tokenizer@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.1.tgz#125d486de28ffd5365624c11a71944a2cc2826dc"
+simple-html-tokenizer@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.3.tgz#c1c246a53ccf1cd65fb2fa970967145b47602ce4"
 
 simple-is@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Enables matching `@` in tagnames for dynamic angle bracket invocation of named arguments (e.g. `<@foo></@foo>`).