### PR TITLE
Update `broccoli-typescript-compiler` to v4.1.0 

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,7 +2,7 @@
 
 const merge = require('broccoli-merge-trees');
 const funnel = require('broccoli-funnel');
-const { typescript } = require('broccoli-typescript-compiler');
+const typescript = require('broccoli-typescript-compiler').default;
 
 const buildTests = require('./build/broccoli/build-tests');
 const buildPackages = require('./build/broccoli/build-packages.js');

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "broccoli-persistent-filter": "^2.1.1",
     "broccoli-rollup": "^2.0.0",
     "broccoli-source": "^1.1.0",
-    "broccoli-typescript-compiler": "^2.3.0",
+    "broccoli-typescript-compiler": "^4.1.0",
     "dag-map": "^2.0.2",
     "ember-cli": "~3.4.4",
     "ember-cli-sauce": "^2.2.0",

--- a/packages/@glimmer/dom-change-list/lib/node-tokens.ts
+++ b/packages/@glimmer/dom-change-list/lib/node-tokens.ts
@@ -11,7 +11,7 @@ export class NodeTokens implements INodeTokens {
     return token;
   }
 
-  reify<N extends Simple.Node>(token: NodeToken): N {
-    return this.nodes[token] as N;
+  reify(token: NodeToken): Simple.Node {
+    return this.nodes[token];
   }
 }

