### PR TITLE
Feat: Add option to turn on `ignoreStandalone` in HBS parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     ]
   },
   "dependencies": {
-    "babel-plugin-debug-macros": "^0.1.11",
-    "handlebars": "^4.0.6",
-    "simple-html-tokenizer": "^0.5.6",
     "@simple-dom/document": "^1.4.0",
+    "@simple-dom/interface": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0",
-    "@simple-dom/interface": "^1.4.0"
+    "babel-plugin-debug-macros": "^0.1.11",
+    "handlebars": "^4.0.6",
+    "simple-html-tokenizer": "^0.5.6"
   },
   "devDependencies": {
     "@glimmer/build": "^0.8.2",

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -342,6 +342,7 @@ export interface PreprocessOptions {
   plugins?: {
     ast?: ASTPluginBuilder[];
   };
+  ignoreStandalone?: boolean;
 }
 
 export interface Syntax {
@@ -361,7 +362,8 @@ const syntax: Syntax = {
 };
 
 export function preprocess(html: string, options?: PreprocessOptions): AST.Program {
-  let ast = typeof html === 'object' ? html : handlebars.parse(html);
+  const ignoreStandalone = options ? options.ignoreStandalone : false;
+  let ast = typeof html === 'object' ? html : handlebars.parse(html, { ignoreStandalone });
   let program = new TokenizerEventHandlers(html).acceptNode(ast);
 
   if (options && options.plugins && options.plugins.ast) {

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -342,7 +342,7 @@ export interface PreprocessOptions {
   plugins?: {
     ast?: ASTPluginBuilder[];
   };
-  ignoreStandalone?: boolean;
+  parseOptions?: object;
 }
 
 export interface Syntax {
@@ -362,8 +362,8 @@ const syntax: Syntax = {
 };
 
 export function preprocess(html: string, options?: PreprocessOptions): AST.Program {
-  const ignoreStandalone = options ? options.ignoreStandalone : false;
-  let ast = typeof html === 'object' ? html : handlebars.parse(html, { ignoreStandalone });
+  const parseOptions = options ? options.parseOptions : {};
+  let ast = typeof html === 'object' ? html : handlebars.parse(html, parseOptions);
   let program = new TokenizerEventHandlers(html).acceptNode(ast);
 
   if (options && options.plugins && options.plugins.ast) {

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -354,6 +354,44 @@ test('Stripping - removes unnecessary text nodes', function() {
   );
 });
 
+test('Whitespace control - linebreaks after blocks removed by default', function() {
+  let t = '{{#each}}\n  <li> foo </li>\n{{/each}}';
+
+  astEqual(
+    t,
+    b.program([
+      b.block(
+        b.path('each'),
+        [],
+        b.hash(),
+        b.program([b.text('  '), b.element('li', [], [], [b.text(' foo ')]), b.text('\n')]),
+        null
+      ),
+    ])
+  );
+});
+
+test('Whitespace control - preserve all whitespace if config is set', function() {
+  let t = '{{#each}}\n  <li> foo </li>\n{{/each}}';
+
+  astEqual(
+    t,
+    b.program([
+      b.block(
+        b.path('each'),
+        [],
+        b.hash(),
+        b.program([b.text('\n  '), b.element('li', [], [], [b.text(' foo ')]), b.text('\n')]),
+        null
+      ),
+    ]),
+    undefined,
+    {
+      ignoreStandalone: true,
+    }
+  );
+});
+
 // TODO: Make these throw an error.
 //test("Awkward mustache in unquoted attribute value", function() {
 //  let t = "<div class=a{{foo}}></div>";

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -387,7 +387,9 @@ test('Whitespace control - preserve all whitespace if config is set', function()
     ]),
     undefined,
     {
-      ignoreStandalone: true,
+      parseOptions: {
+        ignoreStandalone: true,
+      },
     }
   );
 });

--- a/packages/@glimmer/syntax/test/support.ts
+++ b/packages/@glimmer/syntax/test/support.ts
@@ -1,4 +1,4 @@
-import { preprocess as parse, AST } from '@glimmer/syntax';
+import { preprocess as parse, AST, PreprocessOptions } from '@glimmer/syntax';
 
 function normalizeNode(obj: AST.Node | Array<AST.Node>): AST.Node | Array<AST.Node> {
   if (obj && typeof obj === 'object') {
@@ -26,13 +26,14 @@ function normalizeNode(obj: AST.Node | Array<AST.Node>): AST.Node | Array<AST.No
 export function astEqual(
   actual: any | null | undefined,
   expected: any | null | undefined,
-  message?: string
+  message?: string,
+  parseOptions?: PreprocessOptions
 ) {
   if (typeof actual === 'string') {
-    actual = parse(actual);
+    actual = parse(actual, parseOptions);
   }
   if (typeof expected === 'string') {
-    expected = parse(expected);
+    expected = parse(expected, parseOptions);
   }
 
   actual = normalizeNode(actual);

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,9 +89,9 @@
   integrity sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==
 
 "@types/handlebars@^4.0.32":
-  version "4.0.32"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.32.tgz#637e8d945a9354aab47df7125005490fe9f8e592"
-  integrity sha1-Y36NlFqTVKq0ffcSUAVJD+n45ZI=
+  version "4.0.40"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.40.tgz#b714e13d296a75bff3f199316d1311933ca79ffd"
+  integrity sha512-sGWNtsjNrLOdKha2RV1UeF8+UbQnPSG7qbe5wwbni0mw4h2gHXyPFUMOC+xwGirIiiydM/HSqjDO4rk6NFB18w==
 
 "@types/node@^8.0.53":
   version "8.0.53"


### PR DESCRIPTION
Adds new config option, `ignoreStandalone`, to `preprocess()` method.
This property is passed on to the handlebars parser (default: false).
When enabled, the handlebars parser preserves more whitespace. This,
in turn, creates ASTs that, when printed back into templates, results in
more developer-friendly code.

Also bumps `@types/handlebars` to latest, as this is necessary for glimmer
to recognize that `handlebars.parse()` does accept options.