### PR TITLE
Avoid duplicating the test type for each test.

### DIFF
--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -888,7 +888,7 @@ function componentModule<D extends RenderDelegate, T extends RenderTest, E exten
 
     return (type: ComponentKind, klass: RenderTestConstructor<D, T>) => {
       if (!shouldSkip) {
-        QUnit.test(`${type.toLowerCase()}: ${prop}`, assert => {
+        QUnit.test(`${prop}`, assert => {
           let instance = new klass(new Delegate());
           instance['testType'] = type;
           test.call(instance, assert);


### PR DESCRIPTION
Prior to this change, the test names for nearly all component tests were something akin to:

```
[NEW] [glimmer-runtime] Basic Components > TypeHere: typehere: creating a new basic curly component
```

```
[NEW] [glimmer-runtime] Basic Components > TypeHere: creating a new basic curly component
```