### PR TITLE
Allow angle invoked names to be customized during compilation.

### DIFF
--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -69,7 +69,7 @@ export function precompile(
 ): TemplateJavascript {
   let ast = preprocess(string, options);
   let { meta } = options;
-  let { block } = TemplateCompiler.compile(ast);
+  let { block } = TemplateCompiler.compile(ast, options);
   let idFn = options.id || defaultId;
   let blockJSON = JSON.stringify(block.toJSON());
   let templateJSONObject: SerializedTemplateWithLazyBlock<TemplateMeta> = {

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -9,6 +9,7 @@ import { PathHead } from './compiler-ops';
 
 export interface CompileOptions {
   meta: Opaque;
+  customizeComponentName?(tag: string): string;
 }
 
 function isTrustedValue(value: any) {
@@ -18,7 +19,7 @@ function isTrustedValue(value: any) {
 export const THIS = 0;
 
 export default class TemplateCompiler {
-  static compile(ast: AST.Program): Template {
+  static compile(ast: AST.Program, options?: CompileOptions): Template {
     let templateVisitor = new TemplateVisitor();
     templateVisitor.visit(ast);
 
@@ -26,7 +27,7 @@ export default class TemplateCompiler {
     let opcodes: SymbolInOp[] = compiler.process(templateVisitor.actions);
     let symbols: SymbolOutOp[] = new SymbolAllocator(opcodes).process();
 
-    return JavaScriptCompiler.process(symbols, ast['symbols']);
+    return JavaScriptCompiler.process(symbols, ast['symbols'], options);
   }
 
   private templateId = 0;

--- a/packages/@glimmer/compiler/test/compile-options-test.ts
+++ b/packages/@glimmer/compiler/test/compile-options-test.ts
@@ -36,3 +36,23 @@ QUnit.test('returned meta is correct', assert => {
   assert.equal(wire.meta.moduleName, 'my/module-name', 'Template has correct meta');
   assert.equal(wire.meta.metaIsOpaque, 'yes', 'Template has correct meta');
 });
+
+QUnit.test('customizeComponentName is used if present', function(assert) {
+  let wire = JSON.parse(
+    precompile('<XFoo />', {
+      meta: {
+        moduleName: 'my/module-name',
+        metaIsOpaque: 'yes',
+      },
+      customizeComponentName(input: string) {
+        return input
+          .split('')
+          .reverse()
+          .join('');
+      },
+    })
+  );
+
+  let [componentInvocation] = JSON.parse(wire.block).statements;
+  assert.equal(componentInvocation[1], 'ooFX', 'customized component name was used');
+});

--- a/packages/@glimmer/test-helpers/lib/environment/components/tagless.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/tagless.ts
@@ -31,7 +31,7 @@ export class StaticTaglessComponentManager extends BasicComponentManager {
     let handle = resolver.lookup('template-source', name)!;
 
     return resolver.compileTemplate(handle, name, (source, options) => {
-      let template = createTemplate(source, {});
+      let template = createTemplate(source);
       let layout = template.create(options).asLayout();
 
       return {

--- a/packages/@glimmer/test-helpers/lib/environment/shared.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/shared.ts
@@ -1,14 +1,17 @@
 import { Dict, Option, Opaque } from '@glimmer/interfaces';
 import { SerializedTemplateWithLazyBlock } from '@glimmer/wire-format';
-import { precompile } from '@glimmer/compiler';
+import { precompile, PrecompileOptions } from '@glimmer/compiler';
 import { templateFactory, TemplateFactory } from '@glimmer/opcode-compiler';
 
 export type Attrs = Dict<any>;
 export type AttrsDiff = { oldAttrs: Option<Attrs>; newAttrs: Attrs };
 
-export function createTemplate<T = Opaque>(templateSource: string, meta?: T): TemplateFactory<T> {
-  let wrapper: SerializedTemplateWithLazyBlock<T> = JSON.parse(
-    precompile(templateSource, { meta })
+export function createTemplate(
+  templateSource: string,
+  options?: PrecompileOptions
+): TemplateFactory<Opaque> {
+  let wrapper: SerializedTemplateWithLazyBlock<Opaque> = JSON.parse(
+    precompile(templateSource, options)
   );
-  return templateFactory<T>(wrapper);
+  return templateFactory<Opaque>(wrapper);
 }


### PR DESCRIPTION
This change allows the caller of `precompile` to customize the component name to be used. The specific purpose of this is to allow Ember to customize `<JsonViewer />` into looking for `json-viewer` while still allowing Glimmer.js apps to use `JsonViewer` on the filesystem.