### PR TITLE
Fixup issues with dynamic angle bracket invocation.

### DIFF
--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -464,19 +464,21 @@ function isArg(path: AST.PathExpression): boolean {
 function isDynamicComponent(element: AST.ElementNode): boolean {
   let open = element.tag.charAt(0);
 
+  let [maybeLocal] = element.tag.split('.');
   let isNamedArgument = open === '@';
-  let isLocal = element['symbols'].has(element.tag);
-  let isPath = element.tag.indexOf('.') > -1;
+  let isLocal = element['symbols'].has(maybeLocal);
+  let isThisPath = element.tag.indexOf('this.') === 0;
 
-  return isLocal || isNamedArgument || isPath;
+  return isLocal || isNamedArgument || isThisPath;
 }
 
 function isComponent(element: AST.ElementNode): boolean {
   let open = element.tag.charAt(0);
+  let isPath = element.tag.indexOf('.') > -1;
 
   let isUpperCase = open === open.toUpperCase() && open !== open.toLowerCase();
 
-  return isUpperCase || isDynamicComponent(element);
+  return (isUpperCase && !isPath) || isDynamicComponent(element);
 }
 
 function assertIsSimplePath(path: AST.PathExpression, loc: AST.SourceLocation, context: string) {


### PR DESCRIPTION
This fixes two different issues identified with dynamic invocation via angle brackets:

* The Angle Bracket Invocation RFC specifically forbids implicit `this` lookups from being considered. Prior to the changes here `<foo.bar />` would have worked the same as `<this.foo.bar />`. These changes bring the implementation in line with the RFC. Related to https://github.com/emberjs/ember.js/issues/16712.
* The prior implementation did not support using a path off of a local, these changes fix that.