### PR TITLE
Fix issue with unquoted attribute followed by self closing tag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-plugin-debug-macros": "^0.1.11",
     "handlebars": "^4.0.6",
     "simple-dom": "^0.3.0",
-    "simple-html-tokenizer": "^0.5.3"
+    "simple-html-tokenizer": "^0.5.5"
   },
   "devDependencies": {
     "@glimmer/build": "^0.8.2",

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -84,7 +84,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
   MustacheStatement(rawMustache: HandlebarsAST.MustacheStatement) {
     let { tokenizer } = this;
 
-    if (tokenizer['state'] === 'comment') {
+    if (tokenizer.state === 'comment') {
       this.appendToCommentData(this.sourceForNode(rawMustache));
       return;
     }

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -115,10 +115,10 @@ test('Handlebars embedded in an attribute (unquoted)', function() {
 
 test('Handlebars embedded in an attribute of a self-closing tag (unqouted)', function() {
   let t = '<input value={{foo}}/>';
-  astEqual(
-    t,
-    b.program([b.element('input', [b.attr('value', b.mustache(b.path('foo')))], [], [])])
-  );
+
+  let element = b.element('input', [b.attr('value', b.mustache(b.path('foo')))], [], []);
+  element.selfClosing = true;
+  astEqual(t, b.program([element]));
 });
 
 test('Handlebars embedded in an attribute (sexprs)', function() {
@@ -485,4 +485,11 @@ test('disallowed mustaches in the tagName space', function(assert) {
   assert.throws(() => {
     parse('<input{{bar}}>');
   }, /Cannot use mustaches in an elements tagname: `{{bar` at L1:C6/);
+});
+
+test('mustache immediately followed by self closing tag does not error', function() {
+  let ast = parse('<FooBar data-foo={{blah}}/>');
+  let element = b.element('FooBar', [b.attr('data-foo', b.mustache('blah'))]);
+  element.selfClosing = true;
+  astEqual(ast, b.program([element]));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6801,9 +6801,9 @@ simple-fmt@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-fmt/-/simple-fmt-0.1.0.tgz#191bf566a59e6530482cb25ab53b4a8dc85c3a6b"
 
-simple-html-tokenizer@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.3.tgz#c1c246a53ccf1cd65fb2fa970967145b47602ce4"
+simple-html-tokenizer@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.5.tgz#110e63f2fe095e1f21f2f07e8c259a5ab6d6bebb"
 
 simple-is@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Previously:

```html
<FooBar data-foo=unquotedThing/>
```

This would error (as the self closing flag was not detected by the `afterAttributeUnquoted` state in simple-html-tokenizer).


Fixes https://github.com/glimmerjs/glimmer-vm/issues/829