--- a/packages/@glimmer/interfaces/lib/dom/tree-construction.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/tree-construction.d.ts
@@ -1,10 +1,10 @@
-import { Simple } from '@glimmer/interfaces';
+import * as Simple from './simple';
 import { Namespace } from '@simple-dom/interface';
 
 export type NodeToken = number;
 
 export interface NodeTokens {
-  reify<N extends Simple.Node>(token: NodeToken): N;
+  reify(token: NodeToken): Simple.Node;
 }
 
 export interface Reifiable {

--- a/packages/@glimmer/runtime/test/updating-test.ts
+++ b/packages/@glimmer/runtime/test/updating-test.ts
@@ -2910,7 +2910,7 @@ QUnit.module('Updating SVG', hooks => {
     render(template, object);
 
     function assertNamespaces() {
-      if (assertNodeTagName(svg.firstChild, 'foreignobject')) {
+      if (assertNodeTagName(svg.firstChild, 'foreignObject')) {
         assert.equal(svg.firstChild.namespaceURI, SVG_NAMESPACE);
         if (assertNodeTagName(svg.firstChild.firstChild, 'div')) {
           assert.equal(svg.firstChild.firstChild.namespaceURI, XHTML_NAMESPACE);
@@ -2947,7 +2947,7 @@ QUnit.module('Updating SVG', hooks => {
     function assertNamespaces() {
       if (assertNodeTagName(root.firstChild, 'svg')) {
         assert.equal(root.firstChild.namespaceURI, SVG_NAMESPACE);
-        if (assertNodeTagName(root.firstChild.firstChild, 'foreignobject')) {
+        if (assertNodeTagName(root.firstChild.firstChild, 'foreignObject')) {
           assert.equal(root.firstChild.firstChild.namespaceURI, SVG_NAMESPACE);
           if (assertNodeTagName(root.firstChild.firstChild.firstChild, 'div')) {
             assert.equal(root.firstChild.firstChild.firstChild.namespaceURI, XHTML_NAMESPACE);
@@ -3117,7 +3117,7 @@ QUnit.module('Updating SVG', hooks => {
 
     equalTokens(root, `<svg>${context.content}</svg><div></div>`);
     assertNamespaces(svg => {
-      if (assertNodeTagName(svg.firstChild, 'foreignobject')) {
+      if (assertNodeTagName(svg.firstChild, 'foreignObject')) {
         assert.equal(
           svg.firstChild.namespaceURI,
           SVG_NAMESPACE,

--- a/packages/@glimmer/syntax/lib/types/nodes.ts
+++ b/packages/@glimmer/syntax/lib/types/nodes.ts
@@ -1,3 +1,5 @@
+import { VisitorKeysMap } from './visitor-keys';
+
 export type Option<T> = T | null;
 
 export interface BaseNode {
@@ -204,29 +206,6 @@ export interface Nodes {
   SubExpression: SubExpression;
   Hash: Hash;
   HashPair: HashPair;
-}
-
-export interface VisitorKeysMap {
-  Program: ['body'];
-  MustacheStatement: ['path', 'params', 'hash'];
-  BlockStatement: ['path', 'params', 'hash', 'program', 'inverse'];
-  ElementModifierStatement: ['path', 'params', 'hash'];
-  PartialStatement: ['name', 'params', 'hash'];
-  CommentStatement: never[];
-  MustacheCommentStatement: never[];
-  ElementNode: ['attributes', 'modifiers', 'children', 'comments'];
-  AttrNode: ['value'];
-  TextNode: never[];
-  ConcatStatement: ['parts'];
-  SubExpression: ['path', 'params', 'hash'];
-  PathExpression: never[];
-  StringLiteral: never[];
-  BooleanLiteral: never[];
-  NumberLiteral: never[];
-  NullLiteral: never[];
-  UndefinedLiteral: never[];
-  Hash: ['pairs'];
-  HashPair: ['value'];
 }
 
 export type NodeType = keyof Nodes;

--- a/packages/@glimmer/syntax/lib/types/nodes.ts
+++ b/packages/@glimmer/syntax/lib/types/nodes.ts
@@ -1,4 +1,4 @@
-import { VisitorKeysMap } from './visitor-keys';
+import visitorKeys, { VisitorKeysMap } from './visitor-keys';
 
 export type Option<T> = T | null;
 
@@ -212,8 +212,7 @@ export type NodeType = keyof Nodes;
 export type Node = Nodes[NodeType];
 
 // VisitorKeysMap drives ParentNode and LeafNode typing
-export type ValuesOfType<T, U> = { [K in keyof T]: T[K] extends U ? T[K] : never }[keyof T];
-export type ChildKeyByNodeType = { [T in NodeType]: ValuesOfType<VisitorKeysMap[T], string> };
+export type ChildKeyByNodeType = { [T in keyof VisitorKeysMap]: typeof visitorKeys[T][number] };
 
 // All potential child keys, e.g. `body`, `value`, `path`, ...
 export type ChildKey = ChildKeyByNodeType[NodeType];

--- a/packages/@glimmer/syntax/lib/types/visitor-keys.ts
+++ b/packages/@glimmer/syntax/lib/types/visitor-keys.ts
@@ -1,31 +1,37 @@
-import { VisitorKeysMap } from './nodes';
+function tuple(): never[];
+function tuple<T extends string[]>(...args: T): T;
+function tuple<T>(...args: T[]): T[] {
+  return args;
+}
 
 // ensure stays in sync with typing
 // ParentNode and ChildKey types are derived from VisitorKeysMap
-const visitorKeys: VisitorKeysMap = {
-  Program: ['body'],
-  MustacheStatement: ['path', 'params', 'hash'],
-  BlockStatement: ['path', 'params', 'hash', 'program', 'inverse'],
-  ElementModifierStatement: ['path', 'params', 'hash'],
-  PartialStatement: ['name', 'params', 'hash'],
-  CommentStatement: [],
-  MustacheCommentStatement: [],
-  ElementNode: ['attributes', 'modifiers', 'children', 'comments'],
-  AttrNode: ['value'],
-  TextNode: [],
+const visitorKeys = {
+  Program: tuple('body'),
+  MustacheStatement: tuple('path', 'params', 'hash'),
+  BlockStatement: tuple('path', 'params', 'hash', 'program', 'inverse'),
+  ElementModifierStatement: tuple('path', 'params', 'hash'),
+  PartialStatement: tuple('name', 'params', 'hash'),
+  CommentStatement: tuple(),
+  MustacheCommentStatement: tuple(),
+  ElementNode: tuple('attributes', 'modifiers', 'children', 'comments'),
+  AttrNode: tuple('value'),
+  TextNode: tuple(),
 
-  ConcatStatement: ['parts'],
-  SubExpression: ['path', 'params', 'hash'],
-  PathExpression: [],
+  ConcatStatement: tuple('parts'),
+  SubExpression: tuple('path', 'params', 'hash'),
+  PathExpression: tuple(),
 
-  StringLiteral: [],
-  BooleanLiteral: [],
-  NumberLiteral: [],
-  NullLiteral: [],
-  UndefinedLiteral: [],
+  StringLiteral: tuple(),
+  BooleanLiteral: tuple(),
+  NumberLiteral: tuple(),
+  NullLiteral: tuple(),
+  UndefinedLiteral: tuple(),
 
-  Hash: ['pairs'],
-  HashPair: ['value'],
+  Hash: tuple('pairs'),
+  HashPair: tuple('value'),
 };
 
 export default visitorKeys;
+
+export type VisitorKeysMap = typeof visitorKeys;

--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -26,7 +26,7 @@ export class TestDynamicScope implements DynamicScope {
     return this.bucket[key];
   }
 
-  set(key: string, reference: PathReference<Opaque>) {
+  set(key: string, reference: PathReference<Opaque>): PathReference<Opaque> {
     return (this.bucket[key] = reference);
   }
 

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -157,7 +157,7 @@ export default class EagerRenderDelegate implements RenderDelegate {
     };
   }
 
-  getSelf(context: Opaque) {
+  getSelf(context: Opaque): UpdatableReference<Opaque> {
     return new UpdatableReference(context);
   }
 

--- a/packages/@glimmer/test-helpers/lib/helpers.ts
+++ b/packages/@glimmer/test-helpers/lib/helpers.ts
@@ -319,14 +319,15 @@ export function assertNodeTagName<
   U extends ElementTagNameMap[T]
 >(node: any, tagName: T): node is U {
   if (assertIsElement(node)) {
+    const lowerTagName = tagName.toLowerCase();
     const nodeTagName = node.tagName.toLowerCase();
     QUnit.assert.pushResult({
-      result: nodeTagName === tagName,
+      result: nodeTagName === lowerTagName,
       expected: tagName,
       actual: nodeTagName,
       message: `expected tagName to be ${tagName} but was ${nodeTagName}`,
     });
-    return nodeTagName === tagName;
+    return nodeTagName === lowerTagName;
   }
   return false;
 }

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -649,7 +649,7 @@ export class RehydrationDelegate implements RenderDelegate {
     return this.serialize(element);
   }
 
-  getSelf(context: Opaque) {
+  getSelf(context: Opaque): UpdatableReference<Opaque> {
     return new UpdatableReference(context);
   }
 
@@ -993,13 +993,13 @@ export function renderTemplate(
   env: LazyTestEnvironment,
   self: PathReference<Opaque>,
   builder: ElementBuilder
-) {
+): RenderResult<Opaque> {
   let template = env.preprocess(src);
   let iterator = env.renderMain(template, self, builder);
   return renderSync(env, iterator);
 }
 
-export function renderSync(env: Environment, iterator: TemplateIterator) {
+export function renderSync(env: Environment, iterator: TemplateIterator): RenderResult<Opaque> {
   env.begin();
 
   let iteratorResult: IteratorResult<RenderResult>;

--- a/packages/@glimmer/test-helpers/lib/suites/initial-render.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/initial-render.ts
@@ -630,7 +630,7 @@ export class InitialRenderSuite extends RenderTest {
       this.assert.equal(svg.namespaceURI, SVG_NAMESPACE);
 
       let foreignObject = svg.firstChild!;
-      if (assertNodeTagName(foreignObject, 'foreignobject')) {
+      if (assertNodeTagName(foreignObject, 'foreignObject')) {
         this.assert.equal(
           foreignObject.namespaceURI,
           SVG_NAMESPACE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -397,11 +397,6 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-array-binsearch@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/array-binsearch/-/array-binsearch-1.0.1.tgz#35586dca04ca9ab259c4c4708435acd1babb08ad"
-  integrity sha1-NVhtygTKmrJZxMRwhDWs0bq7CK0=
-
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
@@ -2161,19 +2156,18 @@ broccoli-string-replace@0.1.1:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^2.0.8"
 
-broccoli-typescript-compiler@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/broccoli-typescript-compiler/-/broccoli-typescript-compiler-2.3.0.tgz#7922a553b55055138ae0d8b76abec0580d254dd0"
-  integrity sha1-eSKlU7VQVROK4Ni3ar7AWA0lTdA=
+broccoli-typescript-compiler@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-typescript-compiler/-/broccoli-typescript-compiler-4.1.0.tgz#8511b73a7b019f6b6267679df64e211ca65ba036"
+  integrity sha512-pz+hQMlfwvklezPB1K4COYdf5SIQX6Dl4bdLX/R0uTNEJAwVa3Is/4YSXXm2L+LQdfMCZSXzqjbC5AGgvdbB6A==
   dependencies:
-    array-binsearch "^1.0.1"
     broccoli-funnel "^2.0.1"
-    broccoli-merge-trees "^2.0.0"
+    broccoli-merge-trees "^3.0.0"
     broccoli-plugin "^1.3.0"
     fs-tree-diff "^0.5.7"
     heimdalljs "0.3.3"
     md5-hex "^2.0.0"
-    typescript "~2.8.3"
+    typescript "~3.2.1"
     walk-sync "^0.3.2"
 
 broccoli-uglify-sourcemap@^1.0.1:
@@ -9942,10 +9936,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
-  integrity sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==
+typescript@~3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR attempts to update the `broccoli-typescript-compiler` dependency to v4.1.0, which internally updates TypeScript from v2.8.3 to v3.2.2. This results in a few different types of errors, most of which got resolved by #889 already. There are two types of errors remaining:

- use of `foreignobject` instead of `foreignObject` as a tag name string (fixed in this PR)
- broken type declarations in `@glimmer/syntax/lib/types/nodes.ts` (I've spent 2-3 hours trying to get this to work but still fail to understand how this is supposed to work)

I've given up trying to fix the `nodes.ts` issue,  which is why I opened this PR as WIP.

@krisselden according to git you wrote the type declarations in that file. would be great if you could have a look.

This PR will be needed to unblock https://github.com/emberjs/ember.js/pull/17298

**UPDATE:** After another 2 hours, I seem to have found a solution to the `nodes.ts` issues. Afterward, I also discovered other issues which are fixed by #896, #895 and two more commits in this PR.

/cc @tomdale @rwjblue 