### PR TITLE
Failing test for forwarding attributes to yielded components

### DIFF
--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -315,6 +315,9 @@ export default class JavaScriptCompiler
   }
 
   attrSplat(to: Option<number>) {
+    // consume (and disregard) the value pushed for the
+    // ...attributes attribute
+    this.popValue();
     this.push([Ops.AttrSplat, to!]);
   }
 

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -135,7 +135,6 @@ export default class TemplateCompiler {
     let { name, value } = action;
 
     let namespace = getAttrNamespace(name);
-
     let isStatic = this.prepareAttributeValue(value);
 
     if (name.charAt(0) === '@') {

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -138,26 +138,25 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({
-    kind: 'basic',
+    kind: 'fragment',
   })
   'invoke a component forwarding attributes'() {
     this.registerComponent(
       'Glimmer',
       'InnerComponent',
-      '<p data-foo="target" ...attributes>Inner Component</p>'
+      '<p data-foo="definition" data-bar="definition" ...attributes>Inner Component</p>'
     );
     this.render(
       {
-        name: 'OuterComponent',
-        layout: '{{#with (component "InnerComponent") as |Inner|}}<Inner ...attributes />{{/with}}',
-        template: 'hello!',
-        args: {},
+        layout:
+          '{{#with (component "InnerComponent") as |Inner|}}<Inner data-foo="invocation" ...attributes />{{/with}}',
         attributes: { title: 'Emberconf' },
       },
       {}
     );
-    debugger;
-    this.assertHTML("<div title='emberconf'><p data-foo='target' title='Emberconf'>Inner Component</p></div>");
+    this.assertHTML(
+      "<p data-foo='invocation' data-bar='definition' title='Emberconf'>Inner Component</p>"
+    );
     this.assertStableRerender();
   }
 

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -140,6 +140,30 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'basic',
   })
+  'invoke a component forwarding attributes'() {
+    this.registerComponent(
+      'Glimmer',
+      'InnerComponent',
+      '<p data-foo="target" ...attributes>Inner Component</p>'
+    );
+    this.render(
+      {
+        name: 'OuterComponent',
+        layout: '{{#with (component "InnerComponent") as |Inner|}}<Inner ...attributes />{{/with}}',
+        template: 'hello!',
+        args: {},
+        attributes: { title: 'Emberconf' },
+      },
+      {}
+    );
+    debugger;
+    this.assertHTML("<div title='emberconf'><p data-foo='target' title='Emberconf'>Inner Component</p></div>");
+    this.assertStableRerender();
+  }
+
+  @test({
+    kind: 'basic',
+  })
   'creating a new component yielding values'() {
     this.render(
       {


### PR DESCRIPTION
Extracted from https://github.com/emberjs/ember.js/pull/17146

@chancancode @rwjblue I hope this reproduction helps track this down.

In the test, as it stands right now, the `<Inner ...attributes>` component is not rendered at all. If you remove the `...attributes` it does render.