### PR TITLE
Fix debug issues reported in glimmerjs/glimmer-vm#846

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -1,6 +1,10 @@
 import { WriteOnlyConstants } from '@glimmer/program';
 
 export default class DebugConstants extends WriteOnlyConstants {
+  getNumber(value: number): number {
+    return this.numbers[value];
+  }
+
   getString(value: number): string {
     return this.strings[value];
   }

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -174,6 +174,7 @@ function decodePrimitive(primitive: number, constants: DebugConstants): Primitiv
           return undefined;
       }
     case PrimitiveType.NEGATIVE:
+    case PrimitiveType.BIG_NUM:
       return constants.getNumber(value);
     default:
       throw unreachable();

--- a/packages/@glimmer/vm/lib/-debug-strip.ts
+++ b/packages/@glimmer/vm/lib/-debug-strip.ts
@@ -427,7 +427,8 @@ OPCODE_METADATA(Op.BindEvalScope, {
 
 OPCODE_METADATA(Op.InvokeComponentLayout, {
   name: 'InvokeComponentLayout',
-  stackChange: -2,
+  ops: [Register('state')],
+  stackChange: 0,
 });
 
 OPCODE_METADATA(Op.PopulateLayout, {


### PR DESCRIPTION
The debug variables had gone out of sync at some point. 
Verified this change works by enabling glimmer logging in the testem chrome window all opcodes were logged as expected.

Fixes #846 