### PR TITLE
CI: Split `script` into multiple jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,24 @@ before_install:
 
 jobs:
   include:
-    - name: Tests
-      env:
-        - SAUCE_USERNAME=htmlbars-ci
-        - SAUCE_ACCESS_KEY=71947947-f373-4e9c-9166-23038df7ddf2
+    - name: Tests (Chrome + Node.js)
 
       addons:
         chrome: stable
+
+      script:
+        - yarn test
+
+    - name: Tests (Saucelabs)
+      env:
+        - SAUCE_USERNAME=htmlbars-ci
+        - SAUCE_ACCESS_KEY=71947947-f373-4e9c-9166-23038df7ddf2
 
       before_script:
         - yarn run sauce:connect
 
       script:
-        - yarn run test:ci
+        - yarn run test:sauce
 
       after_script:
         - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,24 +32,24 @@ jobs:
         - SAUCE_ACCESS_KEY=71947947-f373-4e9c-9166-23038df7ddf2
 
       before_script:
-        - yarn run sauce:connect
+        - yarn sauce:connect
 
       script:
-        - yarn run test:sauce
+        - yarn test:sauce
 
       after_script:
         - sleep 10
-        - yarn run sauce:disconnect
+        - yarn sauce:disconnect
 
     - name: Type Tests
 
       script:
-        - yarn run build
-        - yarn run test:types
+        - yarn build
+        - yarn test:types
 
     - name: Linting
 
       script:
-        - yarn run problems
-        - yarn run tslint
-        - yarn run eslint
+        - yarn problems
+        - yarn tslint
+        - yarn eslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,7 @@ language: node_js
 node_js:
   - 6
 
-addons:
-  chrome: stable
-
 env:
-  global:
-    - SAUCE_USERNAME=htmlbars-ci
-    - SAUCE_ACCESS_KEY=71947947-f373-4e9c-9166-23038df7ddf2
   matrix:
     - TEST_NODE=1 TEST_BROWSERS=1
 
@@ -26,17 +20,35 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 
-before_script:
-  - yarn run sauce:connect
+jobs:
+  include:
+    - name: Tests
+      env:
+        - SAUCE_USERNAME=htmlbars-ci
+        - SAUCE_ACCESS_KEY=71947947-f373-4e9c-9166-23038df7ddf2
 
-script:
-  - yarn run problems
-  - yarn run test:ci
-  - yarn run build
-  - yarn run test:types
-  - yarn run eslint
-  - yarn run tslint
+      addons:
+        chrome: stable
 
-after_script:
-  - sleep 10
-  - yarn run sauce:disconnect
+      before_script:
+        - yarn run sauce:connect
+
+      script:
+        - yarn run test:ci
+
+      after_script:
+        - sleep 10
+        - yarn run sauce:disconnect
+
+    - name: Type Tests
+
+      script:
+        - yarn run build
+        - yarn run test:types
+
+    - name: Linting
+
+      script:
+        - yarn run problems
+        - yarn run tslint
+        - yarn run eslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ language: node_js
 node_js:
   - 6
 
-env:
-  matrix:
-    - TEST_NODE=1 TEST_BROWSERS=1
-
 matrix:
   fast_finish: true
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sauce:disconnect": "ember sauce:disconnect",
     "start": "ember serve --port=7357",
     "test": "ember test",
-    "test:ci": "ember test --test-port=7000 --config-file=testem-sauce.js",
+    "test:sauce": "ember test --test-port=7000 --config-file=testem-sauce.js",
     "test:node": "bin/run-node-tests.js",
     "test:types": "bin/run-types-tests.js",
     "tslint": "tslint --project tsconfig.json",

--- a/testem-sauce.js
+++ b/testem-sauce.js
@@ -8,10 +8,6 @@ module.exports = {
   "parallel": 2,
   "launchers":
     {
-      "Node": {
-        "command": "./bin/run-node-tests.js",
-        "protocol": "tap"
-      },
       "SL_Chrome_Current": {
         "command": "ember sauce:launch -p 'Windows 10' -b chrome -v latest --no-connect -u '<url>'",
         "protocol": "tap"
@@ -46,21 +42,8 @@ module.exports = {
       }
     }
   ,
-  "launch_in_dev": [
-    "Node",
-    "Chrome"
-  ],
-  "browser_args": {
-    "Chrome": [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=0',
-      '--no-sandbox'
-    ]
-  },
+  "launch_in_dev": [],
   "launch_in_ci": [
-    "Node",
-    "Chrome",
     "SL_Chrome_Current",
     "SL_Chrome_Last",
     "SL_Firefox_Current",

--- a/testem.js
+++ b/testem.js
@@ -16,9 +16,15 @@ let config = {
     "Chrome": {
       "mode": "ci",
       "args": [
-        '--disable-gpu',
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--remote-debugging-port=9222'
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        '--mute-audio',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
       ]
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9661,9 +9661,9 @@ term-size@^0.1.0:
     execa "^0.4.0"
 
 testem@^1.13.0, testem@^1.15.0, testem@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/testem/-/testem-1.16.0.tgz#3933040b5d5b5fbdb6a2b1e7032e511b54a05867"
-  integrity sha1-OTMEC11bX722orHnAy5RG1SgWGc=
+  version "1.18.5"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-1.18.5.tgz#912f3bfd4773519fa3cce0a8fd0e354763cbd545"
+  integrity sha512-0jMQquldcrSl1HwNAkePOr02g/3ZQVZYw7GVJNbOiGvR5esyXvRPX916CLWxcdZqB3yHM80NZiz5P5biogu2Vw==
   dependencies:
     backbone "^1.1.2"
     bluebird "^3.4.6"


### PR DESCRIPTION
... so that linting, type tests and saucelabs can run in parallel

This brings CI time down from 6-7min to ~4.5min