### PR TITLE
Ensure `assertComponent` identifies angle invocation has-block tests.

### DIFF
--- a/packages/@glimmer/test-helpers/lib/suites/has-block.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/has-block.ts
@@ -221,7 +221,7 @@ export class HasBlockSuite extends RenderTest {
     this.assertStableRerender();
   }
 
-  @test
+  @test({ kind: 'glimmer' })
   'self closing angle bracket invocation (subexpr, default)'() {
     this.registerComponent(
       'Glimmer',
@@ -234,7 +234,7 @@ export class HasBlockSuite extends RenderTest {
     this.assertStableRerender();
   }
 
-  @test
+  @test({ kind: 'glimmer' })
   'self closing angle bracket invocation (subexpr, inverse)'() {
     this.registerComponent(
       'Glimmer',
@@ -247,7 +247,7 @@ export class HasBlockSuite extends RenderTest {
     this.assertStableRerender();
   }
 
-  @test
+  @test({ kind: 'glimmer' })
   'self closing angle bracket invocation (concatted attr, default)'() {
     this.registerComponent(
       'Glimmer',


### PR DESCRIPTION
This fixes the current failing tests on the master branch. The failures were introduced by the combination of #819 and #820. Both of them were green independently, but the tests added in #819 would have needed to be updated in #820 to prevent failures.

tldr; these crossed in the mail :P