### PR TITLE
Use type generic for `scope()` function

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -472,7 +472,7 @@ export default abstract class VM<C extends JitOrAotBlock> implements PublicVM, I
     return this.elementStack;
   }
 
-  scope(): Scope<JitOrAotBlock> {
+  scope(): Scope<C> {
     return expect(this[STACKS].scope.current, 'expected scope on the scope stack');
   }
 


### PR DESCRIPTION
We're getting errors from TS downstream when trying to use `@glimmer/component` in Ember apps with TS, this change fixes them. I _believe_ it makes sense, based on my understanding of TS and generics, for scope to be the generic defined in the abstract class, but if I'm wrong I'm happy to make the correct change to fix (and learn more about how TS works 😄)