### PR TITLE
glimmer-syntax: failing test for printing if/block statements and leading/trailing whitespace

### DIFF
--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -94,6 +94,10 @@ test('BlockStatement: multiline', function() {
   printEqual('<ul>{{#each foos as |foo index|}}\n  <li>{{foo}}: {{index}}</li>\n{{/each}}</ul>');
 });
 
+test('BlockStatement: leading-whitespace multiline', function() {
+  printEqual('<div>\n  {{#if foo}}\n    <div>hi</div>\n  {{/if}}\n</div>');
+});
+
 test('BlockStatement: inline', function() {
   printEqual('{{#if foo}}<p>{{foo}}</p>{{/if}}');
 });


### PR DESCRIPTION
The printer does not seem to preserve whitespace whenever an `{{#if}}` / block statement is involved. For example:

Expected:

```handlebars
<div>
  {{#if foo}}
    <div>hi</div>
  {{/if}}
</div>
```

Got:

```handlebars
<div>
{{#if foo}}  <div>hi</div>
{{/if}}</div>
```