### PR TITLE
Fixed typo on method name; compilerModuleLocatorResolver

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
+++ b/packages/@glimmer/bundle-compiler/lib/bundle-compiler.ts
@@ -197,7 +197,7 @@ export default class BundleCompiler {
       main: this.context.stdlib.main,
       heap: this.context.heap.capture(this.context.stdlib) as SerializedHeap,
       pool: this.context.constants.toPool(),
-      table: this.compilerModuleLocatoresolver().getTable(),
+      table: this.compilerModuleLocatorResolver().getTable(),
       symbolTables,
     };
   }
@@ -208,7 +208,7 @@ export default class BundleCompiler {
     return template.toJSON();
   }
 
-  compilerModuleLocatoresolver(): BundleCompilerLookup<ModuleLocator> {
+  compilerModuleLocatorResolver(): BundleCompilerLookup<ModuleLocator> {
     return this.context.resolverDelegate;
   }
 
@@ -220,7 +220,7 @@ export default class BundleCompiler {
     // If this locator already has an assigned VM handle, it means we've already
     // compiled it. We need to skip compiling it again and just return the same
     // VM handle.
-    let vmHandle = this.compilerModuleLocatoresolver().getHandleByLocator(locator);
+    let vmHandle = this.compilerModuleLocatorResolver().getHandleByLocator(locator);
     if (vmHandle !== undefined) return vmHandle;
 
     // It's an error to try to compile a template that wasn't first added to the
@@ -237,7 +237,7 @@ export default class BundleCompiler {
     vmHandle = compilableTemplate.compile(syntaxCompilationContext(this.context, this.macros));
 
     // Index the locator by VM handle and vice versa for easy lookups.
-    this.compilerModuleLocatoresolver().setHandleByLocator(locator, vmHandle);
+    this.compilerModuleLocatorResolver().setHandleByLocator(locator, vmHandle);
 
     return vmHandle;
   }


### PR DESCRIPTION
- Renamed method from `compilerModuleLocatoresolver` to `compilerModuleLocatorResolver`