### PR TITLE
Fix printing of MustacheStatement with literal path

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -1,7 +1,6 @@
 import { Option } from '@glimmer/interfaces';
 import * as AST from '../types/nodes';
 import { voidMap } from '../parser/tokenizer-event-handlers';
-import { isLiteral } from '../utils';
 import { escapeText, escapeAttrValue } from './util';
 
 function unreachable(): never {
@@ -207,10 +206,6 @@ function pathParams(ast: AST.Node): string {
     case 'SubExpression':
     case 'ElementModifierStatement':
     case 'BlockStatement':
-      if (isLiteral(ast.path)) {
-        return String(ast.path.value);
-      }
-
       path = build(ast.path);
       break;
     case 'PartialStatement':

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -48,6 +48,18 @@ test('MustacheStatement: StringLiteral param', function() {
   printEqual('<h1>{{link-to "Foo"}}</h1>');
 });
 
+test('MustacheStatement: StringLiteral path', function() {
+  printEqual('<Panel @arg={{"Foo"}}></Panel>');
+});
+
+test('MustacheStatement: BooleanLiteral path', function() {
+  printEqual('<Panel @arg={{true}}></Panel>');
+});
+
+test('MustacheStatement: NumberLiteral path', function() {
+  printEqual('<Panel @arg={{5}}></Panel>');
+});
+
 test('MustacheStatement: hash', function() {
   printEqual('<h1>{{link-to "Foo" class="bar"}}</h1>');
 });


### PR DESCRIPTION
MustacheStatements with StringLiteral paths like:

```hbs
{{"foo"}}
```

Print as 

```hbs
{{foo}}
```

which is definitely not what you want.

Demonstration (thanks @turbo87) on ast explorer: https://astexplorer.net/#/gist/c6f6427272fb4c4ab5af92d63e29cc4c/4247bebaba608580fe996ed619df2ad6c34aab6f

It was only the StringLiteral case that was actually broken. But I also added tests for the BooleanLiteral and NumberLiteral case just to make sure I hadn't broken them.