### PR TITLE
Expose meta data to AST plugins environment

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -151,7 +151,7 @@ export default class BundleCompiler {
   addTemplateSource(_locator: ModuleLocator, templateSource: string): SerializedTemplateBlock {
     let l = normalizeLocator(_locator);
 
-    let block = this.preprocess(templateSource);
+    let block = this.preprocess(templateSource, { meta: { module: l.module, name: l.name }, plugins: { ast: this.plugins } });
     this.context.compiledBlocks.set(l, block);
 
     let layout = {
@@ -202,8 +202,9 @@ export default class BundleCompiler {
     };
   }
 
-  preprocess(input: string): SerializedTemplateBlock {
-    let ast = preprocess(input, { plugins: { ast: this.plugins } });
+  preprocess(input: string, options?: object): SerializedTemplateBlock {
+    options = options || { plugins: { ast: this.plugins } };
+    let ast = preprocess(input, options);
     let template = TemplateCompiler.compile(ast);
     return template.toJSON();
   }
@@ -228,7 +229,7 @@ export default class BundleCompiler {
     let compilableTemplate = expect(
       this.context.compilableTemplates.get(locator),
       `Can't compile a template that wasn't already added to the bundle (${locator.name} @ ${
-        locator.module
+      locator.module
       })`
     );
 

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -8,7 +8,7 @@ import { PathHead } from './compiler-ops';
 import { DEBUG } from '@glimmer/local-debug-flags';
 
 export interface CompileOptions {
-  meta: unknown;
+  meta?: unknown;
   customizeComponentName?(tag: string): string;
 }
 
@@ -537,7 +537,7 @@ function assertValidPartial(statement: AST.MustacheStatement) /* : expr */ {
   if (params && params.length !== 1) {
     throw new SyntaxError(
       `Partial found with no arguments. You must specify a template name. (on line ${
-        loc.start.line
+      loc.start.line
       })`,
       statement.loc
     );
@@ -549,7 +549,7 @@ function assertValidPartial(statement: AST.MustacheStatement) /* : expr */ {
   } else if (!escaped) {
     throw new SyntaxError(
       `{{{partial ...}}} is not supported, please use {{partial ...}} instead (on line ${
-        loc.start.line
+      loc.start.line
       })`,
       statement.loc
     );

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -160,7 +160,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     if (tag.type === 'EndTag') {
       throw new SyntaxError(
         `Invalid end tag: closing tag must not have attributes, ` +
-          `in \`${tag.name}\` (on line ${this.tokenizer.line}).`,
+        `in \`${tag.name}\` (on line ${this.tokenizer.line}).`,
         tag.loc
       );
     }
@@ -261,8 +261,8 @@ function assembleAttributeValue(
       } else {
         throw new SyntaxError(
           `An unquoted attribute value must be a string or a mustache, ` +
-            `preceeded by whitespace or a '=' character, and ` +
-            `followed by whitespace, a '>' character, or '/>' (on line ${line})`,
+          `preceeded by whitespace or a '=' character, and ` +
+          `followed by whitespace, a '>' character, or '/>' (on line ${line})`,
           b.loc(line, 0)
         );
       }
@@ -335,11 +335,12 @@ export interface ASTPlugin {
 }
 
 export interface ASTPluginEnvironment {
-  meta?: any;
+  meta?: object;
   syntax: Syntax;
 }
 
 export interface PreprocessOptions {
+  meta?: unknown;
   plugins?: {
     ast?: ASTPluginBuilder[];
   };

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -6,6 +6,7 @@ import {
   ASTPluginEnvironment,
   ASTPluginBuilder,
 } from '@glimmer/syntax';
+import { ModuleLocator } from '../../interfaces';
 
 const { test } = QUnit;
 
@@ -136,4 +137,38 @@ test('AST plugins can be chained', assert => {
   });
 
   assert.equal(THIRD_PLUGIN.get(ast), true, 'return value from last AST transform is used');
+});
+
+test('AST plugins can access meta from environment', assert => {
+  assert.expect(2);
+
+  const locator: ModuleLocator = {
+    module: 'template/module/name',
+    name: 'default'
+  };
+
+  let hasExposedEnvMeta = (env: ASTPluginEnvironment) => {
+    return {
+      name: 'exposedMetaTemplateData',
+      visitor: {
+        Program() {
+          const { meta }: any = env;
+          const { module, name }: ModuleLocator = meta;
+          assert.equal(module, 'template/module/name', 'module was passed in the meta enviornment property');
+          assert.equal(name, 'default', 'name was passed in the meta enviornment property');
+        }
+      },
+    };
+  };
+
+  preprocess('<div></div>', {
+    meta: {
+      module: locator.module,
+      name: locator.name
+    },
+    plugins: {
+      ast: [hasExposedEnvMeta],
+    },
+  });
+
 });


### PR DESCRIPTION
- Spread `ModuleLocator` attributes into `meta` property in `PreprocessOptions`.
  This is similar to `PrecompileOptions` existing use of `meta` attribute.
- Modify interface to allow for optional attribute to extend correctly.
- Wrote test to validate passing of meta data, that gets exposed in the env
  for AST plugins.