### PR TITLE
CI: Run only for `master` branch, tags and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+\.\d+/
+
 language: node_js
 node_js:
   - 6


### PR DESCRIPTION
to prevent unnecessary double builds for e.g. dependabot PRs