### PR TITLE
Add ability to pass in dynamic scope to render component apis

### DIFF
--- a/packages/@glimmer/integration-tests/lib/modes/aot/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/aot/delegate.ts
@@ -19,6 +19,7 @@ import {
   AotRuntimeContext,
   ConstantPool,
   ElementBuilder,
+  DynamicScope,
 } from '@glimmer/interfaces';
 import { WrappedBuilder } from '@glimmer/opcode-compiler';
 import { PathReference, UpdatableReference, StableState } from '@glimmer/reference';
@@ -250,7 +251,8 @@ export class AotRenderDelegate implements RenderDelegate {
   renderComponent(
     name: string,
     args: Dict<PathReference<unknown>>,
-    element: SimpleElement
+    element: SimpleElement,
+    dyanmicScope?: DynamicScope
   ): RenderResult {
     let bundleCompiler = this.getBundleCompiler();
     this.addRegisteredComponents(bundleCompiler);
@@ -259,7 +261,14 @@ export class AotRenderDelegate implements RenderDelegate {
     let cursor = { element, nextSibling: null };
     let runtime = this.getRuntimeContext(compilationResult);
     let builder = this.getElementBuilder(runtime.env, cursor);
-    let iterator = renderAotComponent(runtime, builder, compilationResult.main, name, args);
+    let iterator = renderAotComponent(
+      runtime,
+      builder,
+      compilationResult.main,
+      name,
+      args,
+      dyanmicScope
+    );
 
     return renderSync(runtime.env, iterator);
   }

--- a/packages/@glimmer/integration-tests/lib/suites/entry-point.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/entry-point.ts
@@ -1,4 +1,5 @@
-import { PrimitiveReference } from '@glimmer/runtime';
+import { PrimitiveReference, DefaultDynamicScope } from '@glimmer/runtime';
+import { ConstReference } from '@glimmer/reference';
 import { RenderTest, Count } from '../render-test';
 import { ComponentKind } from '../components/types';
 import { test } from '../test-decorator';
@@ -54,5 +55,19 @@ export class EntryPointTest extends RenderTest {
     let body = PrimitiveReference.create('text');
     delegate.renderComponent('Body', { body }, element);
     QUnit.assert.equal((element as Element).innerHTML, '<p>body text</p>');
+  }
+
+  @test
+  'supports passing in an initial dynamic context'() {
+    let delegate = new AotRenderDelegate();
+    delegate.registerComponent('Basic', 'Basic', 'Locale', `{{-get-dynamic-var "locale"}}`);
+
+    let element = delegate.getInitialElement();
+    let dynamicScope = new DefaultDynamicScope({
+      locale: new ConstReference('en_US'),
+    });
+    delegate.renderComponent('Locale', {}, element, dynamicScope);
+
+    QUnit.assert.equal((element as Element).innerHTML, 'en_US');
   }
 }

--- a/packages/@glimmer/runtime/lib/dynamic-scope.ts
+++ b/packages/@glimmer/runtime/lib/dynamic-scope.ts
@@ -5,7 +5,7 @@ import { PathReference } from '@glimmer/reference';
 export class DefaultDynamicScope implements DynamicScope {
   private bucket: any;
 
-  constructor(bucket = null) {
+  constructor(bucket: any = null) {
     if (bucket) {
       this.bucket = assign({}, bucket);
     } else {

--- a/packages/@glimmer/runtime/lib/dynamic-scope.ts
+++ b/packages/@glimmer/runtime/lib/dynamic-scope.ts
@@ -1,11 +1,11 @@
-import { DynamicScope } from '@glimmer/interfaces';
+import { DynamicScope, Dict } from '@glimmer/interfaces';
 import { assign } from '@glimmer/util';
 import { PathReference } from '@glimmer/reference';
 
 export class DefaultDynamicScope implements DynamicScope {
-  private bucket: any;
+  private bucket: Dict<PathReference>;
 
-  constructor(bucket: any = null) {
+  constructor(bucket?: Dict<PathReference>) {
     if (bucket) {
       this.bucket = assign({}, bucket);
     } else {

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -139,7 +139,7 @@ export function renderAotComponent<R>(
   args: RenderComponentArgs = {},
   dynamicScope: DynamicScope = new DefaultDynamicScope()
 ): TemplateIterator {
-  let vm = AotVM.empty(runtime, dynamicScope, { treeBuilder, handle: main });
+  let vm = AotVM.empty(runtime, { treeBuilder, handle: main, dynamicScope });
 
   const definition = expect(
     resolveComponent(vm.runtime.resolver, name),
@@ -170,7 +170,7 @@ export function renderJitComponent(
   args: RenderComponentArgs = {},
   dynamicScope: DynamicScope = new DefaultDynamicScope()
 ): TemplateIterator {
-  let vm = JitVM.empty(runtime, dynamicScope, { treeBuilder, handle: main }, context);
+  let vm = JitVM.empty(runtime, { treeBuilder, handle: main, dynamicScope }, context);
 
   const definition = expect(
     resolveComponent(vm.runtime.resolver, name),

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -136,9 +136,10 @@ export function renderAotComponent<R>(
   treeBuilder: ElementBuilder,
   main: number,
   name: string,
-  args: RenderComponentArgs = {}
+  args: RenderComponentArgs = {},
+  dynamicScope: DynamicScope = new DefaultDynamicScope()
 ): TemplateIterator {
-  let vm = AotVM.empty(runtime, { treeBuilder, handle: main });
+  let vm = AotVM.empty(runtime, dynamicScope, { treeBuilder, handle: main });
 
   const definition = expect(
     resolveComponent(vm.runtime.resolver, name),
@@ -166,9 +167,10 @@ export function renderJitComponent(
   context: SyntaxCompilationContext,
   main: number,
   name: string,
-  args: RenderComponentArgs = {}
+  args: RenderComponentArgs = {},
+  dynamicScope: DynamicScope = new DefaultDynamicScope()
 ): TemplateIterator {
-  let vm = JitVM.empty(runtime, { treeBuilder, handle: main }, context);
+  let vm = JitVM.empty(runtime, dynamicScope, { treeBuilder, handle: main }, context);
 
   const definition = expect(
     resolveComponent(vm.runtime.resolver, name),

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -612,9 +612,18 @@ export interface InitOptions extends MinimalInitOptions {
 export class AotVM extends VM<number> implements InternalVM<number> {
   static empty(
     runtime: AotRuntimeContext,
+    dynamicScope: DynamicScope,
     { handle, treeBuilder }: MinimalInitOptions
   ): InternalVM<number> {
-    let vm = initAOT(runtime, vmState(runtime.program.heap.getaddr(handle)), treeBuilder);
+    let vm = initAOT(
+      runtime,
+      vmState(
+        runtime.program.heap.getaddr(handle),
+        ScopeImpl.root<number>(UNDEFINED_REFERENCE, 0),
+        dynamicScope
+      ),
+      treeBuilder
+    );
     vm.pushUpdating();
     return vm;
   }
@@ -675,10 +684,19 @@ export class JitVM extends VM<CompilableBlock> implements InternalJitVM {
 
   static empty(
     runtime: JitRuntimeContext,
+    dynamicScope: DynamicScope,
     { handle, treeBuilder }: MinimalInitOptions,
     context: SyntaxCompilationContext
   ) {
-    let vm = initJIT(context)(runtime, vmState(runtime.program.heap.getaddr(handle)), treeBuilder);
+    let vm = initJIT(context)(
+      runtime,
+      vmState(
+        runtime.program.heap.getaddr(handle),
+        ScopeImpl.root<CompilableBlock>(UNDEFINED_REFERENCE, 0),
+        dynamicScope
+      ),
+      treeBuilder
+    );
     vm.pushUpdating();
     return vm;
   }

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -574,22 +574,10 @@ export default abstract class VM<C extends JitOrAotBlock> implements PublicVM, I
   }
 }
 
-const EMPTY_DYNAMIC_SCOPE: DynamicScope = {
-  get() {
-    return UNDEFINED_REFERENCE;
-  },
-  set() {
-    return UNDEFINED_REFERENCE;
-  },
-  child() {
-    return EMPTY_DYNAMIC_SCOPE;
-  },
-};
-
 function vmState<C extends JitOrAotBlock>(
   pc: number,
   scope: Scope<C> = ScopeImpl.root<C>(UNDEFINED_REFERENCE, 0),
-  dynamicScope: DynamicScope = EMPTY_DYNAMIC_SCOPE
+  dynamicScope: DynamicScope
 ) {
   return {
     pc,
@@ -602,18 +590,17 @@ function vmState<C extends JitOrAotBlock>(
 export interface MinimalInitOptions {
   handle: number;
   treeBuilder: ElementBuilder;
+  dynamicScope: DynamicScope;
 }
 
 export interface InitOptions extends MinimalInitOptions {
   self: PathReference<unknown>;
-  dynamicScope: DynamicScope;
 }
 
 export class AotVM extends VM<number> implements InternalVM<number> {
   static empty(
     runtime: AotRuntimeContext,
-    dynamicScope: DynamicScope,
-    { handle, treeBuilder }: MinimalInitOptions
+    { handle, treeBuilder, dynamicScope }: MinimalInitOptions
   ): InternalVM<number> {
     let vm = initAOT(
       runtime,
@@ -684,8 +671,7 @@ export class JitVM extends VM<CompilableBlock> implements InternalJitVM {
 
   static empty(
     runtime: JitRuntimeContext,
-    dynamicScope: DynamicScope,
-    { handle, treeBuilder }: MinimalInitOptions,
+    { handle, treeBuilder, dynamicScope }: MinimalInitOptions,
     context: SyntaxCompilationContext
   ) {
     let vm = initJIT(context)(


### PR DESCRIPTION
Currently only the renderMain API's have the ability to take in a DynamicScope as an argument. This PR extends that ability to the renderComponent API's as well.