### PR TITLE
Fix self-imports

### DIFF
--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -1,8 +1,7 @@
-import { Maybe, Opaque, Option } from './core';
-import { BlockSymbolTable, ProgramSymbolTable, SymbolTable } from './tier1/symbol-table';
+import { Opaque, Option } from './core';
+import { BlockSymbolTable, SymbolTable } from './tier1/symbol-table';
 import ComponentCapabilities from './component-capabilities';
 import { CompileTimeConstants } from './program';
-import { ComponentDefinition } from './components';
 import { CompilableProgram } from './serialize';
 import {
   Statement,
@@ -12,7 +11,6 @@ import {
   Core,
   SerializedInlineBlock,
 } from '@glimmer/wire-format';
-import { CompileTimeProgram } from '@glimmer/interfaces';
 
 export type CompilableBlock = CompilableTemplate<BlockSymbolTable>;
 

--- a/packages/@glimmer/opcode-compiler/lib/template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/template.ts
@@ -9,7 +9,7 @@ import { assign } from '@glimmer/util';
 import { SerializedTemplateBlock, SerializedTemplateWithLazyBlock } from '@glimmer/wire-format';
 import { CompilableProgram as CompilableProgramInstance } from './compilable-template';
 import { WrappedBuilder } from './wrapped-component';
-import { LazyCompiler } from '@glimmer/opcode-compiler';
+import { LazyCompiler } from './lazy';
 
 export interface TemplateFactory<Locator> {
   /**


### PR DESCRIPTION
TypeScript 3.x will scream about importing from yourself with absolute paths, e.g. `import foo from 'bar'` when used inside the `bar` package.

This PR resolves these cases by
- replacing with a relative import
- removing unused imports