### PR TITLE
Add implicit ...attributes to wrapped layouts.

### DIFF
--- a/packages/@glimmer/vm/lib/opcodes.ts
+++ b/packages/@glimmer/vm/lib/opcodes.ts
@@ -997,7 +997,7 @@ export const enum Op {
   GetComponentSelf,
 
   /**
-   * Operation: Push the component's `self` onto the stack.
+   * Operation: Push the component's `tagName` onto the stack.
    *
    * Format:
    *   (GetComponentTagName state:register)


### PR DESCRIPTION
This implements the implicit `...attributes` support for wrapped layouts (which is what `Ember.Component` uses) as specified in the [Angle Bracket Invocation RFC](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#html-attributes):

> Classic components (Ember.Component) will implicitly have an ...attributes added to the end of the wrapper element (if tagName is not an empty string), after any attributes added by the component itself (using attributeBindings, classNames etc). This means that attributes provided by the caller will override (replace) those added by the component (except for class, which is merged).


TODO:

- [x] add tests confirming merging behaviors (invocation attributes clobber, except `class` which merges)