### PR TITLE
Fix modifiers order

### DIFF
--- a/build/debug.js
+++ b/build/debug.js
@@ -24,6 +24,7 @@ write(
     '\n' +
     syscall.predicate
 );
+
 write(
   './packages/@glimmer/interfaces/lib/vm-opcodes.d.ts',
   machine.enumString + '\n\n' + syscall.enumString
@@ -62,6 +63,10 @@ ${contents}
   );
 }
 
+/*
+  Formats the string in accordance with our prettier rules to avoid
+  test failures.
+*/
 function format(file, contents) {
   let linter = new tslint.Linter({ fix: true });
   let config = tslint.Configuration.findConfiguration(
@@ -69,5 +74,9 @@ function format(file, contents) {
     __filename
   );
   linter.lint(file, contents, config.results);
-  linter.getResult();
+  let result = linter.getResult();
+
+  if (result.fixes.length === 0) {
+    fs.writeFileSync(file, contents, { encoding: 'utf8' });
+  }
 }

--- a/packages/@glimmer/compiler/lib/allocate-symbols.ts
+++ b/packages/@glimmer/compiler/lib/allocate-symbols.ts
@@ -169,8 +169,8 @@ export class SymbolAllocator
   text(_op: string) {}
   comment(_op: string) {}
   openComponent(_op: AST.ElementNode) {}
-  openElement(_op: AST.ElementNode) {}
-  openSplattedElement(_op: AST.ElementNode) {}
+  openElement(_op: [AST.ElementNode, boolean]) {}
+  openElementWithOperations(_op: AST.ElementNode) {}
   staticArg(_op: string) {}
   dynamicArg(_op: string) {}
   staticAttr(_op: [string, Option<string>]) {}

--- a/packages/@glimmer/compiler/lib/compiler-ops.ts
+++ b/packages/@glimmer/compiler/lib/compiler-ops.ts
@@ -13,10 +13,9 @@ export interface CompilerOps<Variable> {
   endBlock: null;
   text: string;
   comment: string;
-  openElement: AST.ElementNode;
+  openElement: [AST.ElementNode, boolean];
   openComponent: AST.ElementNode;
   openNamedBlock: AST.ElementNode;
-  openSplattedElement: AST.ElementNode;
   flushElement: AST.ElementNode;
   closeElement: AST.ElementNode;
   closeComponent: AST.ElementNode;

--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -283,7 +283,7 @@ export default class JavaScriptCompiler
     this.blocks.push(block);
   }
 
-  openSplattedElement(element: AST.ElementNode) {
+  openElement([element, simple]: [AST.ElementNode, boolean]) {
     let tag = element.tag;
 
     if (element.blockParams.length > 0) {
@@ -291,19 +291,7 @@ export default class JavaScriptCompiler
         `Compile Error: <${element.tag}> is not a component and doesn't support block parameters`
       );
     } else {
-      this.push([SexpOpcodes.OpenSplattedElement, tag]);
-    }
-  }
-
-  openElement(element: AST.ElementNode) {
-    let tag = element.tag;
-
-    if (element.blockParams.length > 0) {
-      throw new Error(
-        `Compile Error: <${element.tag}> is not a component and doesn't support block parameters`
-      );
-    } else {
-      this.push([SexpOpcodes.OpenElement, tag]);
+      this.push([SexpOpcodes.OpenElement, tag, simple]);
     }
   }
 

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -79,14 +79,18 @@ export default class TemplateCompiler {
 
   openElement([action]: [AST.ElementNode]) {
     let attributes = action.attributes;
-    let hasSplat = false;
+    let simple = true;
 
     for (let i = 0; i < attributes.length; i++) {
       let attr = attributes[i];
       if (attr.name === '...attributes') {
-        hasSplat = true;
+        simple = false;
         break;
       }
+    }
+
+    if (action.modifiers.length > 0) {
+      simple = false;
     }
 
     let actionIsComponent = false;
@@ -105,10 +109,8 @@ export default class TemplateCompiler {
     } else if (isComponent(action)) {
       this.opcode(['openComponent', action], action);
       actionIsComponent = true;
-    } else if (hasSplat) {
-      this.opcode(['openSplattedElement', action], action);
     } else {
-      this.opcode(['openElement', action], action);
+      this.opcode(['openElement', [action, simple]], action);
     }
 
     if (!isNamedBlock(action)) {
@@ -120,11 +122,11 @@ export default class TemplateCompiler {
           typeAttr = attrs[i];
           continue;
         }
-        this.attribute([attrs[i]], hasSplat || actionIsComponent);
+        this.attribute([attrs[i]], !simple || actionIsComponent);
       }
 
       if (typeAttr) {
-        this.attribute([typeAttr], hasSplat || actionIsComponent);
+        this.attribute([typeAttr], !simple || actionIsComponent);
       }
 
       for (let i = 0; i < action.modifiers.length; i++) {

--- a/packages/@glimmer/integration-tests/test/modifiers-test.ts
+++ b/packages/@glimmer/integration-tests/test/modifiers-test.ts
@@ -303,6 +303,52 @@ class ModifierTests extends RenderTest {
   }
 
   @test
+  'same element insertion order'(assert: Assert) {
+    let insertionOrder: string[] = [];
+
+    class Foo extends AbstractInsertable {
+      didInsertElement() {
+        insertionOrder.push('foo');
+      }
+    }
+
+    class Bar extends AbstractInsertable {
+      didInsertElement() {
+        insertionOrder.push('bar');
+      }
+    }
+    this.registerModifier('bar', Bar);
+    this.registerModifier('foo', Foo);
+
+    this.render('<div {{foo}} {{bar}}></div>');
+    assert.deepEqual(insertionOrder, ['foo', 'bar']);
+  }
+
+  @test
+  'same element destruction order'(assert: Assert) {
+    let destructionOrder: string[] = [];
+
+    class Foo extends AbstractDestroyable {
+      willDestroyElement() {
+        destructionOrder.push('foo');
+      }
+    }
+
+    class Bar extends AbstractDestroyable {
+      willDestroyElement() {
+        destructionOrder.push('bar');
+      }
+    }
+    this.registerModifier('bar', Bar);
+    this.registerModifier('foo', Foo);
+
+    this.render('{{#if nuke}}<div {{foo}} {{bar}}></div>{{/if}}', { nuke: true });
+    assert.deepEqual(destructionOrder, []);
+    this.rerender({ nuke: false });
+    assert.deepEqual(destructionOrder, ['foo', 'bar']);
+  }
+
+  @test
   'parent -> child insertion order'(assert: Assert) {
     let insertionOrder: string[] = [];
 

--- a/packages/@glimmer/integration-tests/test/modifiers-test.ts
+++ b/packages/@glimmer/integration-tests/test/modifiers-test.ts
@@ -321,7 +321,7 @@ class ModifierTests extends RenderTest {
     this.registerModifier('foo', Foo);
 
     this.render('<div {{foo}}><div {{bar}}></div></div>');
-    assert.deepEqual(insertionOrder, ['foo', 'bar']);
+    assert.deepEqual(insertionOrder, ['bar', 'foo']);
   }
 
   @test
@@ -345,7 +345,7 @@ class ModifierTests extends RenderTest {
     this.render('{{#if nuke}}<div {{foo}}><div {{bar}}></div></div>{{/if}}', { nuke: true });
     assert.deepEqual(destructionOrder, []);
     this.rerender({ nuke: false });
-    assert.deepEqual(destructionOrder, ['foo', 'bar']);
+    assert.deepEqual(destructionOrder, ['bar', 'foo']);
   }
 
   @test
@@ -374,7 +374,7 @@ class ModifierTests extends RenderTest {
     this.registerModifier('baz', Baz);
 
     this.render('<div {{foo}}><div {{bar}}></div><div {{baz}}></div></div>');
-    assert.deepEqual(insertionOrder, ['foo', 'bar', 'baz']);
+    assert.deepEqual(insertionOrder, ['bar', 'baz', 'foo']);
   }
 
   @test
@@ -407,7 +407,7 @@ class ModifierTests extends RenderTest {
     });
     assert.deepEqual(destructionOrder, []);
     this.rerender({ nuke: false });
-    assert.deepEqual(destructionOrder, ['foo', 'bar', 'baz']);
+    assert.deepEqual(destructionOrder, ['bar', 'baz', 'foo']);
   }
 
   @test

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -23,7 +23,6 @@ export const enum SexpOpcodes {
   Component = 5,
   DynamicComponent = 6,
   OpenElement = 7,
-  OpenSplattedElement = 8,
   FlushElement = 9,
   CloseElement = 10,
   StaticAttr = 11,
@@ -62,7 +61,6 @@ export interface SexpOpcodeMap {
   [SexpOpcodes.Component]: Statements.Component;
   [SexpOpcodes.DynamicComponent]: Statements.DynamicComponent;
   [SexpOpcodes.OpenElement]: Statements.OpenElement;
-  [SexpOpcodes.OpenSplattedElement]: Statements.SplatElement;
   [SexpOpcodes.FlushElement]: Statements.FlushElement;
   [SexpOpcodes.CloseElement]: Statements.CloseElement;
   [SexpOpcodes.StaticAttr]: Statements.StaticAttr;
@@ -163,8 +161,7 @@ export namespace Statements {
     Hash,
     Blocks
   ];
-  export type OpenElement = [SexpOpcodes.OpenElement, str];
-  export type SplatElement = [SexpOpcodes.OpenSplattedElement, str];
+  export type OpenElement = [SexpOpcodes.OpenElement, str, boolean];
   export type FlushElement = [SexpOpcodes.FlushElement];
   export type CloseElement = [SexpOpcodes.CloseElement];
   export type StaticAttr = [SexpOpcodes.StaticAttr, str, str, Option<str>];
@@ -191,7 +188,6 @@ export namespace Statements {
     | Component
     | DynamicComponent
     | OpenElement
-    | SplatElement
     | FlushElement
     | CloseElement
     | StaticAttr

--- a/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
@@ -12,6 +12,7 @@ import { ElementOperations, Environment } from '../runtime';
 import { GlimmerTreeConstruction, GlimmerTreeChanges } from './changes';
 import { Stack } from '../stack';
 import { LinkedList, LinkedListNode } from '../list';
+import { ModifierManager } from '@glimmer/interfaces';
 
 export interface LiveBlock extends Bounds {
   openElement(element: SimpleElement): void;
@@ -45,7 +46,7 @@ export interface DOMStack {
   popRemoteElement(): void;
   popElement(): void;
   openElement(tag: string, _operations?: ElementOperations): SimpleElement;
-  flushElement(): void;
+  flushElement(modifiers: Option<[ModifierManager, unknown][]>): void;
   appendText(string: string): SimpleText;
   appendComment(string: string): SimpleComment;
 
@@ -61,7 +62,8 @@ export interface DOMStack {
     isTrusting: boolean,
     namespace: Option<string>
   ): AttributeOperation;
-  closeElement(): void;
+
+  closeElement(): Option<[ModifierManager, unknown][]>;
 }
 
 export interface TreeOperations {

--- a/packages/@glimmer/interfaces/lib/runtime/element.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/element.d.ts
@@ -1,5 +1,6 @@
 import { VersionedReference } from '@glimmer/reference';
 import { Option } from '../core';
+import { ModifierManager } from '@glimmer/interfaces';
 
 export interface ElementOperations {
   setAttribute(
@@ -8,4 +9,6 @@ export interface ElementOperations {
     trusting: boolean,
     namespace: Option<string>
   ): void;
+
+  addModifier<S>(manager: ModifierManager<S>, state: S): void;
 }

--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -1,4 +1,4 @@
-import { Bounds, Environment, Option, ElementBuilder } from '@glimmer/interfaces';
+import { Bounds, Environment, Option, ElementBuilder, ModifierManager } from '@glimmer/interfaces';
 import { ConcreteBounds, NewElementBuilder } from '@glimmer/runtime';
 import { RemoteLiveBlock } from '@glimmer/runtime';
 import { SimpleElement, SimpleNode, SimpleText } from '@simple-dom/interface';
@@ -68,13 +68,13 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
     return super.__appendText(string);
   }
 
-  closeElement() {
+  closeElement(): Option<[ModifierManager, unknown][]> {
     if (NEEDS_EXTRA_CLOSE.has(this.element)) {
       NEEDS_EXTRA_CLOSE.delete(this.element);
       super.closeElement();
     }
 
-    super.closeElement();
+    return super.closeElement();
   }
 
   openElement(tag: string) {
@@ -86,7 +86,7 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
         // account for the insertion since it is injected here and not
         // really in the template.
         NEEDS_EXTRA_CLOSE.set(this.constructing!, true);
-        this.flushElement();
+        this.flushElement(null);
       }
     }
 

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -60,12 +60,13 @@ STATEMENTS.add(SexpOpcodes.TrustingComponentAttr, ([, name, value, namespace]) =
   op(Op.ComponentAttr, name, true, namespace),
 ]);
 
-STATEMENTS.add(SexpOpcodes.OpenElement, ([, tag]) => op(Op.OpenElement, tag));
-
-STATEMENTS.add(SexpOpcodes.OpenSplattedElement, ([, tag]) => [
-  op(Op.PutComponentOperations),
-  op(Op.OpenElement, tag),
-]);
+STATEMENTS.add(SexpOpcodes.OpenElement, ([, tag, simple]) => {
+  if (simple) {
+    return op(Op.OpenElement, tag);
+  } else {
+    return [op(Op.PutComponentOperations), op(Op.OpenElement, tag)];
+  }
+});
 
 STATEMENTS.add(SexpOpcodes.DynamicComponent, ([, definition, attrs, args, blocks]) => {
   return op('DynamicComponent', {

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -190,13 +190,13 @@ class TransactionImpl implements Transaction {
   }
 
   scheduleInstallModifier(modifier: unknown, manager: ModifierManager) {
-    this.scheduledInstallManagers.push(manager);
     this.scheduledInstallModifiers.push(modifier);
+    this.scheduledInstallManagers.push(manager);
   }
 
   scheduleUpdateModifier(modifier: unknown, manager: ModifierManager) {
-    this.scheduledUpdateModifierManagers.push(manager);
     this.scheduledUpdateModifiers.push(modifier);
+    this.scheduledUpdateModifierManagers.push(manager);
   }
 
   didDestroy(d: Drop) {
@@ -229,16 +229,16 @@ class TransactionImpl implements Transaction {
     let { scheduledInstallManagers, scheduledInstallModifiers } = this;
 
     for (let i = 0; i < scheduledInstallManagers.length; i++) {
-      let manager = scheduledInstallManagers[i];
       let modifier = scheduledInstallModifiers[i];
+      let manager = scheduledInstallManagers[i];
       manager.install(modifier);
     }
 
     let { scheduledUpdateModifierManagers, scheduledUpdateModifiers } = this;
 
     for (let i = 0; i < scheduledUpdateModifierManagers.length; i++) {
-      let manager = scheduledUpdateModifierManagers[i];
       let modifier = scheduledUpdateModifiers[i];
+      let manager = scheduledUpdateModifierManagers[i];
       manager.update(modifier);
     }
   }

--- a/packages/@glimmer/wire-format/lib/opcodes.ts
+++ b/packages/@glimmer/wire-format/lib/opcodes.ts
@@ -8,7 +8,7 @@ export enum Opcodes {
   Component,
   DynamicComponent,
   OpenElement,
-  OpenSplattedElement,
+  OpenElementWithOperations,
   FlushElement,
   CloseElement,
   StaticAttr,


### PR DESCRIPTION
This is probably not the "best" approach. We may revisit this in the future (e.g. turning "non-simple" elements into components, using the VM eval stack to thread this, etc) but this works for now. As an added bonus, it is a smaller set of changes for backporting purposes.