### PR TITLE
`Bounds` must be non-empty

### DIFF
--- a/packages/@glimmer/interfaces/lib/dom/simple.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/simple.d.ts
@@ -83,4 +83,5 @@ export interface Element extends Node {
   removeAttributeNS(namespaceURI: string, name: string): void;
   setAttribute(name: string, value: string): void;
   setAttributeNS(namespaceURI: string, qualifiedName: string, value: string): void;
+  insertAdjacentHTML(position: 'beforebegin' | 'beforeend', html: string): void;
 }

--- a/packages/@glimmer/node/lib/node-dom-helper.ts
+++ b/packages/@glimmer/node/lib/node-dom-helper.ts
@@ -1,6 +1,7 @@
 import * as SimpleDOM from 'simple-dom';
 import { DOMTreeConstruction, Bounds, ConcreteBounds } from '@glimmer/runtime';
 import { Simple } from '@glimmer/interfaces';
+import { Option } from '@glimmer/util';
 
 export default class NodeDOMTreeConstruction extends DOMTreeConstruction {
   protected document!: SimpleDOM.Document; // Hides property on base class
@@ -11,16 +12,10 @@ export default class NodeDOMTreeConstruction extends DOMTreeConstruction {
   // override to prevent usage of `this.document` until after the constructor
   protected setupUselessElement() {}
 
-  insertHTMLBefore(parent: Simple.Element, reference: Simple.Node, html: string): Bounds {
-    let prev = reference ? reference.previousSibling : parent.lastChild;
-
+  insertHTMLBefore(parent: Simple.Element, reference: Option<Simple.Node>, html: string): Bounds {
     let raw = this.document.createRawHTMLSection(html);
     parent.insertBefore(raw, reference);
-
-    let first = prev ? prev.nextSibling : parent.firstChild;
-    let last = reference ? reference.previousSibling : parent.lastChild;
-
-    return new ConcreteBounds(parent, first, last);
+    return new ConcreteBounds(parent, raw, raw);
   }
 
   // override to avoid SVG detection/work when in node (this is not needed in SSR)

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -77,7 +77,6 @@ export {
   DOMChanges as IDOMChanges,
   DOMTreeConstruction,
   isWhitespace,
-  insertHTMLBefore,
 } from './lib/dom/helper';
 export { normalizeProperty } from './lib/dom/props';
 export {

--- a/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
@@ -44,13 +44,17 @@ export function applySVGInnerHTMLFix(
         return super.insertHTMLBefore(parent, nextSibling, html);
       }
 
-      // TODO: why are these casts okay???
-      return fixSVG(parent as Element, div, html, nextSibling as Option<Node>);
+      return fixSVG(parent, div, html, nextSibling);
     }
   };
 }
 
-function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Option<Node>): Bounds {
+function fixSVG(
+  parent: Simple.Element,
+  div: HTMLElement,
+  html: string,
+  reference: Option<Simple.Node>
+): Bounds {
   assert(html !== '', 'html cannot be empty');
 
   let source: Node;

--- a/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
@@ -1,6 +1,7 @@
-import { Bounds, ConcreteBounds } from '../bounds';
+import { Bounds } from '../bounds';
 import { moveNodesBefore, DOMOperations } from '../dom/helper';
-import { Option, unwrap } from '@glimmer/util';
+import { Option, unwrap, assert } from '@glimmer/util';
+import { Simple } from '@glimmer/interfaces';
 
 export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 export type SVG_NAMESPACE = typeof SVG_NAMESPACE;
@@ -30,17 +31,28 @@ export function applySVGInnerHTMLFix(
   let div = document.createElement('div');
 
   return class DOMChangesWithSVGInnerHTMLFix extends DOMClass {
-    insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
+    insertHTMLBefore(
+      parent: Simple.Element,
+      nextSibling: Option<Simple.Node>,
+      html: string
+    ): Bounds {
+      if (html === '') {
+        return super.insertHTMLBefore(parent, nextSibling, html);
+      }
+
       if (parent.namespaceURI !== svgNamespace) {
         return super.insertHTMLBefore(parent, nextSibling, html);
       }
 
-      return fixSVG(parent, div, html, nextSibling);
+      // TODO: why are these casts okay???
+      return fixSVG(parent as Element, div, html, nextSibling as Option<Node>);
     }
   };
 }
 
-function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Node): Bounds {
+function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Option<Node>): Bounds {
+  assert(html !== '', 'html cannot be empty');
+
   let source: Node;
 
   // This is important, because decendants of the <foreignObject> integration
@@ -48,7 +60,7 @@ function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Node
   if (parent.tagName.toUpperCase() === 'FOREIGNOBJECT') {
     // IE, Edge: also do not correctly support using `innerHTML` on SVG
     // namespaced elements. So here a wrapper is used.
-    let wrappedHtml = '<svg><foreignObject>' + (html || '<!---->') + '</foreignObject></svg>';
+    let wrappedHtml = '<svg><foreignObject>' + html + '</foreignObject></svg>';
 
     div.innerHTML = wrappedHtml;
 
@@ -56,15 +68,14 @@ function fixSVG(parent: Element, div: HTMLElement, html: string, reference: Node
   } else {
     // IE, Edge: also do not correctly support using `innerHTML` on SVG
     // namespaced elements. So here a wrapper is used.
-    let wrappedHtml = '<svg>' + (html || '<!---->') + '</svg>';
+    let wrappedHtml = '<svg>' + html + '</svg>';
 
     div.innerHTML = wrappedHtml;
 
     source = div.firstChild!;
   }
 
-  let [first, last] = moveNodesBefore(source, parent, reference);
-  return new ConcreteBounds(parent, first, last);
+  return moveNodesBefore(source, parent, reference);
 }
 
 function shouldApplyFix(document: Document, svgNamespace: SVG_NAMESPACE) {

--- a/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/text-node-merging-fix.ts
@@ -1,6 +1,7 @@
 import { Bounds } from '../bounds';
 import { DOMOperations } from '../dom/helper';
 import { Option } from '@glimmer/util';
+import { Simple } from '@glimmer/interfaces';
 
 // Patch:    Adjacent text node merging fix
 // Browsers: IE, Edge, Firefox w/o inspector open
@@ -32,10 +33,19 @@ export function applyTextNodeMergingFix(
       this.uselessComment = document.createComment('');
     }
 
-    insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
+    insertHTMLBefore(
+      parent: Simple.Element,
+      nextSibling: Option<Simple.Node>,
+      html: string
+    ): Bounds {
+      if (html === '') {
+        return super.insertHTMLBefore(parent, nextSibling, html);
+      }
+
       let didSetUselessComment = false;
 
       let nextPrevious = nextSibling ? nextSibling.previousSibling : parent.lastChild;
+
       if (nextPrevious && nextPrevious instanceof Text) {
         didSetUselessComment = true;
         parent.insertBefore(this.uselessComment, nextSibling);

--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -96,7 +96,7 @@ export function moveNodesBefore(
 }
 
 export class DOMOperations {
-  protected uselessElement!: HTMLElement; // Set by this.setupUselessElement() in constructor
+  protected uselessElement!: Simple.Element; // Set by this.setupUselessElement() in constructor
 
   constructor(protected document: Simple.Document) {
     this.setupUselessElement();
@@ -137,20 +137,12 @@ export class DOMOperations {
     parent.insertBefore(node, reference);
   }
 
-  insertHTMLBefore(
-    _parent: Simple.Element,
-    _nextSibling: Option<Simple.Node>,
-    html: string
-  ): Bounds {
+  insertHTMLBefore(parent: Simple.Element, nextSibling: Option<Simple.Node>, html: string): Bounds {
     if (html === '') {
       let comment = this.createComment('');
-      _parent.insertBefore(comment, _nextSibling);
-      return new ConcreteBounds(_parent, comment, comment);
+      parent.insertBefore(comment, nextSibling);
+      return new ConcreteBounds(parent, comment, comment);
     }
-
-    // TODO why are these casts okay???
-    let parent = _parent as Element;
-    let nextSibling = _nextSibling as Option<Node>;
 
     let prev = nextSibling ? nextSibling.previousSibling : parent.lastChild;
     let last: Simple.Node;

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -1,7 +1,7 @@
 import { NewElementBuilder, ElementBuilder, RemoteBlockTracker } from './element-builder';
 
 import { Environment } from '../environment';
-import Bounds, { bounds, Cursor } from '../bounds';
+import Bounds, { Cursor, ConcreteBounds } from '../bounds';
 import { Simple, Option } from '@glimmer/interfaces';
 import {
   expect,
@@ -195,7 +195,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       let first = candidateBounds.firstNode()!;
       let last = candidateBounds.lastNode()!;
 
-      let newBounds = bounds(this.element, first.nextSibling!, last.previousSibling!);
+      let newBounds = new ConcreteBounds(this.element, first.nextSibling!, last.previousSibling!);
 
       let possibleEmptyMarker = this.remove(first);
       this.remove(last);
@@ -232,7 +232,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
         last = expect(last.nextSibling, `BUG: serialization markers must be paired`);
       }
 
-      return bounds(this.element, first, last);
+      return new ConcreteBounds(this.element, first, last);
     } else {
       return null;
     }

--- a/packages/@glimmer/runtime/lib/vm/render-result.ts
+++ b/packages/@glimmer/runtime/lib/vm/render-result.ts
@@ -1,4 +1,4 @@
-import { Option, LinkedList } from '@glimmer/util';
+import { LinkedList } from '@glimmer/util';
 import Environment from '../environment';
 import { DestroyableBounds, clear } from '../bounds';
 import UpdatingVM, { ExceptionHandler } from './update';
@@ -24,11 +24,11 @@ export default class RenderResult<T = Opaque> implements DestroyableBounds, Exce
     return this.bounds.parentElement();
   }
 
-  firstNode(): Option<Simple.Node> {
+  firstNode(): Simple.Node {
     return this.bounds.firstNode();
   }
 
-  lastNode(): Option<Simple.Node> {
+  lastNode(): Simple.Node {
     return this.bounds.lastNode();
   }
 


### PR DESCRIPTION
💣 contains breaking changes

The `Bounds` object represents a _inclusive_ range. That is, the bounds is referring to the range in DOM _including_ the `firstNode()` and the `lastNode()`. Therefore, it does not ever make sense for those endpoints to be `null`. (Technically, `(parent, null, null)` is a valid way to represent an _empty_ range. However, in practice we do not have a use case for this, and every use of `null` were actual bugs.)

This is technically a breaking change, but then again, if `null` were passed today it's likely a bug, and if the consuming side was checking for `null` it's likely just deadcode that will never execute in practice.
