### PR TITLE
Decouple `didCreateElement` from `...attributes`.

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -169,7 +169,6 @@ export function statementCompiler(): Compilers<WireFormat.Statement> {
     let [, to] = sexp;
 
     builder.yield(to, []);
-    builder.didCreateElement(Register.s0);
     builder.setComponentAttrs(false);
   });
 

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -12,6 +12,7 @@ import {
   stripTight,
   TestEnvironment,
   TestModifierManager,
+  assertElement,
 } from '@glimmer/test-helpers';
 import { assign } from '@glimmer/util';
 import { Template } from '@glimmer/interfaces';
@@ -1227,19 +1228,15 @@ QUnit.test('component helper: currying works inline', () => {
 
 module('Emberish Component - ids');
 
-QUnit.test('emberish component should have unique IDs', assert => {
+QUnit.test('emberish curly component should have unique IDs', assert => {
   env.registerEmberishCurlyComponent('x-curly', null, '');
-  env.registerEmberishGlimmerComponent('XGlimmer', null, '<div ...attributes />');
 
   appendViewFor(
     stripTight`
       <div>
         {{x-curly}}
         {{x-curly}}
-        <XGlimmer />
-        <XGlimmer />
         {{x-curly}}
-        <XGlimmer />
       </div>`
   );
 
@@ -1261,24 +1258,6 @@ QUnit.test('emberish component should have unique IDs', assert => {
     { id: regex(/^ember\d*$/), class: 'ember-view' },
     ''
   );
-  equalsElement(
-    view.element.childNodes[3] as Element,
-    'div',
-    { id: regex(/^ember\d*$/), class: 'ember-view' },
-    ''
-  );
-  equalsElement(
-    view.element.childNodes[4] as Element,
-    'div',
-    { id: regex(/^ember\d*$/), class: 'ember-view' },
-    ''
-  );
-  equalsElement(
-    view.element.childNodes[5] as Element,
-    'div',
-    { id: regex(/^ember\d*$/), class: 'ember-view' },
-    ''
-  );
 
   let IDs = {};
 
@@ -1289,11 +1268,8 @@ QUnit.test('emberish component should have unique IDs', assert => {
   markAsSeen(view.element.childNodes[0] as Element);
   markAsSeen(view.element.childNodes[1] as Element);
   markAsSeen(view.element.childNodes[2] as Element);
-  markAsSeen(view.element.childNodes[3] as Element);
-  markAsSeen(view.element.childNodes[4] as Element);
-  markAsSeen(view.element.childNodes[5] as Element);
 
-  assert.equal(Object.keys(IDs).length, 6, 'Expected the components to each have a unique IDs');
+  assert.equal(Object.keys(IDs).length, 3, 'Expected the components to each have a unique IDs');
 
   for (let id in IDs) {
     assert.equal(IDs[id], 1, `Expected ID ${id} to be unique`);
@@ -1326,22 +1302,12 @@ styles.forEach(style => {
     appendViewFor('<NonBlock />');
 
     let node = view.element.firstChild;
-    equalsElement(
-      view.element,
-      style.tagName,
-      { class: 'ember-view', id: regex(/^ember\d*$/) },
-      'In layout'
-    );
+    equalsElement(view.element, style.tagName, {}, 'In layout');
 
     rerender();
 
     assert.strictEqual(node, view.element.firstChild, 'The inner element has not changed');
-    equalsElement(
-      view.element,
-      style.tagName,
-      { class: 'ember-view', id: regex(/^ember\d*$/) },
-      'In layout'
-    );
+    equalsElement(view.element, style.tagName, {}, 'In layout');
   });
 
   style.test(`NonBlock with attributes replaced with ${style.name}`, function() {
@@ -1354,12 +1320,7 @@ styles.forEach(style => {
     appendViewFor('<NonBlock @stability={{stability}} />', { stability: 'stability' });
 
     let node = view.element;
-    equalsElement(
-      node,
-      style.tagName,
-      { such: 'stability', class: 'ember-view', id: regex(/^ember\d*$/) },
-      'In layout'
-    );
+    equalsElement(node, style.tagName, { such: 'stability' }, 'In layout');
 
     set(view, 'stability', 'changed!!!');
     rerender();
@@ -1369,12 +1330,7 @@ styles.forEach(style => {
       view.element.firstElementChild,
       'The inner element has not changed'
     );
-    equalsElement(
-      node,
-      style.tagName,
-      { such: 'changed!!!', class: 'ember-view', id: regex(/^ember\d*$/) },
-      'In layout'
-    );
+    equalsElement(node, style.tagName, { such: 'changed!!!' }, 'In layout');
   });
 });
 
@@ -1383,12 +1339,7 @@ QUnit.test(`Ensure components can be invoked`, function() {
   env.registerEmberishGlimmerComponent('Inner', null, `<div ...attributes>hi!</div>`);
 
   appendViewFor('<Outer />');
-  equalsElement(
-    view.element,
-    'div',
-    { class: classes('ember-view'), id: regex(/^ember\d*$/) },
-    'hi!'
-  );
+  equalsElement(view.element, 'div', {}, 'hi!');
 });
 
 QUnit.test(`Glimmer component with element modifier`, function(assert) {
@@ -1672,12 +1623,12 @@ QUnit.test('Glimmer component hooks', assert => {
   assertFired(instance, 'didInsertElement');
   assertFired(instance, 'didRender');
 
-  assertEmberishElement('div', 'In layout - someProp: wycats');
+  assertElement(view.element as HTMLElement, 'div', 'In layout - someProp: wycats');
 
   set(view, 'someProp', 'tomdale');
   rerender();
 
-  assertEmberishElement('div', 'In layout - someProp: tomdale');
+  assertElement(view.element as HTMLElement, 'div', 'In layout - someProp: tomdale');
 
   assertFired(instance, 'didReceiveAttrs', 2);
   assertFired(instance, 'willUpdate');
@@ -1687,7 +1638,7 @@ QUnit.test('Glimmer component hooks', assert => {
 
   rerender();
 
-  assertEmberishElement('div', 'In layout - someProp: tomdale');
+  assertElement(view.element as HTMLElement, 'div', 'In layout - someProp: tomdale');
 
   assertFired(instance, 'didReceiveAttrs', 3);
   assertFired(instance, 'willUpdate', 2);
@@ -1724,11 +1675,11 @@ QUnit.test('Glimmer component hooks (force recompute)', assert => {
   assertFired(instance, 'didInsertElement', 1);
   assertFired(instance, 'didRender', 1);
 
-  assertEmberishElement('div', 'In layout - someProp: wycats');
+  assertElement(view.element as HTMLElement, 'div', 'In layout - someProp: wycats');
 
   rerender();
 
-  assertEmberishElement('div', 'In layout - someProp: wycats');
+  assertElement(view.element as HTMLElement, 'div', 'In layout - someProp: wycats');
 
   assertFired(instance, 'didReceiveAttrs', 1);
   assertFired(instance, 'willRender', 1);
@@ -1737,7 +1688,7 @@ QUnit.test('Glimmer component hooks (force recompute)', assert => {
   instance.recompute();
   rerender();
 
-  assertEmberishElement('div', 'In layout - someProp: wycats');
+  assertElement(view.element as HTMLElement, 'div', 'In layout - someProp: wycats');
 
   assertFired(instance, 'didReceiveAttrs', 2);
   assertFired(instance, 'willUpdate', 1);
@@ -2291,7 +2242,7 @@ QUnit.test('it works for unwrapped components', function(assert) {
   env.registerEmberishGlimmerComponent(
     'FooBar',
     FooBar,
-    '<!-- ohhh --><span ...attributes>foo bar!</span>'
+    '<!-- ohhh --><span id="ralph-the-wrench" ...attributes>foo bar!</span>'
   );
 
   appendViewFor('zomg <FooBar /> wow');
@@ -2302,9 +2253,11 @@ QUnit.test('it works for unwrapped components', function(assert) {
     return;
   }
 
-  assertEmberishElement('span', {}, 'foo bar!');
+  assertElement(view.element as HTMLElement, 'span', { id: 'ralph-the-wrench' }, 'foo bar!');
+
+  let ralphy = document.getElementById('ralph-the-wrench')!;
 
   assert.equal(instance.bounds.parentElement(), document.querySelector('#qunit-fixture'));
-  assert.equal(instance.bounds.firstNode(), instance.element.previousSibling);
-  assert.equal(instance.bounds.lastNode(), instance.element);
+  assert.equal(instance.bounds.firstNode(), ralphy.previousSibling);
+  assert.equal(instance.bounds.lastNode(), ralphy);
 });

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -18,6 +18,7 @@ import {
   ComponentBlueprint,
   GLIMMER_TEST_COMPONENT,
   assertEmberishElement,
+  assertElement,
   assertSerializedInElement,
 } from '@glimmer/test-helpers';
 import { expect } from '@glimmer/util';
@@ -503,10 +504,15 @@ class RehydratingComponents extends AbstractRehydrationTests {
   }
 
   assertServerComponent(html: string, attrs: Object = {}) {
-    if (this.testType === 'Dynamic') {
-      assertEmberishElement(this.element.childNodes[3] as HTMLElement, 'div', attrs, html);
+    // the Dynamic test type is using {{component 'foo'}} style invocation
+    // and therefore an extra node is added delineating the block start
+    let elementIndex = this.testType === 'Dynamic' ? 3 : 2;
+    let element = this.element.childNodes[elementIndex] as HTMLElement;
+
+    if (this.testType === 'Glimmer') {
+      assertElement(element, 'div', attrs, html);
     } else {
-      assertEmberishElement(this.element.childNodes[2] as HTMLElement, 'div', attrs, html);
+      assertEmberishElement(element, 'div', attrs, html);
     }
   }
 

--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -103,7 +103,7 @@ export function equalsElement(
   element: Element | null,
   tagName: string,
   attributes: Object,
-  content: string
+  content: string | null
 ) {
   if (element === null) {
     QUnit.assert.pushResult({

--- a/packages/@glimmer/test-helpers/lib/environment/components/emberish-glimmer.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/emberish-glimmer.ts
@@ -4,8 +4,6 @@ import {
   WithStaticLayout,
   Environment,
   Arguments,
-  PrimitiveReference,
-  ElementOperations,
   Bounds,
   Invocation,
 } from '@glimmer/runtime';
@@ -106,20 +104,7 @@ export class EmberishGlimmerComponentManager
     return new UpdatableReference(component);
   }
 
-  didCreateElement(
-    { component }: EmberishGlimmerComponentState,
-    element: Element,
-    operations: ElementOperations
-  ): void {
-    component.element = element;
-    operations.setAttribute(
-      'id',
-      PrimitiveReference.create(`ember${component._guid}`),
-      false,
-      null
-    );
-    operations.setAttribute('class', PrimitiveReference.create('ember-view'), false, null);
-  }
+  didCreateElement(): void {}
 
   didRenderLayout({ component }: EmberishGlimmerComponentState, bounds: Bounds): void {
     component.bounds = bounds;

--- a/packages/@glimmer/test-helpers/lib/environment/modes/ssr/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/ssr/environment.ts
@@ -65,10 +65,14 @@ export class AbstractNodeTest extends RenderTest {
 
   assertComponent(html: string) {
     let el = this.element.firstChild! as Element;
-    this.assert.equal(el.getAttribute('class'), 'ember-view');
-    this.assert.ok(el.getAttribute('id'));
-    this.assert.ok(el.getAttribute('id')!.indexOf('ember') > -1);
-    let serialized = this.serializer.serializeChildren(this.element.firstChild!);
+
+    if (this.testType !== 'Glimmer') {
+      this.assert.equal(el.getAttribute('class'), 'ember-view');
+      this.assert.ok(el.getAttribute('id'));
+      this.assert.ok(el.getAttribute('id')!.indexOf('ember') > -1);
+    }
+
+    let serialized = this.serializer.serializeChildren(el);
     this.assert.equal(serialized, html);
   }
 }

--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -1,4 +1,4 @@
-import { RenderTest, test, assertEmberishElement } from '../render-test';
+import { RenderTest, test, assertElement } from '../render-test';
 import { classes } from '../environment';
 import { EmberishGlimmerComponent } from '../environment/components/emberish-glimmer';
 import { strip } from '../helpers';
@@ -82,19 +82,9 @@ export class EmberishComponentTests extends RenderTest {
     `,
       { components: [{ name: 'Foo', child: 'Bar', mount: el, data: { wat: 'Wat' } }] }
     );
-    assertEmberishElement(
-      el.firstChild as HTMLElement,
-      'div',
-      { 'data-bar': 'Bar' },
-      'Hello World'
-    );
+    assertElement(el.firstChild as HTMLElement, 'div', { 'data-bar': 'Bar' }, 'Hello World');
     this.rerender({ components: [{ name: 'Foo', child: 'Bar', mount: el, data: { wat: 'Wat' } }] });
-    assertEmberishElement(
-      el.firstChild as HTMLElement,
-      'div',
-      { 'data-bar': 'Bar' },
-      'Hello World'
-    );
+    assertElement(el.firstChild as HTMLElement, 'div', { 'data-bar': 'Bar' }, 'Hello World');
   }
 
   @test({ kind: 'glimmer' })


### PR DESCRIPTION
This changes the generated opcodes such that `<div ...attributes></div>` no longer invokes the `didCreateElement` hook on the associated manager.

`didCreateElement` is intended only for the "wrapping element" in scenarios like `Ember.Component` (which specifically uses the `WrappedBuilder` et al).

~~glimmer.js will need some tweaking (specifically around how it represents `this.element`) before updating (hence the breaking change label).~~