### PR TITLE
Implement dynamic angle bracket invocation.

### DIFF
--- a/packages/@glimmer/compiler/lib/allocate-symbols.ts
+++ b/packages/@glimmer/compiler/lib/allocate-symbols.ts
@@ -1,10 +1,10 @@
-import { CompilerOps, Processor, Op, OpName, TemplateCompilerOps } from './compiler-ops';
+import { CompilerOps, Processor, Op, OpName, TemplateCompilerOps, PathHead } from './compiler-ops';
 import { AST } from '@glimmer/syntax';
 import { Option, Opaque } from '@glimmer/interfaces';
 import { Stack, expect } from '@glimmer/util';
 import { SymbolTable } from './template-visitor';
 
-export type InVariable = 0 | string;
+export type InVariable = PathHead;
 export type OutVariable = number;
 
 export type OutOp<K extends keyof CompilerOps<OutVariable> = OpName> = Op<
@@ -13,7 +13,7 @@ export type OutOp<K extends keyof CompilerOps<OutVariable> = OpName> = Op<
   K
 >;
 export type InOp<K extends keyof TemplateCompilerOps = keyof TemplateCompilerOps> = Op<
-  0 | string,
+  PathHead,
   TemplateCompilerOps,
   K
 >;

--- a/packages/@glimmer/compiler/lib/allocate-symbols.ts
+++ b/packages/@glimmer/compiler/lib/allocate-symbols.ts
@@ -77,6 +77,10 @@ export class SymbolAllocator
     this.symbolStack.pop();
   }
 
+  closeComponent(_op: AST.ElementNode) {
+    this.symbolStack.pop();
+  }
+
   attrSplat(_op: Option<InVariable>): OutOp<'attrSplat'> {
     return ['attrSplat', this.symbols.allocateBlock('attrs')];
   }
@@ -153,6 +157,7 @@ export class SymbolAllocator
 
   text(_op: string) {}
   comment(_op: string) {}
+  openComponent(_op: AST.ElementNode) {}
   openElement(_op: AST.ElementNode) {}
   openSplattedElement(_op: AST.ElementNode) {}
   staticArg(_op: string) {}

--- a/packages/@glimmer/compiler/lib/allocate-symbols.ts
+++ b/packages/@glimmer/compiler/lib/allocate-symbols.ts
@@ -81,6 +81,10 @@ export class SymbolAllocator
     this.symbolStack.pop();
   }
 
+  closeDynamicComponent(_op: AST.ElementNode) {
+    this.symbolStack.pop();
+  }
+
   attrSplat(_op: Option<InVariable>): OutOp<'attrSplat'> {
     return ['attrSplat', this.symbols.allocateBlock('attrs')];
   }

--- a/packages/@glimmer/compiler/lib/compiler-ops.ts
+++ b/packages/@glimmer/compiler/lib/compiler-ops.ts
@@ -1,6 +1,11 @@
 import { AST } from '@glimmer/syntax';
 import { Option, Opaque } from '@glimmer/interfaces';
 
