### PR TITLE
Ensure positionals are passed when prepareArgs is false

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder.ts
@@ -774,7 +774,7 @@ export abstract class OpcodeBuilder<Locator = Opaque> extends StdOpcodeBuilder {
 
     if (capabilities.createArgs) {
       this.pushFrame();
-      this.compileArgs(null, hash, null, synthetic);
+      this.compileArgs(params, hash, null, synthetic);
     }
 
     this.beginComponentTransaction();

--- a/packages/@glimmer/test-helpers/lib/environment/components/basic-curly.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/components/basic-curly.ts
@@ -1,0 +1,135 @@
+import {
+  CapturedArguments,
+  ComponentManager,
+  WithStaticLayout,
+  Environment,
+  Arguments,
+  Invocation,
+} from '@glimmer/runtime';
+import { Opaque, ComponentCapabilities, Dict } from '@glimmer/interfaces';
+import { PathReference, Tag, combine, DirtyableTag, TagWrapper } from '@glimmer/reference';
+import { UpdatableReference } from '@glimmer/object-reference';
+import { Destroyable } from '@glimmer/util';
+
+import { createTemplate } from '../shared';
+import { BASIC_CAPABILITIES } from './basic';
+import { TestComponentDefinitionState } from '../components';
+import LazyRuntimeResolver from '../modes/lazy/runtime-resolver';
+import EagerRuntimeResolver from '../modes/eager/runtime-resolver';
+import {} from '@glimmer/bundle-compiler';
+
+export type BasicCurlyArgs = {
+  named: Dict<Opaque>;
+  positional: Opaque[];
+};
+
+export const BASIC_CURLY_CAPABILITIES = {
+  ...BASIC_CAPABILITIES,
+  createArgs: true,
+  updateHook: true,
+};
+
+export interface BasicCurlyComponentState {
+  args: CapturedArguments;
+  component: BasicCurlyComponent;
+}
+
+export class BasicCurlyComponentManager
+  implements
+    ComponentManager<BasicCurlyComponentState, TestComponentDefinitionState>,
+    WithStaticLayout<
+      BasicCurlyComponentState,
+      TestComponentDefinitionState,
+      Opaque,
+      LazyRuntimeResolver
+    > {
+  getCapabilities(state: TestComponentDefinitionState): ComponentCapabilities {
+    return state.capabilities;
+  }
+
+  prepareArgs(): null {
+    return null;
+  }
+
+  create(
+    _environment: Environment,
+    definition: TestComponentDefinitionState,
+    _args: Arguments,
+    _dynamicScope: any,
+    _callerSelf: PathReference<Opaque>,
+    _hasDefaultBlock: boolean
+  ): BasicCurlyComponentState {
+    let args = _args.capture();
+    let klass: typeof BasicCurlyComponent = definition.ComponentClass || BaseBasicCurlyComponent;
+    let invocationArgs = { named: args.named.value(), positional: args.positional.value() };
+    let component = new klass(invocationArgs);
+
+    return { args, component };
+  }
+
+  getTag({ args: { tag }, component: { dirtinessTag } }: BasicCurlyComponentState): Tag {
+    return combine([tag, dirtinessTag]);
+  }
+
+  getLayout(
+    state: TestComponentDefinitionState,
+    resolver: LazyRuntimeResolver | EagerRuntimeResolver
+  ): Invocation {
+    let { name, locator } = state;
+    if (resolver instanceof LazyRuntimeResolver) {
+      let compile = (source: string) => {
+        let template = createTemplate(source);
+        let layout = template.create(resolver.compiler).asLayout();
+
+        return {
+          handle: layout.compile(),
+          symbolTable: layout.symbolTable,
+        };
+      };
+
+      let handle = resolver.lookup('template-source', name)!;
+
+      return resolver.compileTemplate(handle, name, compile);
+    }
+
+    return resolver.getInvocation(locator.meta);
+  }
+
+  getSelf({ component }: BasicCurlyComponentState): PathReference<Opaque> {
+    return new UpdatableReference(component);
+  }
+
+  didCreateElement(): void {}
+  didRenderLayout(): void {}
+  didCreate(): void {}
+
+  update({ args, component }: BasicCurlyComponentState): void {
+    component.args = { named: args.named.value(), positional: args.positional.value() };
+    component.recompute();
+  }
+
+  didUpdateLayout(): void {}
+  didUpdate(): void {}
+
+  getDestructor({ component }: BasicCurlyComponentState): Destroyable {
+    return {
+      destroy() {
+        component.destroy();
+      },
+    };
+  }
+}
+
+export class BasicCurlyComponent {
+  public dirtinessTag: TagWrapper<DirtyableTag> = DirtyableTag.create();
+
+  constructor(public args: BasicCurlyArgs) {}
+
+  recompute() {
+    this.dirtinessTag.inner.dirty();
+  }
+
+  destroy() {}
+}
+
+const BaseBasicCurlyComponent = class extends BasicCurlyComponent {};

--- a/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/eager/render-delegate.ts
@@ -61,6 +61,11 @@ import {
   TestModifierManager,
 } from '../../modifier';
 import { Locator } from '../../components';
+import {
+  BasicCurlyComponent,
+  BasicCurlyComponentManager,
+  BASIC_CURLY_CAPABILITIES,
+} from '../../components/basic-curly';
 
 export type RenderDelegateComponentDefinition = ComponentDefinition<TestComponentDefinitionState>;
 
@@ -68,6 +73,7 @@ type Entries<T> = { [F in ComponentKind]: Option<T> };
 
 const COMPONENT_CLASSES: Entries<Opaque> = {
   Basic: BasicComponent,
+  BasicCurly: BasicCurlyComponent,
   Glimmer: EmberishGlimmerComponent,
   Dynamic: EmberishCurlyComponent,
   Curly: EmberishCurlyComponent,
@@ -76,6 +82,7 @@ const COMPONENT_CLASSES: Entries<Opaque> = {
 
 const COMPONENT_MANAGERS: Entries<ComponentManager<Opaque, Opaque>> = {
   Basic: new BasicComponentManager(),
+  BasicCurly: new BasicCurlyComponentManager(),
   Glimmer: new EmberishGlimmerComponentManager(),
   Dynamic: new EmberishCurlyComponentManager(),
   Curly: new EmberishCurlyComponentManager(),
@@ -84,6 +91,7 @@ const COMPONENT_MANAGERS: Entries<ComponentManager<Opaque, Opaque>> = {
 
 const COMPONENT_CAPABILITIES: Entries<ComponentCapabilities> = {
   Basic: BASIC_CAPABILITIES,
+  BasicCurly: BASIC_CURLY_CAPABILITIES,
   Glimmer: EMBERISH_GLIMMER_CAPABILITIES,
   Dynamic: EMBERISH_CURLY_CAPABILITIES,
   Curly: EMBERISH_CURLY_CAPABILITIES,

--- a/packages/@glimmer/test-helpers/lib/environment/modes/lazy/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment/modes/lazy/environment.ts
@@ -67,8 +67,14 @@ import TestMacros from '../../macros';
 import { Opaque } from '@glimmer/util';
 import { PathReference } from '@glimmer/reference';
 import { TemplateMeta } from '@glimmer/wire-format';
+import {
+  BasicCurlyComponent,
+  BASIC_CURLY_CAPABILITIES,
+  BasicCurlyComponentManager,
+} from '../../components/basic-curly';
 
 const BASIC_COMPONENT_MANAGER = new BasicComponentManager();
+const BASIC_CURLY_COMPONENT_MANAGER = new BasicCurlyComponentManager();
 const EMBERISH_CURLY_COMPONENT_MANAGER = new EmberishCurlyComponentManager();
 const EMBERISH_GLIMMER_COMPONENT_MANAGER = new EmberishGlimmerComponentManager();
 const STATIC_TAGLESS_COMPONENT_MANAGER = new StaticTaglessComponentManager();
@@ -225,6 +231,25 @@ export default class LazyTestEnvironment extends TestEnvironment<TestMeta> {
       handle,
       ComponentClass,
       EMBERISH_GLIMMER_CAPABILITIES
+    );
+  }
+
+  registerBasicCurlyComponent(
+    name: string,
+    Component: Option<typeof BasicCurlyComponent>,
+    layoutSource: string
+  ): void {
+    let { handle } = this.registerTemplate(name, layoutSource);
+
+    let ComponentClass = Component || BasicCurlyComponent;
+
+    this.registerComponent(
+      name,
+      'BasicCurly',
+      BASIC_CURLY_COMPONENT_MANAGER,
+      handle,
+      ComponentClass,
+      BASIC_CURLY_CAPABILITIES
     );
   }
 

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -35,6 +35,7 @@ import {
 import RenderDelegate from './render-delegate';
 import { debugRehydration } from './environment/modes/rehydration/debug-builder';
 import { TestModifierConstructor } from './environment/modifier';
+import { BasicCurlyComponent } from './environment/components/basic-curly';
 
 export const OPEN: { marker: 'open-block' } = { marker: 'open-block' };
 export const CLOSE: { marker: 'close-block' } = { marker: 'close-block' };
@@ -75,7 +76,7 @@ export class VersionedObject implements Tagged {
   }
 }
 
-export type ComponentKind = 'Glimmer' | 'Curly' | 'Dynamic' | 'Basic' | 'Fragment';
+export type ComponentKind = 'Glimmer' | 'Curly' | 'Dynamic' | 'Basic' | 'Fragment' | 'BasicCurly';
 
 export interface ComponentBlueprint {
   layout: string;
@@ -175,6 +176,7 @@ export class RenderTest {
       case 'Glimmer':
         invocation = this.buildGlimmerComponent(blueprint);
         break;
+      case 'BasicCurly':
       case 'Curly':
         invocation = this.buildCurlyComponent(blueprint);
         break;
@@ -568,6 +570,7 @@ export const CLASSES = {
   Dynamic: EmberishCurlyComponent,
   Basic: BasicComponent,
   Fragment: BasicComponent,
+  BasicCurly: BasicCurlyComponent,
 };
 
 export type ComponentTypes = typeof CLASSES;
@@ -582,6 +585,9 @@ export function registerComponent<K extends ComponentKind>(
   switch (type) {
     case 'Glimmer':
       env.registerEmberishGlimmerComponent(name, Class as typeof EmberishGlimmerComponent, layout);
+      break;
+    case 'BasicCurly':
+      env.registerBasicCurlyComponent(name, Class as typeof BasicCurlyComponent, layout);
       break;
     case 'Curly':
       env.registerEmberishCurlyComponent(name, Class as typeof EmberishCurlyComponent, layout);
@@ -786,8 +792,8 @@ function isServerMarker(node: Simple.Node) {
 }
 
 export interface ComponentTestMeta {
-  kind?: 'glimmer' | 'curly' | 'dynamic' | 'basic' | 'fragment';
-  skip?: boolean | 'glimmer' | 'curly' | 'dynamic' | 'basic' | 'fragment';
+  kind?: 'glimmer' | 'curly' | 'dynamic' | 'basic' | 'fragment' | 'basic-curly';
+  skip?: boolean | 'glimmer' | 'curly' | 'dynamic' | 'basic' | 'fragment' | 'basic-curly';
 }
 
 function setTestingDescriptor(descriptor: PropertyDescriptor): void {
@@ -865,6 +871,7 @@ interface ComponentTests {
   dynamic: Function[];
   basic: Function[];
   fragment: Function[];
+  basicCurly: Function[];
 }
 
 function componentModule<D extends RenderDelegate, T extends RenderTest, E extends Environment>(
@@ -878,6 +885,7 @@ function componentModule<D extends RenderDelegate, T extends RenderTest, E exten
     dynamic: [],
     basic: [],
     fragment: [],
+    basicCurly: [],
   };
 
   function createTest(prop: string, test: any, skip?: boolean) {
@@ -957,6 +965,10 @@ function componentModule<D extends RenderDelegate, T extends RenderTest, E exten
 
       if (kind === 'basic') {
         tests.basic.push(createTest(prop, test));
+      }
+
+      if (kind === 'basic-curly') {
+        tests.basicCurly.push(createTest(prop, test));
       }
 
       if (kind === 'fragment') {

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -1,5 +1,6 @@
 import { RenderTest, test } from '../render-test';
 import { stripTight, EmberishGlimmerComponent } from '../../index';
+import { BasicCurlyComponent } from '../environment/components/basic-curly';
 
 export class FragmentComponents extends RenderTest {
   @test({
@@ -682,5 +683,54 @@ export class BasicComponents extends RenderTest {
 
     this.render('<Foo data-from-top />');
     this.assertHTML('<div data-from-qux data-from-bar data-from-foo data-from-top></div>');
+  }
+
+  @test({ kind: 'basic-curly' })
+  'creating a new basic curly component'() {
+    this.registerComponent('BasicCurly', 'MyComponent', '<div color="{{@color}}">{{yield}}</div>');
+
+    this.render(`{{#MyComponent color=color}}hello!{{/MyComponent}}`, {
+      color: 'red',
+    });
+
+    this.assertHTML(`<div color='red'>hello!</div>`);
+    this.assertStableRerender();
+
+    this.rerender({ color: 'green' });
+    this.assertHTML(`<div color='green'>hello!</div>`);
+    this.assertStableNodes();
+
+    this.rerender({ color: 'red' });
+    this.assertHTML(`<div color='red'>hello!</div>`);
+    this.assertStableNodes();
+  }
+
+  @test({ kind: 'basic-curly' })
+  'creating a new basic curly component with positional args'() {
+    this.registerComponent(
+      'BasicCurly',
+      'MyComponent',
+      '<div color="{{this.color}}">{{yield}}</div>',
+      class extends BasicCurlyComponent {
+        get color() {
+          return this.args.positional[0];
+        }
+      }
+    );
+
+    this.render(`{{#MyComponent color}}hello!{{/MyComponent}}`, {
+      color: 'red',
+    });
+
+    this.assertHTML(`<div color='red'>hello!</div>`);
+    this.assertStableRerender();
+
+    this.rerender({ color: 'green' });
+    this.assertHTML(`<div color='green'>hello!</div>`);
+    this.assertStableNodes();
+
+    this.rerender({ color: 'red' });
+    this.assertHTML(`<div color='red'>hello!</div>`);
+    this.assertStableNodes();
   }
 }


### PR DESCRIPTION
Without this change, it is not possible to have a custom component manager that provides positional args. Specifically when `prepareArgs` is set we always bail out of `invokeStaticComponent` and use `invokeComponent` instead, but when `prepareArgs` is `false` we _always_ compile args with positional of `null`.

TODO:

- [x] add tests....