### PR TITLE
Failing test: incorrect loc for attrs following valueless attr.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-plugin-debug-macros": "^0.1.11",
     "handlebars": "^4.0.6",
     "simple-dom": "^0.3.0",
-    "simple-html-tokenizer": "^0.5.5"
+    "simple-html-tokenizer": "^0.5.6"
   },
   "devDependencies": {
     "@glimmer/build": "^0.8.2",

--- a/packages/@glimmer/syntax/test/loc-node-test.ts
+++ b/packages/@glimmer/syntax/test/loc-node-test.ts
@@ -278,6 +278,7 @@ test('element attribute', function() {
       data-derp="lolol"
 data-barf="herpy"
   data-qux=lolnoquotes
+        data-something-boolean
     data-hurky="some {{thing}} here">
       Hi, fivetanley!
     </div>
@@ -285,18 +286,19 @@ data-barf="herpy"
 
   let [, div] = ast.body;
   if (assertNodeType(div, 'ElementNode')) {
-    let [dataFoo, dataDerp, dataBarf, dataQux, dataHurky] = div.attributes;
+    let [dataFoo, dataDerp, dataBarf, dataQux, dataSomethingBoolean, dataHurky] = div.attributes;
 
-    locEqual(dataFoo, 2, 9, 2, 24);
-    locEqual(dataDerp, 3, 6, 3, 23);
-    locEqual(dataBarf, 4, 0, 4, 17);
-    locEqual(dataQux, 5, 2, 5, 22);
+    locEqual(dataFoo, 2, 9, 2, 24, 'data-foo');
+    locEqual(dataDerp, 3, 6, 3, 23, 'data-derp');
+    locEqual(dataBarf, 4, 0, 4, 17, 'data-barf');
+    locEqual(dataQux, 5, 2, 5, 22, 'data-qux');
+    locEqual(dataSomethingBoolean, 6, 8, 7, 4, 'data-something-boolean');
 
-    locEqual(dataFoo.value, 2, 18, 2, 24);
-    locEqual(dataDerp.value, 3, 16, 3, 23);
-    locEqual(dataBarf.value, 4, 10, 4, 17);
-    locEqual(dataQux.value, 5, 11, 5, 22);
-    locEqual(dataHurky.value, 6, 15, 6, 36);
+    locEqual(dataFoo.value, 2, 18, 2, 24, 'data-foo value');
+    locEqual(dataDerp.value, 3, 16, 3, 23, 'data-derp value');
+    locEqual(dataBarf.value, 4, 10, 4, 17, 'data-barf value');
+    locEqual(dataQux.value, 5, 11, 5, 22, 'data-qux value');
+    locEqual(dataHurky.value, 7, 15, 7, 36, 'data-hurky value');
   }
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6801,9 +6801,9 @@ simple-fmt@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-fmt/-/simple-fmt-0.1.0.tgz#191bf566a59e6530482cb25ab53b4a8dc85c3a6b"
 
-simple-html-tokenizer@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.5.tgz#110e63f2fe095e1f21f2f07e8c259a5ab6d6bebb"
+simple-html-tokenizer@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.6.tgz#e1e442b14f5484bf9a7e2924f78f00855e6b3c14"
 
 simple-is@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Given the following:

```hbs
<div
  data-foo
  class="blah"
></div>
```

We currently suggest that the `AttrNode` for `class` starts _after_ the `c` in `class`, this is definitely incorrect. The fix will need to be made in simple-html-tokenizer.

Originally reported in https://github.com/ember-template-lint/ember-template-lint/issues/483