### PR TITLE
Fixed Windows Build Error

### DIFF
--- a/build/symlink-dependencies/index.js
+++ b/build/symlink-dependencies/index.js
@@ -49,7 +49,8 @@ module.exports = {
         if (isScopedPackage(dep)) { mkdirpScope(dep, modulesPath); }
         fs.symlinkSync(
           path.join('../../../../', dep),
-          path.join(modulesPath, dep)
+          path.join(modulesPath, dep),
+          'junction'
         );
       });
     }

--- a/testem.js
+++ b/testem.js
@@ -8,7 +8,7 @@ let config = {
   "disable_watching": true,
   "launchers": {
     "Node": {
-      "command": "./bin/run-node-tests.js",
+      "exe": "node", args: ["./bin/run-node-tests.js"],
       "protocol": "tap"
      }
   },


### PR DESCRIPTION
Ran yarn test, got a permissions error attempting to create the symlinks, changed to use junction instead since it was trying to symlink a directory.  Also got error from testem- Node launcher relied on being executed with a shell.