### PR TITLE
Temporarily disable smoke test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,9 @@ jobs:
         - yarn problems
         - yarn tslint
         - yarn eslint
-
-    - name: Smoke Test
-
-      addons:
-        chrome: stable
-
-      script:
-        - yarn test:smoke
+    # Temporarily disabling the smoke test as it is causing timeouts on Travis
+    # - name: Smoke Test
+    #   addons:
+    #     chrome: stable
+    #   script:
+    #     - yarn test:smoke


### PR DESCRIPTION
This test is intermittently timing out even with the timeout extended to 120 seconds. It seems like this test is causing Chrome to hang in the Travis environment. Will need to investigate the root cause of this more.