### PR TITLE
[WIP] Attempt more graceful recovery of render-time exceptions

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -478,12 +478,21 @@ export default class VM<T> implements PublicVM {
     return result.value;
   }
 
+  recover() {
+    this.elementStack.panic();
+  }
+
   next(): IteratorResult<RenderResult> {
     let { env, program, updatingOpcodeStack, elementStack } = this;
     let opcode = this.inner.nextStatement();
     let result: IteratorResult<RenderResult>;
     if (opcode !== null) {
-      this.inner.evaluateOuter(opcode, this);
+      try {
+        this.inner.evaluateOuter(opcode, this);
+      } catch (err) {
+        this.recover();
+        throw err;
+      }
       result = { done: false, value: null };
     } else {
       // Unload the stack

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -129,6 +129,7 @@ export interface ElementBuilder extends Cursor, DOMStack, TreeOperations {
   expectConstructing(method: string): Simple.Element;
 
   block(): Tracker;
+  panic(): void;
 
   pushSimpleBlock(): Tracker;
   pushUpdatableBlock(): UpdatableTracker;
@@ -190,6 +191,12 @@ export class NewElementBuilder implements ElementBuilder {
 
   block(): Tracker {
     return expect(this.blockStack.current, 'Expected a current block tracker');
+  }
+
+  panic(): void {
+    while (this.blockStack.current) {
+      this.popBlock();
+    }
   }
 
   popElement() {


### PR DESCRIPTION
This PR attempts to implement basic graceful recovery of VM state in the event of an exception getting thrown during render. The most important constraint is that subsequent revalidations after a failed revalidation are possible, i.e. a single exception during render doesn't crash the entire application and require a page reload.

I don't feel confident that this approach doesn't introduce its own problems and would like review from folks who are more familiar with this part of the architecture.