### PR TITLE
Async-rerender proof of concept

### DIFF
--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -257,10 +257,16 @@ export abstract class Environment {
   }
 
   didCreate(component: Component, manager: ComponentManager) {
+    if (!this.transaction) {
+      return;
+    }
     this.transaction.didCreate(component, manager);
   }
 
   didUpdate(component: Component, manager: ComponentManager) {
+    if (!this.transaction) {
+      return;
+    }
     this.transaction.didUpdate(component, manager);
   }
 
@@ -273,10 +279,16 @@ export abstract class Environment {
   }
 
   didDestroy(d: Destroyable) {
+    if (!this.transaction) {
+      return;
+    }
     this.transaction.didDestroy(d);
   }
 
   commit() {
+    if (!this.transaction) {
+      return;
+    }
     let transaction = this.transaction;
     this._transaction = null;
     transaction.commit();

--- a/packages/@glimmer/runtime/lib/vm/render-result.ts
+++ b/packages/@glimmer/runtime/lib/vm/render-result.ts
@@ -14,6 +14,12 @@ export default class RenderResult<T = Opaque> implements DestroyableBounds, Exce
     private bounds: DestroyableBounds
   ) {}
 
+  async rerenderAsync({ alwaysRevalidate = false } = { alwaysRevalidate: false }) {
+    let { env, program, updating } = this;
+    let vm = new UpdatingVM(env, program, { alwaysRevalidate });
+    return await vm.executeAsync(updating, this);
+  }
+
   rerender({ alwaysRevalidate = false } = { alwaysRevalidate: false }) {
     let { env, program, updating } = this;
     let vm = new UpdatingVM(env, program, { alwaysRevalidate });

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -76,9 +76,6 @@ export default class UpdatingVM<T = Opaque> {
 
     this.try(opcodes, handler);
 
-    // const deadline = 10;
-    // let executionTime = performance.now();
-
     while (true) {
       if (frameStack.isEmpty()) break;
 


### PR DESCRIPTION
Donno why `commit` in env running before `didCreate/didUpdate` etc.
Checking for `transaction != null` solve this issue, but I don't like this approach

part of work in https://github.com/glimmerjs/glimmer.js/pull/134