### PR TITLE
[BUGFIX] AST Builder and Printer Fixes

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -35,6 +35,10 @@ export default function build(ast: HBS.Node): string {
         output.push(' ', buildEach(ast.comments).join(' '));
       }
 
+      if (ast.blockParams.length) {
+        output.push(' ', 'as', ' ', `|${ast.blockParams.join(' ')}|`);
+      }
+
       if (voidMap[ast.tag]) {
         if (ast.selfClosing) {
           output.push(' /');
@@ -48,11 +52,16 @@ export default function build(ast: HBS.Node): string {
       }
       break;
     case 'AttrNode':
-      output.push(ast.name, '=');
       const value = build(ast.value);
       if (ast.value.type === 'TextNode') {
-        output.push('"', value, '"');
+        if (ast.value.chars !== '') {
+          output.push(ast.name, '=');
+          output.push('"', value, '"');
+        } else {
+          output.push(ast.name);
+        }
       } else {
+        output.push(ast.name, '=');
         output.push(value);
       }
       break;

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -122,7 +122,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
   finishStartTag() {
     let { name, attributes, modifiers, comments, selfClosing } = this.currentStartTag;
     let loc = b.loc(this.tagOpenLine, this.tagOpenColumn);
-    let element = b.element({ name, selfClosing }, attributes, modifiers, [], comments, loc);
+    let element = b.element({ name, selfClosing }, attributes, modifiers, [], comments, [], loc);
     this.elementStack.push(element);
   }
 

--- a/packages/@glimmer/syntax/test/builders-test.ts
+++ b/packages/@glimmer/syntax/test/builders-test.ts
@@ -5,7 +5,7 @@ QUnit.module('[glimmer-syntax] AST Builders');
 
 QUnit.test('element uses comments as loc when comments is not an array', function() {
   let actual = b.element('div', [], [], [], b.loc(1, 1, 1, 1));
-  let expected = b.element('div', [], [], [], [], b.loc(1, 1, 1, 1));
+  let expected = b.element('div', [], [], [], [], [], b.loc(1, 1, 1, 1));
 
   astEqual(actual, expected);
 });

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -116,3 +116,11 @@ test('Void elements', function() {
 test('Void elements self closing', function() {
   printEqual('<br />');
 });
+
+test('Block params', function() {
+  printEqual('<Foo as |bar|>{{bar}}</Foo>');
+});
+
+test('Attributes without value', function() {
+  printEqual('<input disabled />');
+});


### PR DESCRIPTION
This fixes 2 issues:

- `builders.element` now allows you to emit block params
- attributes no longer get normalized into an empty string if they do not have a value

These changes should be backwards compatible.