### PR TITLE
Ensure `has-block` is false for `<Foo />`.

### DIFF
--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -78,7 +78,7 @@ export class ComponentBlock extends Block {
   private inParams = true;
   public positionals: number[] = [];
 
-  constructor(private table: BlockSymbolTable) {
+  constructor(private table: BlockSymbolTable, private selfClosing: boolean) {
     super();
   }
 
@@ -104,15 +104,14 @@ export class ComponentBlock extends Block {
     let args = this.arguments;
     let keys = args.map(arg => arg[1]);
     let values = args.map(arg => arg[2]);
+    let block = this.selfClosing
+      ? null
+      : {
+          statements: this.statements,
+          parameters: this.table.slots,
+        };
 
-    return [
-      this.attributes,
-      [keys, values],
-      {
-        statements: this.statements,
-        parameters: this.table.slots,
-      },
-    ];
+    return [this.attributes, [keys, values], block];
   }
 }
 
@@ -359,7 +358,7 @@ export default class JavaScriptCompiler
   /// Stack Management Opcodes
 
   startComponent(element: AST.ElementNode) {
-    let component = new ComponentBlock(element['symbols']);
+    let component = new ComponentBlock(element['symbols'], element.selfClosing);
     this.blocks.push(component);
   }
 

--- a/packages/@glimmer/runtime/test/partial-test.ts
+++ b/packages/@glimmer/runtime/test/partial-test.ts
@@ -189,9 +189,9 @@ QUnit.test('static partial with has-block in basic component', () => {
     root,
     strip`
     <p>true-false</p>
-    <p>true-false</p>
+    <p>false-false</p>
     <p>true-false-true-false</p>
-    <p>true-false-true-false</p>
+    <p>false-false-false-false</p>
   `
   );
 

--- a/packages/@glimmer/test-helpers/lib/suites/has-block.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/has-block.ts
@@ -220,4 +220,43 @@ export class HasBlockSuite extends RenderTest {
     this.assertComponent('<button data-has-block="is-false"></button>');
     this.assertStableRerender();
   }
+
+  @test
+  'self closing angle bracket invocation (subexpr, default)'() {
+    this.registerComponent(
+      'Glimmer',
+      'TestComponent',
+      `<div ...attributes>{{#if (has-block)}}Yes{{else}}No{{/if}}</div>`
+    );
+    this.render(`<TestComponent />`);
+
+    this.assertComponent('No');
+    this.assertStableRerender();
+  }
+
+  @test
+  'self closing angle bracket invocation (subexpr, inverse)'() {
+    this.registerComponent(
+      'Glimmer',
+      'TestComponent',
+      `<div ...attributes>{{#if (has-block 'inverse')}}Yes{{else}}No{{/if}}</div>`
+    );
+    this.render(`<TestComponent />`);
+
+    this.assertComponent('No');
+    this.assertStableRerender();
+  }
+
+  @test
+  'self closing angle bracket invocation (concatted attr, default)'() {
+    this.registerComponent(
+      'Glimmer',
+      'TestComponent',
+      `<div data-has-block="{{has-block}}" ...attributes></div>`
+    );
+    this.render(`<TestComponent />`);
+
+    this.assertComponent('', { 'data-has-block': 'false' });
+    this.assertStableRerender();
+  }
 }


### PR DESCRIPTION
This brings `has-block` in line with the proposed [angle bracket invocation RFC](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#closing-tag). After these changes using self closing tags with the angle bracket invocation style will be `false` (in accordance with the RFC).

From the RFC:

> If no block is passed, the self-closing tag syntax <FooBar /> can also be used (in which case {{has-block}} will be false).