### PR TITLE
Expose template metadata to AST plugins

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -149,20 +149,20 @@ export default class BundleCompiler {
    * Adds the template source code for a component to the bundle.
    */
   addTemplateSource(_locator: ModuleLocator, templateSource: string): SerializedTemplateBlock {
-    let l = normalizeLocator(_locator);
+    let locator = normalizeLocator(_locator);
 
-    let block = this.preprocess(templateSource, { meta: { ...l }, plugins: { ast: this.plugins } });
-    this.context.compiledBlocks.set(l, block);
+    let block = this.preprocess(locator, templateSource);
+    this.context.compiledBlocks.set(locator, block);
 
     let layout = {
       block,
-      referrer: l,
+      referrer: locator,
       asPartial: false,
     };
 
     let template = compilable(layout);
 
-    this.addCompilableTemplate(l, template);
+    this.addCompilableTemplate(locator, template);
 
     return block;
   }
@@ -202,8 +202,8 @@ export default class BundleCompiler {
     };
   }
 
-  preprocess(input: string, options?: object): SerializedTemplateBlock {
-    options = options || { plugins: { ast: this.plugins } };
+  preprocess(locator: ModuleLocator, input: string): SerializedTemplateBlock {
+    let options = { meta: locator, plugins: { ast: this.plugins } };
     let ast = preprocess(input, options);
     let template = TemplateCompiler.compile(ast);
     return template.toJSON();
@@ -229,7 +229,7 @@ export default class BundleCompiler {
     let compilableTemplate = expect(
       this.context.compilableTemplates.get(locator),
       `Can't compile a template that wasn't already added to the bundle (${locator.name} @ ${
-      locator.module
+        locator.module
       })`
     );
 

--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -151,7 +151,7 @@ export default class BundleCompiler {
   addTemplateSource(_locator: ModuleLocator, templateSource: string): SerializedTemplateBlock {
     let l = normalizeLocator(_locator);
 
-    let block = this.preprocess(templateSource);
+    let block = this.preprocess(templateSource, { meta: { ...l }, plugins: { ast: this.plugins } });
     this.context.compiledBlocks.set(l, block);
 
     let layout = {
@@ -202,8 +202,9 @@ export default class BundleCompiler {
     };
   }
 
-  preprocess(input: string): SerializedTemplateBlock {
-    let ast = preprocess(input, { plugins: { ast: this.plugins } });
+  preprocess(input: string, options?: object): SerializedTemplateBlock {
+    options = options || { plugins: { ast: this.plugins } };
+    let ast = preprocess(input, options);
     let template = TemplateCompiler.compile(ast);
     return template.toJSON();
   }
@@ -228,7 +229,7 @@ export default class BundleCompiler {
     let compilableTemplate = expect(
       this.context.compilableTemplates.get(locator),
       `Can't compile a template that wasn't already added to the bundle (${locator.name} @ ${
-        locator.module
+      locator.module
       })`
     );
 

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -8,7 +8,7 @@ import { PathHead } from './compiler-ops';
 import { DEBUG } from '@glimmer/local-debug-flags';
 
 export interface CompileOptions {
-  meta: unknown;
+  meta?: unknown;
   customizeComponentName?(tag: string): string;
 }
 
@@ -537,7 +537,7 @@ function assertValidPartial(statement: AST.MustacheStatement) /* : expr */ {
   if (params && params.length !== 1) {
     throw new SyntaxError(
       `Partial found with no arguments. You must specify a template name. (on line ${
-        loc.start.line
+      loc.start.line
       })`,
       statement.loc
     );
@@ -549,7 +549,7 @@ function assertValidPartial(statement: AST.MustacheStatement) /* : expr */ {
   } else if (!escaped) {
     throw new SyntaxError(
       `{{{partial ...}}} is not supported, please use {{partial ...}} instead (on line ${
-        loc.start.line
+      loc.start.line
       })`,
       statement.loc
     );

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -537,7 +537,7 @@ function assertValidPartial(statement: AST.MustacheStatement) /* : expr */ {
   if (params && params.length !== 1) {
     throw new SyntaxError(
       `Partial found with no arguments. You must specify a template name. (on line ${
-      loc.start.line
+        loc.start.line
       })`,
       statement.loc
     );
@@ -549,7 +549,7 @@ function assertValidPartial(statement: AST.MustacheStatement) /* : expr */ {
   } else if (!escaped) {
     throw new SyntaxError(
       `{{{partial ...}}} is not supported, please use {{partial ...}} instead (on line ${
-      loc.start.line
+        loc.start.line
       })`,
       statement.loc
     );

--- a/packages/@glimmer/integration-tests/lib/modes/aot/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/aot/delegate.ts
@@ -183,7 +183,7 @@ export class AotRenderDelegate implements RenderDelegate {
       let symbolTable;
 
       if (state.type === 'Curly' || state.type === 'Dynamic') {
-        let block = bundleCompiler.preprocess(state.template!);
+        let block = bundleCompiler.preprocess(locator, state.template!);
         let parsedLayout = { block, referrer: locator, asPartial: false };
         let wrapped = new WrappedBuilder(parsedLayout);
         bundleCompiler.addCompilableTemplate(normalizeLocator(locator), wrapped);

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -160,7 +160,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     if (tag.type === 'EndTag') {
       throw new SyntaxError(
         `Invalid end tag: closing tag must not have attributes, ` +
-          `in \`${tag.name}\` (on line ${this.tokenizer.line}).`,
+        `in \`${tag.name}\` (on line ${this.tokenizer.line}).`,
         tag.loc
       );
     }
@@ -261,8 +261,8 @@ function assembleAttributeValue(
       } else {
         throw new SyntaxError(
           `An unquoted attribute value must be a string or a mustache, ` +
-            `preceeded by whitespace or a '=' character, and ` +
-            `followed by whitespace, a '>' character, or '/>' (on line ${line})`,
+          `preceeded by whitespace or a '=' character, and ` +
+          `followed by whitespace, a '>' character, or '/>' (on line ${line})`,
           b.loc(line, 0)
         );
       }
@@ -335,11 +335,12 @@ export interface ASTPlugin {
 }
 
 export interface ASTPluginEnvironment {
-  meta?: any;
+  meta?: object;
   syntax: Syntax;
 }
 
 export interface PreprocessOptions {
+  meta?: unknown;
   plugins?: {
     ast?: ASTPluginBuilder[];
   };

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -160,7 +160,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     if (tag.type === 'EndTag') {
       throw new SyntaxError(
         `Invalid end tag: closing tag must not have attributes, ` +
-        `in \`${tag.name}\` (on line ${this.tokenizer.line}).`,
+          `in \`${tag.name}\` (on line ${this.tokenizer.line}).`,
         tag.loc
       );
     }
@@ -261,8 +261,8 @@ function assembleAttributeValue(
       } else {
         throw new SyntaxError(
           `An unquoted attribute value must be a string or a mustache, ` +
-          `preceeded by whitespace or a '=' character, and ` +
-          `followed by whitespace, a '>' character, or '/>' (on line ${line})`,
+            `preceeded by whitespace or a '=' character, and ` +
+            `followed by whitespace, a '>' character, or '/>' (on line ${line})`,
           b.loc(line, 0)
         );
       }

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -6,6 +6,7 @@ import {
   ASTPluginEnvironment,
   ASTPluginBuilder,
 } from '@glimmer/syntax';
+import { ModuleLocator } from '../../interfaces';
 
 const { test } = QUnit;
 
@@ -136,4 +137,37 @@ test('AST plugins can be chained', assert => {
   });
 
   assert.equal(THIRD_PLUGIN.get(ast), true, 'return value from last AST transform is used');
+});
+
+test('AST plugins can access meta from environment', assert => {
+  assert.expect(2);
+
+  const locator: ModuleLocator = {
+    module: 'template/module/name',
+    name: 'default'
+  };
+
+  let hasExposedEnvMeta = (env: ASTPluginEnvironment) => {
+    return {
+      name: 'exposedMetaTemplateData',
+      visitor: {
+        Program() {
+          const { meta }: any = env;
+          const { module, name }: ModuleLocator = meta;
+          assert.equal(module, 'template/module/name', 'module was passed in the meta enviornment property');
+          assert.equal(name, 'default', 'name was passed in the meta enviornment property');
+        }
+      },
+    };
+  };
+
+  preprocess('<div></div>', {
+    meta: {
+      ...locator
+    },
+    plugins: {
+      ast: [hasExposedEnvMeta],
+    },
+  });
+
 });

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -7,6 +7,7 @@ import {
   ASTPluginBuilder,
 } from '@glimmer/syntax';
 import { ModuleLocator } from '../../interfaces';
+import { expect } from '../../util';
 
 const { test } = QUnit;
 
@@ -144,7 +145,7 @@ test('AST plugins can access meta from environment', assert => {
 
   const locator: ModuleLocator = {
     module: 'template/module/name',
-    name: 'default'
+    name: 'default',
   };
 
   let hasExposedEnvMeta = (env: ASTPluginEnvironment) => {
@@ -152,22 +153,23 @@ test('AST plugins can access meta from environment', assert => {
       name: 'exposedMetaTemplateData',
       visitor: {
         Program() {
-          const { meta }: any = env;
-          const { module, name }: ModuleLocator = meta;
-          assert.equal(module, 'template/module/name', 'module was passed in the meta enviornment property');
+          const { meta } = env;
+          const { module, name } = expect(meta as ModuleLocator, 'expected meta to not be null');
+          assert.equal(
+            module,
+            'template/module/name',
+            'module was passed in the meta enviornment property'
+          );
           assert.equal(name, 'default', 'name was passed in the meta enviornment property');
-        }
+        },
       },
     };
   };
 
   preprocess('<div></div>', {
-    meta: {
-      ...locator
-    },
+    meta: locator,
     plugins: {
       ast: [hasExposedEnvMeta],
     },
   });
-
 });

--- a/test/index.html
+++ b/test/index.html
@@ -33,7 +33,11 @@
         }
       }
 
-      Object.assign = null;
+      Object.assign = function() {
+        throw new Error(
+          'Unexpected use of Object.assign. Object.assign cannot be used because it is unavailable in IE11. This error was likely caused by using syntax like the spread operator ({ ...obj }) which transpiles to Object.assign. Please use alternate syntax that is compatible with IE11.'
+        );
+      };
 
       // Recursively merge all the dependencies for this configuration of
       // packages to ensure that we only inject each dependency once.


### PR DESCRIPTION
Based on @wondersloth's PR at https://github.com/glimmerjs/glimmer-vm/pull/910, this PR changes the BundleCompiler to pass the module locator as metadata to AST plugins when compiling in AOT mode. This allows AST plugins to vary their behavior based on the location of the template being compiled, as they can today in environments using the JIT compiler.

All of the work was done by @wondersloth, I just fixed some IE11 compatibility bugs.