### PR TITLE
[BUGFIX] A failing test for rehydration of the <title> tag

### DIFF
--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -333,6 +333,28 @@ class Rehydration extends AbstractRehydrationTests {
   }
 
   @test
+  'title tag'() {
+    let template = '<title>{{pageTitle}}</title>';
+    this.renderServerSide(template, { pageTitle: 'kiwi' });
+    let b = blockStack();
+    this.assertHTML(strip`
+      ${b(0)}
+      <title>
+        kiwi
+      </title>
+      ${b(0)}
+    `);
+    this.renderClientSide(template, { pageTitle: 'kiwi' });
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertHTML(strip`
+      <title>
+        kiwi
+      </title>
+    `);
+    this.assertStableRerender();
+  }
+
+  @test
   'clearing bounds'() {
     let template = strip`
       {{#if isTrue}}


### PR DESCRIPTION
We have talked about special casing the title tag as we have done with `<svg>`, `{{!-- comments --}}` and `<!-- comment -->` see the conversations below.

A failing test for `<title>` tag

https://github.com/glimmerjs/glimmer-vm/issues/796
https://github.com/ember-fastboot/ember-cli-fastboot/issues/659