### PR TITLE
Introduce ModifierDefinitonState

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -66,7 +66,10 @@ export {
   curry,
 } from './lib/component/curried-component';
 
-export { ModifierManager, Modifier } from './lib/modifier/interfaces';
+export {
+  PublicModifierDefinition as ModifierDefinition,
+  ModifierManager,
+} from './lib/modifier/interfaces';
 
 export {
   default as DOMChanges,

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -9,8 +9,7 @@ import { PublicVM } from './vm/append';
 import { IArguments } from './vm/arguments';
 import { UNDEFINED_REFERENCE, ConditionalReference } from './references';
 import { DynamicAttribute, dynamicAttribute } from './vm/attributes/dynamic';
-import { ModifierManager, Modifier } from './modifier/interfaces';
-import { Component, ComponentManager } from './internal-interfaces';
+import { Component, ComponentManager, ModifierManager, Modifier } from './internal-interfaces';
 
 export type ScopeBlock = [number | CompilableBlock, Scope, BlockSymbolTable];
 export type BlockValue = ScopeBlock[0 | 1 | 2];

--- a/packages/@glimmer/runtime/lib/internal-interfaces.d.ts
+++ b/packages/@glimmer/runtime/lib/internal-interfaces.d.ts
@@ -6,3 +6,8 @@ export {
   ComponentDefinitionState,
   InternalComponentManager as ComponentManager,
 } from './component/interfaces';
+
+export {
+  InternalModifierManager as ModifierManager,
+  ModifierInstanceState as Modifier,
+} from './modifier/interfaces';

--- a/packages/@glimmer/runtime/lib/modifier/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/modifier/interfaces.ts
@@ -2,30 +2,57 @@ import { IArguments } from '../vm/arguments';
 import { DOMChanges } from '../dom/helper';
 import { DynamicScope } from '../environment';
 import { Destroyable } from '@glimmer/util';
-import { Option, Unique } from '@glimmer/interfaces';
+import { Opaque, Option, Unique } from '@glimmer/interfaces';
 import { Tag } from '@glimmer/reference';
 
-export type Modifier = Unique<'ModifierStateBucker'>;
+export type ModifierDefinitionState = Unique<'ModifierDefinitionState'>;
+export type ModifierInstanceState = Unique<'ModifierInstanceState'>;
 
-export interface ModifierManager<T = Modifier> {
+export interface PublicModifierDefinition<
+  ModifierDefinitionState = Opaque,
+  Manager = ModifierManager<Opaque, ModifierDefinitionState>
+> {
+  state: ModifierDefinitionState;
+  manager: Manager;
+}
+
+/* @internal */
+export interface ModifierDefinition {
+  manager: InternalModifierManager;
+  state: ModifierDefinitionState;
+}
+
+/* @internal */
+export type InternalModifierManager = ModifierManager<
+  ModifierInstanceState,
+  ModifierDefinitionState
+>;
+
+export interface ModifierManager<ModifierInstanceState, ModifierDefinitionState> {
   // Create is meant to only produce the state bucket
-  create(element: Element, args: IArguments, dynamicScope: DynamicScope, dom: DOMChanges): T;
+  create(
+    element: Element,
+    state: ModifierDefinitionState,
+    args: IArguments,
+    dynamicScope: DynamicScope,
+    dom: DOMChanges
+  ): ModifierInstanceState;
 
   // Convert the opaque modifier into a `RevisionTag` that determins when
   // the modifier's update hooks need to be called (if at all).
-  getTag(component: T): Tag;
+  getTag(modifier: ModifierInstanceState): Tag;
 
   // At initial render, the modifier gets a chance to install itself on the
   // element it is managing. It can also return a bucket of state that
   // it could use at update time. From the perspective of Glimmer, this
   // is an opaque token.
-  install(modifier: T): void;
+  install(modifier: ModifierInstanceState): void;
 
   // When the modifier's tag has invalidated, the manager's `update` hook is
   // called.
-  update(modifier: T): void;
+  update(modifier: ModifierInstanceState): void;
 
   // Convert the opaque token into an object that implements Destroyable.
   // If it returns null, the modifier will not be destroyed.
-  getDestructor(modifier: T): Option<Destroyable>;
+  getDestructor(modifier: ModifierInstanceState): Option<Destroyable>;
 }

--- a/packages/@glimmer/runtime/test/ember-component-test.ts
+++ b/packages/@glimmer/runtime/test/ember-component-test.ts
@@ -11,7 +11,6 @@ import {
   regex,
   stripTight,
   TestEnvironment,
-  TestModifierManager,
   assertElement,
 } from '@glimmer/test-helpers';
 import { assign } from '@glimmer/util';
@@ -1357,7 +1356,7 @@ QUnit.test(`Glimmer component with element modifier`, function(assert) {
 QUnit.test('Custom element with element modifier', function(assert) {
   assert.expect(0);
 
-  env.registerModifier('foo', new TestModifierManager());
+  env.registerModifier('foo');
 
   appendViewFor('<some-custom-element {{foo "foo"}}></some-custom-element>');
 });

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -12,7 +12,6 @@ import {
   assertNodeTagName,
   BasicComponent,
   TestEnvironment,
-  TestModifierManager,
   equalTokens,
   stripTight,
   trimLines,
@@ -3161,8 +3160,7 @@ QUnit.module('Updating Element Modifiers', hooks => {
   hooks.beforeEach(() => commonSetup());
 
   test('Updating a element modifier', assert => {
-    let manager = new TestModifierManager();
-    env.registerModifier('foo', manager);
+    let { manager } = env.registerModifier('foo');
 
     let template = compile('<div><div {{foo bar baz=fizz}}></div></div>');
     let input = {
@@ -3212,8 +3210,7 @@ QUnit.module('Updating Element Modifiers', hooks => {
   });
 
   test("Const input doesn't trigger update in a element modifier", assert => {
-    let manager = new TestModifierManager();
-    env.registerModifier('foo', manager);
+    let { manager } = env.registerModifier('foo');
 
     let template = compile('<div><div {{foo "bar"}}></div></div>');
     let input = {};
@@ -3241,8 +3238,7 @@ QUnit.module('Updating Element Modifiers', hooks => {
   });
 
   test('Destructor is triggered on element modifiers', assert => {
-    let manager = new TestModifierManager();
-    env.registerModifier('foo', manager);
+    let { manager } = env.registerModifier('foo');
 
     let template = compile('{{#if bar}}<div {{foo bar}}></div>{{else}}<div></div>{{/if}}');
     let input = {

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/compiler-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/compiler-delegate.ts
@@ -42,12 +42,16 @@ export default class EagerCompilerDelegate implements CompilerDelegate<Locator> 
     return { module: path!, name: 'default' };
   }
 
-  hasModifierInScope(_modifierName: string, _referrer: Locator): boolean {
-    return false;
+  hasModifierInScope(modifierName: string, _referrer: Locator): boolean {
+    let modifier = this.modules.get(modifierName);
+    return modifier !== undefined && modifier.type === 'modifier';
   }
 
-  resolveModifier(_modifierName: string, _referrer: Locator): ModuleLocator {
-    throw new Error('Method not implemented.');
+  resolveModifier(modifierName: string, referrer: Locator): ModuleLocator {
+    return {
+      module: this.modules.resolve(modifierName, referrer, 'ui/components')!,
+      name: 'default',
+    };
   }
 
   hasPartialInScope(_partialName: string, _referrer: Locator): boolean {

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -43,6 +43,11 @@ import { TestDynamicScope } from '../../../environment';
 import { NodeEnv } from '../ssr/environment';
 import { TestComponentDefinitionState, locatorFor } from '../../component-definition';
 import { WrappedBuilder } from '@glimmer/opcode-compiler';
+import {
+  TestModifierDefinitionState,
+  TestModifierConstructor,
+  TestModifierManager,
+} from '../../modifier';
 
 export type RenderDelegateComponentDefinition = ComponentDefinition<TestComponentDefinitionState>;
 
@@ -146,6 +151,12 @@ export default class EagerRenderDelegate implements RenderDelegate {
   registerHelper(name: string, helper: UserHelper): void {
     let glimmerHelper: GlimmerHelper = (_vm, args) => new HelperReference(helper, args);
     this.modules.register(name, 'helper', { default: glimmerHelper });
+  }
+
+  registerModifier(name: string, ModifierClass: TestModifierConstructor): void {
+    let state = new TestModifierDefinitionState(ModifierClass);
+    let manager = new TestModifierManager();
+    this.modules.register(name, 'modifier', { default: { manager, state } });
   }
 
   renderTemplate(template: string, context: Dict<Opaque>, element: HTMLElement): RenderResult {

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/render-delegate.ts
@@ -13,6 +13,7 @@ import {
   renderTemplate,
 } from '../../../render-test';
 import { PathReference } from '@glimmer/reference';
+import { TestModifierConstructor } from '../../modifier';
 
 declare const module: any;
 
@@ -39,6 +40,10 @@ export default class LazyRenderDelegate implements RenderDelegate {
     Class?: ComponentTypes[K]
   ) {
     registerComponent(this.env, type, name, layout, Class);
+  }
+
+  registerModifier(name: string, ModifierClass: TestModifierConstructor): void {
+    this.env.registerModifier(name, ModifierClass);
   }
 
   registerHelper(name: string, helper: UserHelper): void {

--- a/packages/@glimmer/test-helpers/lib/environment/registry.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/registry.ts
@@ -2,14 +2,14 @@ import {
   ComponentDefinition,
   Invocation,
   Helper as GlimmerHelper,
-  ModifierManager,
+  ModifierDefinition,
 } from '@glimmer/runtime';
 import { Option, dict } from '@glimmer/util';
 import { PartialDefinition } from '@glimmer/opcode-compiler';
 
 export interface Lookup {
   helper: GlimmerHelper;
-  modifier: ModifierManager;
+  modifier: ModifierDefinition;
   partial: PartialDefinition;
   component: ComponentDefinition;
   template: Invocation;
@@ -47,7 +47,7 @@ export class TypedRegistry<T> {
 
 export default class Registry {
   helper = new TypedRegistry<GlimmerHelper>();
-  modifier: TypedRegistry<ModifierManager> = new TypedRegistry<ModifierManager>();
+  modifier: TypedRegistry<ModifierDefinition> = new TypedRegistry<ModifierDefinition>();
   partial = new TypedRegistry<PartialDefinition>();
   component: TypedRegistry<ComponentDefinition> = new TypedRegistry<ComponentDefinition>();
   template = new TypedRegistry<Invocation>();

--- a/packages/@glimmer/test-helpers/lib/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/render-delegate.ts
@@ -17,6 +17,7 @@ export default interface RenderDelegate {
     Class?: ComponentTypes[K]
   ): void;
   registerHelper(name: string, helper: UserHelper): void;
+  registerModifier(name: string, klass: Opaque): void;
   renderTemplate(
     template: string,
     context: Dict<Opaque>,

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -32,6 +32,7 @@ import {
 } from './environment/components';
 import RenderDelegate from './render-delegate';
 import { debugRehydration } from './environment/modes/rehydration/debug-builder';
+import { TestModifierConstructor } from './environment/modifier';
 
 export const OPEN: { marker: 'open-block' } = { marker: 'open-block' };
 export const CLOSE: { marker: 'close-block' } = { marker: 'close-block' };
@@ -137,6 +138,10 @@ export class RenderTest {
 
   registerHelper(name: string, helper: UserHelper) {
     this.delegate.registerHelper(name, helper);
+  }
+
+  registerModifier(name: string, ModifierClass: TestModifierConstructor) {
+    this.delegate.registerModifier(name, ModifierClass);
   }
 
   registerComponent<K extends ComponentKind>(
@@ -669,6 +674,11 @@ export class RehydrationDelegate implements RenderDelegate {
   registerHelper(name: string, helper: UserHelper): void {
     this.clientEnv.registerHelper(name, helper);
     this.serverEnv.registerHelper(name, helper);
+  }
+
+  registerModifier(name: string, ModifierClass: TestModifierConstructor): void {
+    this.clientEnv.registerModifier(name, ModifierClass);
+    this.serverEnv.registerModifier(name, ModifierClass);
   }
 }
 

--- a/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/ember-components.ts
@@ -116,6 +116,38 @@ export class EmberishComponentTests extends RenderTest {
   }
 
   @test
+  'Element modifier with hooks'(assert: Assert) {
+    assert.expect(4);
+
+    this.registerModifier(
+      'foo',
+      class {
+        element?: Element;
+        didInsertElement() {
+          assert.ok(this.element);
+          assert.equal(this.element!.getAttribute('data-ok'), 'true');
+        }
+
+        didUpdate() {
+          assert.ok(true);
+        }
+
+        willDestroyElement() {
+          assert.ok(true);
+        }
+      }
+    );
+
+    this.render('{{#if ok}}<div data-ok=true {{foo bar}}></div>{{/if}}', {
+      bar: 'bar',
+      ok: true,
+    });
+
+    this.rerender({ bar: 'foo' });
+    this.rerender({ ok: false });
+  }
+
+  @test
   'non-block without properties'() {
     this.render({
       layout: 'In layout',


### PR DESCRIPTION
This introduces the notion of `ModifierDefinitionState`. The purpose of this state
is to encapsulate values that are required for creation of the modifier. For instance the `ModifierDefinitionState` can contain the factory that backs a user defined modifier. This is not a new concept and is in fact why `ComponentDefinitionState` exists.

In the future there is opportunity to unify these ideas. This is the first step.