### PR TITLE
Export RenderComponentArgs

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -1,6 +1,6 @@
 import './lib/bootstrap';
 
-export { renderMain, renderComponent, TemplateIterator } from './lib/render';
+export { renderMain, renderComponent, TemplateIterator, RenderComponentArgs } from './lib/render';
 
 export {
   NULL_REFERENCE,


### PR DESCRIPTION
Export the RenderComponentArgs type so that consuming typescript integrations can have it be properly typed.