+/**
+  - 0 - represents `this`
+  - string - represents any other path
+ */
+export type PathHead = string | 0;
 export interface CompilerOps<Variable> {
   startProgram: AST.Program;
   endProgram: null;
@@ -40,8 +45,8 @@ export interface CompilerOps<Variable> {
   concat: null;
 }
 
-export interface TemplateCompilerOps extends CompilerOps<string | 0> {
-  maybeGet: [string | 0, string[]]; // {{path}}, might be helper
+export interface TemplateCompilerOps extends CompilerOps<PathHead> {
+  maybeGet: [PathHead, string[]]; // {{path}}, might be helper
 }
 
 export type OpName = keyof CompilerOps<Opaque>;

--- a/packages/@glimmer/compiler/lib/compiler-ops.ts
+++ b/packages/@glimmer/compiler/lib/compiler-ops.ts
@@ -9,9 +9,11 @@ export interface CompilerOps<Variable> {
   text: string;
   comment: string;
   openElement: AST.ElementNode;
+  openComponent: AST.ElementNode;
   openSplattedElement: AST.ElementNode;
   flushElement: AST.ElementNode;
   closeElement: AST.ElementNode;
+  closeComponent: AST.ElementNode;
   staticArg: string;
   dynamicArg: string;
   attrSplat: Option<Variable>;

--- a/packages/@glimmer/compiler/lib/compiler-ops.ts
+++ b/packages/@glimmer/compiler/lib/compiler-ops.ts
@@ -14,6 +14,7 @@ export interface CompilerOps<Variable> {
   flushElement: AST.ElementNode;
   closeElement: AST.ElementNode;
   closeComponent: AST.ElementNode;
+  closeDynamicComponent: AST.ElementNode;
   staticArg: string;
   dynamicArg: string;
   attrSplat: Option<Variable>;

--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -16,6 +16,7 @@ import {
   isFlushElement,
   isArgument,
   isAttribute,
+  isAttrSplat,
 } from '@glimmer/wire-format';
 import { Processor, CompilerOps, OpName, Op } from './compiler-ops';
 
@@ -91,6 +92,8 @@ export class ComponentBlock extends Block {
       } else if (isArgument(statement)) {
         this.arguments.push(statement);
       } else if (isAttribute(statement)) {
+        this.attributes.push(statement);
+      } else if (isAttrSplat(statement)) {
         this.attributes.push(statement);
       } else {
         throw new Error('Compile Error: only parameters allowed before flush-element');

--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -234,9 +234,7 @@ export default class JavaScriptCompiler
   openSplattedElement(element: AST.ElementNode) {
     let tag = element.tag;
 
-    if (isComponent(tag)) {
-      throw new Error(`Compile Error: ...attributes can only be used in an element`);
-    } else if (element.blockParams.length > 0) {
+    if (element.blockParams.length > 0) {
       throw new Error(
         `Compile Error: <${element.tag}> is not a component and doesn't support block parameters`
       );
@@ -420,10 +418,4 @@ export default class JavaScriptCompiler
     assert(this.values.length, 'No expression found on stack');
     return this.values.pop() as T;
   }
-}
-
-function isComponent(tag: string): boolean {
-  let open = tag.charAt(0);
-
-  return open === open.toUpperCase() || open === '@';
 }

--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -425,5 +425,5 @@ export default class JavaScriptCompiler
 function isComponent(tag: string): boolean {
   let open = tag.charAt(0);
 
-  return open === open.toUpperCase();
+  return open === open.toUpperCase() || open === '@';
 }

--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -262,14 +262,15 @@ export default class JavaScriptCompiler
   }
 
   closeComponent(element: AST.ElementNode) {
-    //endComponent(): [Statements.Attribute[], Core.Hash, Option<SerializedInlineBlock>] {
-    let component = this.blocks.pop();
-    assert(
-      component instanceof ComponentBlock,
-      'Compiler bug: endComponent() should end a component'
-    );
-    let [attrs, args, block] = (component as ComponentBlock).toJSON();
+    let [attrs, args, block] = this.endComponent();
+
     this.push([Ops.Component, element.tag, attrs, args, block]);
+  }
+
+  closeDynamicComponent(_element: AST.ElementNode) {
+    let [attrs, args, block] = this.endComponent();
+
+    this.push([Ops.DynamicComponent, this.popValue<Expression>(), attrs, args, block]);
   }
 
   closeElement(_element: AST.ElementNode) {
@@ -392,6 +393,16 @@ export default class JavaScriptCompiler
   }
 
   /// Utilities
+
+  endComponent(): [Statements.Attribute[], Core.Hash, Option<SerializedInlineBlock>] {
+    let component = this.blocks.pop();
+    assert(
+      component instanceof ComponentBlock,
+      'Compiler bug: endComponent() should end a component'
+    );
+
+    return (component as ComponentBlock).toJSON();
+  }
 
   push(args: Statement) {
     while (args[args.length - 1] === null) {

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -5,6 +5,7 @@ import { AST, isLiteral, SyntaxError } from '@glimmer/syntax';
 import { getAttrNamespace } from './utils';
 import { Opaque } from '@glimmer/interfaces';
 import { SymbolAllocator, InOp as SymbolInOp, OutOp as SymbolOutOp } from './allocate-symbols';
+import { PathHead } from './compiler-ops';
 
 export interface CompileOptions {
   meta: Opaque;
@@ -82,7 +83,7 @@ export default class TemplateCompiler {
     }
 
     if (isDynamicComponent(action)) {
-      let head: string | 0, rest: string[];
+      let head: PathHead, rest: string[];
       [head, ...rest] = action.tag.split('.');
       if (head === 'this') {
         head = 0;

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -81,9 +81,11 @@ export default class TemplateCompiler {
       }
     }
 
-    if (isComponent(action)) {
-      //let [head, ...rest] = action.tag;
-      //this.opcode(['get', [head, rest]]);
+    if (isDynamicComponent(action)) {
+      let [head, ...rest] = action.tag.split('.');
+      this.opcode(['get', [head, rest]]);
+      this.opcode(['openComponent', action], action);
+    } else if (isComponent(action)) {
       this.opcode(['openComponent', action], action);
     } else if (hasSplat) {
       this.opcode(['openSplattedElement', action], action);
@@ -112,7 +114,9 @@ export default class TemplateCompiler {
   }
 
   closeElement([action]: [AST.ElementNode]) {
-    if (isComponent(action)) {
+    if (isDynamicComponent(action)) {
+      this.opcode(['closeDynamicComponent', action], action);
+    } else if (isComponent(action)) {
       this.opcode(['closeComponent', action], action);
     } else {
       this.opcode(['closeElement', action], action);

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -82,7 +82,11 @@ export default class TemplateCompiler {
     }
 
     if (isDynamicComponent(action)) {
-      let [head, ...rest] = action.tag.split('.');
+      let head: string | 0, rest: string[];
+      [head, ...rest] = action.tag.split('.');
+      if (head === 'this') {
+        head = 0;
+      }
       this.opcode(['get', [head, rest]]);
       this.opcode(['openComponent', action], action);
     } else if (isComponent(action)) {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -883,7 +883,8 @@ export abstract class OpcodeBuilder<Locator = Opaque> extends StdOpcodeBuilder {
 
   dynamicComponent(
     definition: WireFormat.Expression,
-    /* TODO: attrs: Option<RawInlineBlock>, */ params: Option<WireFormat.Core.Params>,
+    attrs: Option<CompilableBlock>,
+    params: Option<WireFormat.Core.Params>,
     hash: WireFormat.Core.Hash,
     synthetic: boolean,
     block: Option<CompilableBlock>,
@@ -903,7 +904,7 @@ export abstract class OpcodeBuilder<Locator = Opaque> extends StdOpcodeBuilder {
 
         this.pushDynamicComponentInstance();
 
-        this.invokeComponent(true, null, params, hash, synthetic, block, inverse);
+        this.invokeComponent(true, attrs, params, hash, synthetic, block, inverse);
 
         this.label('ELSE');
       },

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -104,6 +104,13 @@ export function statementCompiler(): Compilers<WireFormat.Statement> {
     builder.openPrimitiveElement(sexp[1]);
   });
 
+  STATEMENTS.add(Ops.DynamicComponent, (sexp: S.DynamicComponent, builder) => {
+    let [, definition, attrs, args, template] = sexp;
+
+    let block = builder.template(template);
+    builder.dynamicComponent(definition, null, args, false, block, null);
+  });
+
   STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
     let [, tag, _attrs, args, block] = sexp;
     let { referrer } = builder;

--- a/packages/@glimmer/opcode-compiler/lib/syntax.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax.ts
@@ -108,7 +108,15 @@ export function statementCompiler(): Compilers<WireFormat.Statement> {
     let [, definition, attrs, args, template] = sexp;
 
     let block = builder.template(template);
-    builder.dynamicComponent(definition, null, args, false, block, null);
+    let attrsBlock =
+      attrs.length > 0
+        ? builder.inlineBlock({
+            statements: attrs,
+            parameters: EMPTY_ARRAY,
+          })
+        : null;
+
+    builder.dynamicComponent(definition, attrsBlock, null, args, false, block, null);
   });
 
   STATEMENTS.add(Ops.Component, (sexp: S.Component, builder) => {
@@ -734,7 +742,7 @@ export function populateBuiltins(
     }
 
     let [definition, ...params] = _params!;
-    builder.dynamicComponent(definition, params, hash, true, template, inverse);
+    builder.dynamicComponent(definition, null, params, hash, true, template, inverse);
   });
 
   inlines.add('component', (_name, _params, hash, builder) => {
@@ -750,7 +758,7 @@ export function populateBuiltins(
     }
 
     let [definition, ...params] = _params!;
-    builder.dynamicComponent(definition, params, hash, true, null, null);
+    builder.dynamicComponent(definition, null, params, hash, true, null, null);
 
     return true;
   });

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -52,6 +52,7 @@ export class WrappedBuilder<Locator> implements CompilableProgram {
     //        PutValue(TagExpr)
     //        Test
     //        JumpUnless(BODY)
+    //        PutComponentOperations
     //        OpenDynamicPrimitiveElement
     //        DidCreateElement
     //        ...attr statements...

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -113,10 +113,16 @@ export abstract class HandlebarsNodeVisitors extends Parser {
 
     switch (tokenizer.state) {
       // Tag helpers
+      case TokenizerState.tagOpen:
       case TokenizerState.tagName:
-        addElementModifier(this.currentStartTag, mustache);
-        tokenizer.transitionTo(TokenizerState.beforeAttributeName);
-        break;
+        throw new SyntaxError(
+          `Cannot use mustaches in an elements tagname: \`${this.sourceForNode(
+            rawMustache,
+            rawMustache.path
+          )}\` at L${loc.start.line}:C${loc.start.column}`,
+          mustache.loc
+        );
+
       case TokenizerState.beforeAttributeName:
         addElementModifier(this.currentStartTag, mustache);
         break;

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -248,11 +248,6 @@ test('Element modifiers', function() {
   );
 });
 
-test('Tokenizer: MustacheStatement encountered in tagName state', function() {
-  let t = '<input{{bar}}>';
-  astEqual(t, b.program([b.element('input', [], [b.elementModifier(b.path('bar'))])]));
-});
-
 test('Tokenizer: MustacheStatement encountered in beforeAttributeName state', function() {
   let t = '<input {{bar}}>';
   astEqual(t, b.program([b.element('input', [], [b.elementModifier(b.path('bar'))])]));
@@ -480,4 +475,14 @@ test('Handlebars decorator block should error', function(assert) {
   assert.throws(() => {
     parse('{{#* foo}}{{/foo}}');
   }, new Error(`Handlebars decorator blocks are not supported: "{{#* foo" at L1:C0`));
+});
+
+test('disallowed mustaches in the tagName space', function(assert) {
+  assert.throws(() => {
+    parse('<{{"asdf"}}></{{"asdf"}}>');
+  }, /Cannot use mustaches in an elements tagname: `{{"asdf"` at L1:C1/);
+
+  assert.throws(() => {
+    parse('<input{{bar}}>');
+  }, /Cannot use mustaches in an elements tagname: `{{bar` at L1:C6/);
 });

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -168,7 +168,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (named arg) via angle brackets'() {
+  'invoking dynamic component (named arg) via angle brackets'() {
     this.registerComponent('Glimmer', 'Foo', 'hello world!');
     this.render({
       layout: '<@foo />',
@@ -184,7 +184,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (named arg) via angle brackets supports attributes'() {
+  'invoking dynamic component (named arg) via angle brackets supports attributes'() {
     this.registerComponent('Glimmer', 'Foo', '<div ...attributes>hello world!</div>');
     this.render({
       layout: '<@foo data-test="foo"/>',
@@ -200,7 +200,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (named arg) via angle brackets supports args'() {
+  'invoking dynamic component (named arg) via angle brackets supports args'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{@name}}!');
     this.render({
       layout: '<@foo @name="world" />',
@@ -216,7 +216,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (named arg) via angle brackets supports passing a block'() {
+  'invoking dynamic component (named arg) via angle brackets supports passing a block'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{yield}}!');
     this.render({
       layout: '<@foo>world</@foo>',
@@ -232,7 +232,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (named arg) via angle brackets supports args and attributes'() {
+  'invoking dynamic component (named arg) via angle brackets supports args and attributes'() {
     let instance: Foo;
     class Foo extends EmberishGlimmerComponent {
       public localProperty: string;
@@ -289,7 +289,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (local) via angle brackets'() {
+  'invoking dynamic component (local) via angle brackets'() {
     this.registerComponent('Glimmer', 'Foo', 'hello world!');
     this.render(`{{#with (component 'Foo') as |Other|}}<Other />{{/with}}`);
 
@@ -300,7 +300,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (local) via angle brackets (ill-advised "htmlish element name" but supported)'() {
+  'invoking dynamic component (local) via angle brackets (ill-advised "htmlish element name" but supported)'() {
     this.registerComponent('Glimmer', 'Foo', 'hello world!');
     this.render(`{{#with (component 'Foo') as |div|}}<div />{{/with}}`);
 
@@ -311,7 +311,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (local) via angle brackets supports attributes'() {
+  'invoking dynamic component (local) via angle brackets supports attributes'() {
     this.registerComponent('Glimmer', 'Foo', '<div ...attributes>hello world!</div>');
     this.render(`{{#with (component 'Foo') as |Other|}}<Other data-test="foo" />{{/with}}`);
 
@@ -322,7 +322,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (local) via angle brackets supports args'() {
+  'invoking dynamic component (local) via angle brackets supports args'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{@name}}!');
     this.render(`{{#with (component 'Foo') as |Other|}}<Other @name="world" />{{/with}}`);
 
@@ -333,7 +333,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (local) via angle brackets supports passing a block'() {
+  'invoking dynamic component (local) via angle brackets supports passing a block'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{yield}}!');
     this.render(`{{#with (component 'Foo') as |Other|}}<Other>world</Other>{{/with}}`);
 
@@ -344,7 +344,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (local) via angle brackets supports args, attributes, and blocks'() {
+  'invoking dynamic component (local) via angle brackets supports args, attributes, and blocks'() {
     let instance: Foo;
     class Foo extends EmberishGlimmerComponent {
       public localProperty: string;
@@ -394,7 +394,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (path) via angle brackets'() {
+  'invoking dynamic component (path) via angle brackets'() {
     class TestHarness extends EmberishGlimmerComponent {
       public Foo: any;
 
@@ -415,7 +415,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (path) via angle brackets supports attributes'() {
+  'invoking dynamic component (path) via angle brackets supports attributes'() {
     class TestHarness extends EmberishGlimmerComponent {
       public Foo: any;
 
@@ -435,7 +435,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (path) via angle brackets supports args'() {
+  'invoking dynamic component (path) via angle brackets supports args'() {
     class TestHarness extends EmberishGlimmerComponent {
       public Foo: any;
 
@@ -455,7 +455,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (path) via angle brackets supports passing a block'() {
+  'invoking dynamic component (path) via angle brackets supports passing a block'() {
     class TestHarness extends EmberishGlimmerComponent {
       public Foo: any;
 
@@ -475,7 +475,7 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (path) via angle brackets supports args, attributes, and blocks'() {
+  'invoking dynamic component (path) via angle brackets supports args, attributes, and blocks'() {
     let instance: Foo;
     class TestHarness extends EmberishGlimmerComponent {
       public Foo: any;

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -216,6 +216,22 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
+  'rwjblue invoking dynamic component (named arg) via angle brackets supports passing a block'() {
+    this.registerComponent('Glimmer', 'Foo', 'hello {{yield}}!');
+    this.render({
+      layout: '<@foo>world</@foo>',
+      args: {
+        foo: 'component "Foo"',
+      },
+    });
+
+    this.assertHTML(`<div>hello world!</div>`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
   'rwjblue invoking dynamic component (named arg) via angle brackets supports args and attributes'() {
     let instance: Foo;
     class Foo extends EmberishGlimmerComponent {
@@ -317,7 +333,18 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
-  'rwjblue invoking dynamic component (local) via angle brackets supports args and attributes'() {
+  'rwjblue invoking dynamic component (local) via angle brackets supports passing a block'() {
+    this.registerComponent('Glimmer', 'Foo', 'hello {{yield}}!');
+    this.render(`{{#with (component 'Foo') as |Other|}}<Other>world</Other>{{/with}}`);
+
+    this.assertHTML(`hello world!`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (local) via angle brackets supports args, attributes, and blocks'() {
     let instance: Foo;
     class Foo extends EmberishGlimmerComponent {
       public localProperty: string;
@@ -331,28 +358,37 @@ export class BasicComponents extends RenderTest {
     this.registerComponent(
       'Glimmer',
       'Foo',
-      '<div ...attributes>[{{localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}]</div>',
+      '<div ...attributes>[{{localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}] - {{yield}}</div>',
       Foo
     );
     this.render(
-      `{{#with (component 'Foo') as |Other|}}<Other @staticNamedArg="static" data-test1={{outer}} data-test2="static" @dynamicNamedArg={{outer}} />{{/with}}`,
+      `{{#with (component 'Foo') as |Other|}}<Other @staticNamedArg="static" data-test1={{outer}} data-test2="static" @dynamicNamedArg={{outer}}>template</Other>{{/with}}`,
       { outer: 'outer' }
     );
 
-    this.assertHTML(`<div data-test1="outer" data-test2="static">[local static outer]</div>`);
+    this.assertHTML(
+      `<div data-test1="outer" data-test2="static">[local static outer] - template</div>`
+    );
     this.assertStableRerender();
 
     this.rerender({ outer: 'OUTER' });
-    this.assertHTML(`<div data-test1="OUTER" data-test2="static">[local static OUTER]</div>`);
+    this.assertHTML(
+      `<div data-test1="OUTER" data-test2="static">[local static OUTER] - template</div>`
+    );
 
     instance!.localProperty = 'LOCAL';
     instance!.recompute();
     this.rerender();
-    this.assertHTML(`<div data-test1="OUTER" data-test2="static">[LOCAL static OUTER]</div>`);
+    this.assertHTML(
+      `<div data-test1="OUTER" data-test2="static">[LOCAL static OUTER] - template</div>`
+    );
 
     instance!.localProperty = 'local';
     instance!.recompute();
     this.rerender({ outer: 'outer' });
-    this.assertHTML(`<div data-test1="outer" data-test2="static">[local static outer]</div>`);
+    this.assertHTML(
+      `<div data-test1="outer" data-test2="static">[local static outer] - template</div>`
+    );
+  }
   }
 }

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -166,7 +166,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (named arg) via angle brackets'() {
     this.registerComponent('Glimmer', 'Foo', 'hello world!');
@@ -182,7 +182,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (named arg) via angle brackets supports attributes'() {
     this.registerComponent('Glimmer', 'Foo', '<div ...attributes>hello world!</div>');
@@ -198,7 +198,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (named arg) via angle brackets supports args'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{@name}}!');
@@ -214,7 +214,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (named arg) via angle brackets supports passing a block'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{yield}}!');
@@ -230,7 +230,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (named arg) via angle brackets supports args and attributes'() {
     let instance: Foo;
@@ -287,7 +287,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (local) via angle brackets'() {
     this.registerComponent('Glimmer', 'Foo', 'hello world!');
@@ -298,7 +298,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (local) via angle brackets (ill-advised "htmlish element name" but supported)'() {
     this.registerComponent('Glimmer', 'Foo', 'hello world!');
@@ -309,7 +309,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (local) via angle brackets supports attributes'() {
     this.registerComponent('Glimmer', 'Foo', '<div ...attributes>hello world!</div>');
@@ -320,7 +320,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (local) via angle brackets supports args'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{@name}}!');
@@ -331,7 +331,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (local) via angle brackets supports passing a block'() {
     this.registerComponent('Glimmer', 'Foo', 'hello {{yield}}!');
@@ -342,7 +342,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (local) via angle brackets supports args, attributes, and blocks'() {
     let instance: Foo;
@@ -392,7 +392,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (path) via angle brackets'() {
     class TestHarness extends EmberishGlimmerComponent {
@@ -413,7 +413,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (path) via angle brackets supports attributes'() {
     class TestHarness extends EmberishGlimmerComponent {
@@ -433,7 +433,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (path) via angle brackets supports args'() {
     class TestHarness extends EmberishGlimmerComponent {
@@ -453,7 +453,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (path) via angle brackets supports passing a block'() {
     class TestHarness extends EmberishGlimmerComponent {
@@ -473,7 +473,7 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'glimmer',
   })
   'invoking dynamic component (path) via angle brackets supports args, attributes, and blocks'() {
     let instance: Foo;

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -532,4 +532,14 @@ export class BasicComponents extends RenderTest {
       `<div data-test1="outer" data-test2="static">[local static outer] - template</div>`
     );
   }
+
+  @test({ kind: 'glimmer' })
+  'angle bracket invocation can pass forward ...attributes to a nested component'() {
+    this.registerComponent('Glimmer', 'Qux', '<div data-from-qux ...attributes></div>');
+    this.registerComponent('Glimmer', 'Bar', '<Qux data-from-bar ...attributes />');
+    this.registerComponent('Glimmer', 'Foo', '<Bar data-from-foo ...attributes />');
+
+    this.render('<Foo data-from-top />');
+    this.assertHTML('<div data-from-qux data-from-bar data-from-foo data-from-top></div>');
+  }
 }

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -390,5 +390,146 @@ export class BasicComponents extends RenderTest {
       `<div data-test1="outer" data-test2="static">[local static outer] - template</div>`
     );
   }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (path) via angle brackets'() {
+    class TestHarness extends EmberishGlimmerComponent {
+      public Foo: any;
+
+      constructor(args: any) {
+        super();
+        this.Foo = args.attrs.Foo;
+      }
+    }
+    this.registerComponent('Glimmer', 'TestHarness', '<this.Foo />', TestHarness);
+    this.registerComponent('Glimmer', 'Foo', 'hello world!');
+
+    this.render('<TestHarness @Foo={{component "Foo"}} />');
+
+    this.assertHTML(`hello world!`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (path) via angle brackets supports attributes'() {
+    class TestHarness extends EmberishGlimmerComponent {
+      public Foo: any;
+
+      constructor(args: any) {
+        super();
+        this.Foo = args.attrs.Foo;
+      }
+    }
+    this.registerComponent('Glimmer', 'TestHarness', '<this.Foo data-test="foo"/>', TestHarness);
+    this.registerComponent('Glimmer', 'Foo', '<div ...attributes>hello world!</div>');
+    this.render('<TestHarness @Foo={{component "Foo"}} />');
+
+    this.assertHTML(`<div data-test="foo">hello world!</div>`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (path) via angle brackets supports args'() {
+    class TestHarness extends EmberishGlimmerComponent {
+      public Foo: any;
+
+      constructor(args: any) {
+        super();
+        this.Foo = args.attrs.Foo;
+      }
+    }
+    this.registerComponent('Glimmer', 'TestHarness', '<this.Foo @name="world"/>', TestHarness);
+    this.registerComponent('Glimmer', 'Foo', 'hello {{@name}}!');
+    this.render('<TestHarness @Foo={{component "Foo"}} />');
+
+    this.assertHTML(`hello world!`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (path) via angle brackets supports passing a block'() {
+    class TestHarness extends EmberishGlimmerComponent {
+      public Foo: any;
+
+      constructor(args: any) {
+        super();
+        this.Foo = args.attrs.Foo;
+      }
+    }
+    this.registerComponent('Glimmer', 'TestHarness', '<this.Foo>world</this.Foo>', TestHarness);
+    this.registerComponent('Glimmer', 'Foo', 'hello {{yield}}!');
+    this.render('<TestHarness @Foo={{component "Foo"}} />');
+
+    this.assertHTML(`hello world!`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (path) via angle brackets supports args, attributes, and blocks'() {
+    let instance: Foo;
+    class TestHarness extends EmberishGlimmerComponent {
+      public Foo: any;
+
+      constructor(args: any) {
+        super();
+        this.Foo = args.attrs.Foo;
+      }
+    }
+    class Foo extends EmberishGlimmerComponent {
+      public localProperty: string;
+
+      constructor() {
+        super();
+        instance = this;
+        this.localProperty = 'local';
+      }
+    }
+    this.registerComponent(
+      'Glimmer',
+      'TestHarness',
+      '<this.Foo @staticNamedArg="static" data-test1={{@outer}} data-test2="static" @dynamicNamedArg={{@outer}}>template</this.Foo>',
+      TestHarness
+    );
+    this.registerComponent(
+      'Glimmer',
+      'Foo',
+      '<div ...attributes>[{{localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}] - {{yield}}</div>',
+      Foo
+    );
+    this.render('<TestHarness @outer={{outer}} @Foo={{component "Foo"}} />', { outer: 'outer' });
+
+    this.assertHTML(
+      `<div data-test1="outer" data-test2="static">[local static outer] - template</div>`
+    );
+    this.assertStableRerender();
+
+    this.rerender({ outer: 'OUTER' });
+    this.assertHTML(
+      `<div data-test1="OUTER" data-test2="static">[local static OUTER] - template</div>`
+    );
+
+    instance!.localProperty = 'LOCAL';
+    instance!.recompute();
+    this.rerender();
+    this.assertHTML(
+      `<div data-test1="OUTER" data-test2="static">[LOCAL static OUTER] - template</div>`
+    );
+
+    instance!.localProperty = 'local';
+    instance!.recompute();
+    this.rerender({ outer: 'outer' });
+    this.assertHTML(
+      `<div data-test1="outer" data-test2="static">[local static outer] - template</div>`
+    );
   }
 }

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -163,4 +163,96 @@ export class BasicComponents extends RenderTest {
     this.assertHTML("<div color='red'>left - hello! yield me</div>");
     this.assertStableNodes();
   }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (named arg) via angle brackets'() {
+    this.registerComponent('Glimmer', 'Foo', 'hello world!');
+    this.render({
+      layout: '<@foo />',
+      args: {
+        foo: 'component "Foo"',
+      },
+    });
+
+    this.assertHTML(`<div>hello world!</div>`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (named arg) via angle brackets supports attributes'() {
+    this.registerComponent('Glimmer', 'Foo', '<div ...attributes>hello world!</div>');
+    this.render({
+      layout: '<@foo data-test="foo"/>',
+      args: {
+        foo: 'component "Foo"',
+      },
+    });
+
+    this.assertHTML(`<div><div data-test="foo">hello world!</div></div>`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (named arg) via angle brackets supports args'() {
+    this.registerComponent('Glimmer', 'Foo', 'hello {{@name}}!');
+    this.render({
+      layout: '<@foo @name="world" />',
+      args: {
+        foo: 'component "Foo"',
+      },
+    });
+
+    this.assertHTML(`<div>hello world!</div>`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (local) via angle brackets'() {
+    this.registerComponent('Glimmer', 'Foo', 'hello world!');
+    this.render(`{{#with (component 'Foo') as |Other|}}<Other />{{/with}}`);
+
+    this.assertHTML(`hello world!`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (local) via angle brackets (ill-advised "htmlish element name" but supported)'() {
+    this.registerComponent('Glimmer', 'Foo', 'hello world!');
+    this.render(`{{#with (component 'Foo') as |div|}}<div />{{/with}}`);
+
+    this.assertHTML(`hello world!`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (local) via angle brackets supports attributes'() {
+    this.registerComponent('Glimmer', 'Foo', '<div ...attributes>hello world!</div>');
+    this.render(`{{#with (component 'Foo') as |Other|}}<Other data-test="foo" />{{/with}}`);
+
+    this.assertHTML(`<div data-test="foo">hello world!</div>`);
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
+  'rwjblue invoking dynamic component (local) via angle brackets supports args'() {
+    this.registerComponent('Glimmer', 'Foo', 'hello {{@name}}!');
+    this.render(`{{#with (component 'Foo') as |Other|}}<Other @name="world" />{{/with}}`);
+
+    this.assertHTML(`hello world!`);
+    this.assertStableRerender();
+  }
 }

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -221,6 +221,7 @@ export type TemplateJavascript = string;
 // Statements
 export const isModifier = is<Statements.Modifier>(Opcodes.Modifier);
 export const isFlushElement = is<Statements.FlushElement>(Opcodes.FlushElement);
+export const isAttrSplat = is<Statements.AttrSplat>(Opcodes.AttrSplat);
 
 export function isAttribute(val: Statement): val is Statements.Attribute {
   return (

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -45,7 +45,6 @@ export namespace Expressions {
   export type MaybeLocal = [Opcodes.MaybeLocal, Path];
 
   export type Value = str | number | boolean | null;
-
   export type HasBlock = [Opcodes.HasBlock, YieldTo];
   export type HasBlockParams = [Opcodes.HasBlockParams, YieldTo];
   export type Undefined = [Opcodes.Undefined];
@@ -106,6 +105,13 @@ export namespace Statements {
     Hash,
     Option<SerializedInlineBlock>
   ];
+  export type DynamicComponent = [
+    Opcodes.DynamicComponent,
+    Expression,
+    Attribute[],
+    Hash,
+    Option<SerializedInlineBlock>
+  ];
   export type OpenElement = [Opcodes.OpenElement, str];
   export type SplatElement = [Opcodes.OpenSplattedElement, str];
   export type FlushElement = [Opcodes.FlushElement];
@@ -130,6 +136,7 @@ export namespace Statements {
     | Modifier
     | Block
     | Component
+    | DynamicComponent
     | OpenElement
     | SplatElement
     | FlushElement

--- a/packages/@glimmer/wire-format/lib/opcodes.ts
+++ b/packages/@glimmer/wire-format/lib/opcodes.ts
@@ -6,6 +6,7 @@ export enum Opcodes {
   Modifier,
   Block,
   Component,
+  DynamicComponent,
   OpenElement,
   OpenSplattedElement,
   FlushElement,


### PR DESCRIPTION
This supports the following dynamic angle bracket invocations:

* Invoking a local (block param):

```
{{#with (component 'special-sauce') as |OtherThing|}}
  <OtherThing data-foo={{thingsHere}} @namedStuff="goes here" />
{{/with}}
```

* Invoking a named argument:

```
<@someThing data-foo="wheeeeee" />
```

* Invoking a path expression:

```
<this.thing.here />
```

All forms support a template, named arguments, and attributes.


---

Significant changes (implementation wise):

* Move Component detection from JavascriptCompiler to TemplateCompiler (required to support emitting different opcodes for dynamic invocation vs static invocation).
* Add `openComponent`, `closeDynamicComponent`, and `closeComponent` template compiler opcodes.
* Add `DynamicComponent` wire-format opcode. During runtime opcode building the `DynamicComponent` opcode invokes `builder.dynamicComponent` (very similarly to `{{component`).
* Add support for `AttrSplat` nodes passed during component invocation (was previously disabled due to implementation details around `openElement` and `openSplattedElement` which were simplified in this PR).
* Add support for an `AttrBlock` to `Builder.prototype.dynamicComponent`.
* Add error when using `{{` in the `TokenizerStates.tagOpen` or `TokenizerState.tagName` states.
* Add tests for various combinations of invocation source (path, local, named arg) and invocation capabilities (passing args, attributes, template).

---

TODO:

- [x] Add tests for using paths `<this.foo />`
- [x] Add tests for using blocks with all three dynamic types
- [x] Remove `rwjblue` prefix from tests added
- [x] Add tests for a component with `...attributes` on another component invocation
- [x] Add template compilation error for things like `<{{"asdf"}}></{{"asdf"}}>`
- [x] Add tests confirming `<foo/bar></foo/bar>` and `<Foo/Bar></Foo/Bar>` does not work
- [x] ~~Update `ElementNode`'s `tag` property to be a new type: `Identifier` (roughly similar to path expression)~~ moving to another PR...

Related to https://github.com/emberjs/ember.js/issues/16688.