### PR TITLE
Move stack interface, to interfaces.

### DIFF
--- a/packages/@glimmer/interfaces/index.d.ts
+++ b/packages/@glimmer/interfaces/index.d.ts
@@ -6,6 +6,7 @@ export * from './lib/module-locators';
 export * from './lib/tier1/symbol-table';
 export * from './lib/template';
 export * from './lib/serialize';
+export * from './lib/stack';
 export { default as ComponentCapabilities } from './lib/component-capabilities';
 
 import * as Simple from './lib/dom/simple';

--- a/packages/@glimmer/interfaces/lib/stack.ts
+++ b/packages/@glimmer/interfaces/lib/stack.ts
@@ -1,0 +1,11 @@
+export interface Stack {
+  sp: number;
+  fp: number;
+
+  pushSmi(value: number): void;
+  pushEncodedImmediate(value: number): void;
+
+  getSmi(position: number): number;
+  peekSmi(offset?: number): number;
+  popSmi(): number;
+}

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -1,21 +1,9 @@
 import { Heap, Opcode } from '@glimmer/program';
-import { Option, Opaque } from '@glimmer/interfaces';
+import { Option, Opaque, Stack } from '@glimmer/interfaces';
 import { APPEND_OPCODES } from '../opcodes';
 import VM from './append';
 import { DEVMODE } from '@glimmer/local-debug-flags';
 import { Op } from '@glimmer/vm';
-
-export interface Stack {
-  sp: number;
-  fp: number;
-
-  pushSmi(value: number): void;
-  pushEncodedImmediate(value: number): void;
-
-  getSmi(position: number): number;
-  peekSmi(offset?: number): number;
-  popSmi(): number;
-}
 
 export interface Program {
   opcode(offset: number): Opcode;

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -3,6 +3,7 @@ import { Opaque } from '@glimmer/interfaces';
 import { PrimitiveType } from '@glimmer/program';
 import { unreachable } from '@glimmer/util';
 import { Stack as WasmStack } from '@glimmer/low-level';
+import { Stack } from '@glimmer/interfaces';
 
 const HI = 0x80000000;
 const MASK = 0x7fffffff;
@@ -80,7 +81,7 @@ export class InnerStack {
   }
 }
 
-export default class EvaluationStack {
+export default class EvaluationStack implements Stack {
   static empty(): EvaluationStack {
     return new this(new InnerStack(), 0, -1);
   }


### PR DESCRIPTION
While exporting stack from `packages/@glimmer/runtime/lib/vm/low-level.ts` is good for people who code against low level, it doesn't help find the implementation of the interface.

To resolve this i moved the interface interfaces, and marked `EvaluationStack` as implementing it. it seems that wasmStack and innerStack, don't implement the interface wholly, but at least it seems clear now that the stack used within low level is the `EvaluationStack`.

If this is a welcomed pr i will make more of them as i find more cases while exploring the code base.