### PR TITLE
Throw a compilation error for path expressions with a trailing `.`.

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -285,6 +285,12 @@ export abstract class HandlebarsNodeVisitors extends Parser {
         );
       }
       parts = [path.parts.join('/')];
+    } else if (original === '.') {
+      let locationInfo = `L${loc.start.line}:C${loc.start.column}`;
+      throw new SyntaxError(
+        `'.' is not a supported path in Glimmer; check for a path with a trailing '.' at ${locationInfo}.`,
+        path.loc
+      );
     } else {
       parts = path.parts;
     }

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -493,3 +493,9 @@ test('mustache immediately followed by self closing tag does not error', functio
   element.selfClosing = true;
   astEqual(ast, b.program([element]));
 });
+
+test('path expression with "dangling dot" throws error', function(assert) {
+  assert.throws(() => {
+    parse('{{if foo. bar baz}}');
+  }, /'\.' is not a supported path in Glimmer; check for a path with a trailing '\.' at L1:C8/);
+});


### PR DESCRIPTION
In prior versions of glimmer-vm the following:

```hbs
{{#if somePath.}}
  Stuff!!
{{/if}}
```

Would actually be treated like:

```hbs
{{#if somePath this}}
  Stuff!!
{{/if}}
```

This is due to how Handlebars internally parses `somePath.` (it sees two path expressions, one for `somePath` and another for `.`).

In more recent versions of glimmer-vm we have began to throw an error in later parts of the compilation pipeline (the `SymbolAllocator`) because it is only able to process `PathExpressions` that have `this` set or have contents in `parts`.

This change adds a much more helpful error.