### PR TITLE
[BUGFIX] Make sure escaping is handled correctly in printer.

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/util.ts
+++ b/packages/@glimmer/syntax/lib/generation/util.ts
@@ -1,0 +1,55 @@
+const enum Char {
+  NBSP = 0xa0,
+  QUOT = 0x22,
+  LT = 0x3c,
+  GT = 0x3e,
+  AMP = 0x26,
+}
+
+const ATTR_VALUE_REGEX_TEST = /[\xA0"&]/;
+const ATTR_VALUE_REGEX_REPLACE = new RegExp(ATTR_VALUE_REGEX_TEST.source, 'g');
+
+const TEXT_REGEX_TEST = /[\xA0&<>]/;
+const TEXT_REGEX_REPLACE = new RegExp(TEXT_REGEX_TEST.source, 'g');
+
+function attrValueReplacer(char: string) {
+  switch (char.charCodeAt(0)) {
+    case Char.NBSP:
+      return '&nbsp;';
+    case Char.QUOT:
+      return '&quot;';
+    case Char.AMP:
+      return '&amp;';
+    default:
+      return char;
+  }
+}
+
+function textReplacer(char: string) {
+  switch (char.charCodeAt(0)) {
+    case Char.NBSP:
+      return '&nbsp;';
+    case Char.AMP:
+      return '&amp;';
+    case Char.LT:
+      return '&lt;';
+    case Char.GT:
+      return '&gt;';
+    default:
+      return char;
+  }
+}
+
+export function escapeAttrValue(attrValue: string) {
+  if (ATTR_VALUE_REGEX_TEST.test(attrValue)) {
+    return attrValue.replace(ATTR_VALUE_REGEX_REPLACE, attrValueReplacer);
+  }
+  return attrValue;
+}
+
+export function escapeText(text: string) {
+  if (TEXT_REGEX_TEST.test(text)) {
+    return text.replace(TEXT_REGEX_REPLACE, textReplacer);
+  }
+  return text;
+}

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -24,6 +24,14 @@ test('ElementNode: attributes', function() {
   printEqual('<h1 class="foo" id="title"></h1>');
 });
 
+test('ElementNode: attributes escaping', function() {
+  printEqual('<h1 class="foo" id="title" data-a="&quot;Foo&nbsp;&amp;&nbsp;Bar&quot;"></h1>');
+});
+
+test('TextNode: chars escape', assert => {
+  assert.equal(printTransform('&lt; &amp; &nbsp; &gt; &copy;2018'), '&lt; &amp; &nbsp; &gt; ©2018');
+});
+
 test('TextNode: chars', function() {
   printEqual('<h1>Test</h1>');
 });
@@ -54,6 +62,10 @@ test('MustacheStatement: as element attribute with path', function() {
 
 test('ConcatStatement: in element attribute string', function() {
   printEqual('<h1 class="{{if active "active" "inactive"}} foo">Test</h1>');
+});
+
+test('ConcatStatement: in element attribute string escaping', function() {
+  printEqual('<h1 class="< &nbsp; {{if x "&" "<"}} &amp; &quot;">Test</h1>');
 });
 
 test('ElementModifierStatement', function() {


### PR DESCRIPTION
Use innerHTML rules:

* Text escapes `'&'`, `'<'`, `'>'`, and `'\u00A0'`.
* Attr value escapes `'&'`, `'"'`, and `'\u00A0'`