### PR TITLE
[BUGFIX] In ListRevalidationDelegate, allow empty string values for `before` argument 

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -215,7 +215,7 @@ class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     let nextSibling: Option<Simple.Node> = null;
     let reference: Option<BlockOpcode> = null;
 
-    if (before) {
+    if (typeof before === 'string') {
       reference = map[before];
       nextSibling = reference['bounds'].firstNode();
     } else {
@@ -247,7 +247,7 @@ class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     let entry = map[key];
     let reference = map[before] || null;
 
-    if (before) {
+    if (typeof before === 'string') {
       moveBounds(entry, reference.firstNode());
     } else {
       moveBounds(entry, this.marker);

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -2183,6 +2183,30 @@ module('[glimmer-runtime] Updating', hooks => {
     "<ul>{{#each list key='key' as |item|}}<li class='{{item.class}}'>{{item.name}}</li>{{/each}}</ul>"
   );
 
+  test('The each helper with empty string items', assert => {
+    let template = compile(
+      `<ul>{{#each list key='@identity' as |item|}}<li>{{item}}</li>{{/each}}</ul>`
+    );
+
+    let object = { list: [''] };
+    render(template, object);
+
+    let lastNode = root.querySelector('li:last-child');
+
+    equalTokens(root, '<ul><li></li></ul>', 'Initial render');
+
+    object = { list: ['first!', ''] };
+    rerender(object);
+
+    equalTokens(root, '<ul><li>first!</li><li></li></ul>', 'After prepending list item');
+
+    assert.strictEqual(
+      root.querySelector('li:last-child'),
+      lastNode,
+      'The last node has not changed after prepending to list'
+    );
+  });
+
   test('The each helper with inverse', assert => {
     let object = { list: [] as any[] };
     let template = compile(


### PR DESCRIPTION
The key generation for empty string list items is problematic. In ListRevalidationDelegate `insert()` and `move()` methods, this changes the `before` truthy check to allow empty strings, so its OpCode nextSibling is retrieved. Otherwise, when keyed by the default `@identity`, items are inserted unexpectedly at the end of list.

I think this might resolve https://github.com/emberjs/ember.js/issues/14814, particularly relevant to @krisselden's [call out](https://github.com/emberjs/ember.js/issues/14814#issuecomment-272309302)?

I'm not all that familiar with glimmer-vm, so I might be way off with this fix. 🙂