### PR TITLE
Add `codemod` mode for @glimmer/syntax preparse.

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -7,10 +7,63 @@ function unreachable(): never {
   throw new Error('unreachable');
 }
 
-export default function build(ast: AST.Node): string {
+interface PrinterOptions {
+  entityEncoding: 'transformed' | 'raw';
+}
+
+export default function build(
+  ast: AST.Node,
+  options: PrinterOptions = { entityEncoding: 'transformed' }
+): string {
   if (!ast) {
     return '';
   }
+
+  function buildEach(asts: AST.Node[]): string[] {
+    return asts.map(node => build(node, options));
+  }
+
+  function pathParams(ast: AST.Node): string {
+    let path: string;
+
+    switch (ast.type) {
+      case 'MustacheStatement':
+      case 'SubExpression':
+      case 'ElementModifierStatement':
+      case 'BlockStatement':
+        path = build(ast.path, options);
+        break;
+      case 'PartialStatement':
+        path = build(ast.name, options);
+        break;
+      default:
+        return unreachable();
+    }
+
+    return compactJoin([path, buildEach(ast.params).join(' '), build(ast.hash, options)], ' ');
+  }
+
+  function compactJoin(array: Option<string>[], delimiter?: string): string {
+    return compact(array).join(delimiter || '');
+  }
+
+  function blockParams(block: AST.BlockStatement): Option<string> {
+    const params = block.program.blockParams;
+    if (params.length) {
+      return ` as |${params.join(' ')}|`;
+    }
+
+    return null;
+  }
+
+  function openBlock(block: AST.BlockStatement): string {
+    return ['{{#', pathParams(block), blockParams(block), '}}'].join('');
+  }
+
+  function closeBlock(block: any): string {
+    return ['{{/', build(block.path, options), '}}'].join('');
+  }
+
   const output: string[] = [];
 
   switch (ast.type) {
@@ -60,29 +113,33 @@ export default function build(ast: AST.Node): string {
       if (ast.value.type === 'TextNode') {
         if (ast.value.chars !== '') {
           output.push(ast.name, '=');
-          output.push('"', escapeAttrValue(ast.value.chars), '"');
+          output.push(
+            '"',
+            options.entityEncoding === 'raw' ? ast.value.chars : escapeAttrValue(ast.value.chars),
+            '"'
+          );
         } else {
           output.push(ast.name);
         }
       } else {
         output.push(ast.name, '=');
         // ast.value is mustache or concat
-        output.push(build(ast.value));
+        output.push(build(ast.value, options));
       }
       break;
     case 'ConcatStatement':
       output.push('"');
       ast.parts.forEach((node: AST.TextNode | AST.MustacheStatement) => {
         if (node.type === 'TextNode') {
-          output.push(escapeAttrValue(node.chars));
+          output.push(options.entityEncoding === 'raw' ? node.chars : escapeAttrValue(node.chars));
         } else {
-          output.push(build(node));
+          output.push(build(node, options));
         }
       });
       output.push('"');
       break;
     case 'TextNode':
-      output.push(escapeText(ast.chars));
+      output.push(options.entityEncoding === 'raw' ? ast.chars : escapeText(ast.chars));
       break;
     case 'MustacheStatement':
       {
@@ -120,13 +177,13 @@ export default function build(ast: AST.Node): string {
           lines.push(openBlock(ast));
         }
 
-        lines.push(build(ast.program));
+        lines.push(build(ast.program, options));
 
         if (ast.inverse) {
           if (!ast.inverse.chained) {
             lines.push('{{else}}');
           }
-          lines.push(build(ast.inverse));
+          lines.push(build(ast.inverse, options));
         }
 
         if (!ast.chained) {
@@ -171,7 +228,7 @@ export default function build(ast: AST.Node): string {
         output.push(
           ast.pairs
             .map(pair => {
-              return build(pair);
+              return build(pair, options);
             })
             .join(' ')
         );
@@ -179,7 +236,7 @@ export default function build(ast: AST.Node): string {
       break;
     case 'HashPair':
       {
-        output.push(`${ast.key}=${build(ast.value)}`);
+        output.push(`${ast.key}=${build(ast.value, options)}`);
       }
       break;
   }
@@ -194,49 +251,4 @@ function compact(array: Option<string>[]): string[] {
     }
   });
   return newArray;
-}
-
-function buildEach(asts: AST.Node[]): string[] {
-  return asts.map(build);
-}
-
-function pathParams(ast: AST.Node): string {
-  let path: string;
-
-  switch (ast.type) {
-    case 'MustacheStatement':
-    case 'SubExpression':
-    case 'ElementModifierStatement':
-    case 'BlockStatement':
-      path = build(ast.path);
-      break;
-    case 'PartialStatement':
-      path = build(ast.name);
-      break;
-    default:
-      return unreachable();
-  }
-
-  return compactJoin([path, buildEach(ast.params).join(' '), build(ast.hash)], ' ');
-}
-
-function compactJoin(array: Option<string>[], delimiter?: string): string {
-  return compact(array).join(delimiter || '');
-}
-
-function blockParams(block: AST.BlockStatement): Option<string> {
-  const params = block.program.blockParams;
-  if (params.length) {
-    return ` as |${params.join(' ')}|`;
-  }
-
-  return null;
-}
-
-function openBlock(block: AST.BlockStatement): string {
-  return ['{{#', pathParams(block), blockParams(block), '}}'].join('');
-}
-
-function closeBlock(block: any): string {
-  return ['{{/', build(block.path), '}}'].join('');
 }

--- a/packages/@glimmer/syntax/lib/parser.ts
+++ b/packages/@glimmer/syntax/lib/parser.ts
@@ -8,8 +8,6 @@ import * as HBS from './types/handlebars-ast';
 import { Option } from '@glimmer/interfaces';
 import { assert, expect } from '@glimmer/util';
 
-const entityParser = new EntityParser(namedCharRefs);
-
 export type Element = AST.Template | AST.Block | AST.ElementNode;
 
 export interface Tag<T extends 'StartTag' | 'EndTag'> {
@@ -39,10 +37,11 @@ export abstract class Parser {
   public currentNode: Option<
     AST.CommentStatement | AST.TextNode | Tag<'StartTag' | 'EndTag'>
   > = null;
-  public tokenizer = new EventedTokenizer(this, entityParser);
+  public tokenizer: EventedTokenizer;
 
-  constructor(source: string) {
+  constructor(source: string, entityParser = new EntityParser(namedCharRefs)) {
     this.source = source.split(/(?:\r\n?|\n)/g);
+    this.tokenizer = new EventedTokenizer(this, entityParser);
   }
 
   abstract Program(node: HBS.Program): HBS.Output<'Program'>;

--- a/packages/@glimmer/syntax/lib/types/nodes.ts
+++ b/packages/@glimmer/syntax/lib/types/nodes.ts
@@ -57,6 +57,8 @@ export interface Block extends CommonProgram {
   symbols?: BlockSymbols;
 }
 
+export type EntityEncodingState = 'transformed' | 'raw';
+
 export interface Template extends CommonProgram {
   type: 'Template';
   symbols?: Symbols;

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -1,162 +1,104 @@
-import { preprocess as parse, print, builders as b } from '@glimmer/syntax';
+import { preprocess as parse, print } from '@glimmer/syntax';
 
 const { test } = QUnit;
 
-function printTransform(template: string) {
-  return print(parse(template));
-}
+let templates = [
+  '<h1></h1>',
+  '<h1 class="foo" id="title"></h1>',
+  '<h1>Test</h1>',
+  '<h1>{{model.title}}</h1>',
+  '<h1>{{link-to "Foo" class="bar"}}</h1>',
+  '<h1 class={{if foo "foo" "bar"}}>Test</h1>',
+  '<h1 class={{color}}>Test</h1>',
+  '<h1 class="{{if active "active" "inactive"}} foo">Test</h1>',
+  '<p {{action "activate"}} {{someting foo="bar"}}>Test</p>',
+  '<p>{{my-component submit=(action (mut model.name) (full-name model.firstName "Smith"))}}</p>',
+  '<ul>{{#each foos as |foo index|}}\n  <li>{{foo}}: {{index}}</li>\n{{/each}}</ul>',
+  '{{#if foo}}<p>{{foo}}</p>{{/if}}',
+  '<Foo>{{bar}}</Foo>',
+  '<Foo></Foo>',
+  '<Foo />',
+  '<Foo as |bar|>{{bar}}</Foo>',
 
-function printEqual(template: string) {
-  QUnit.assert.equal(printTransform(template), template);
-}
+  '<input disabled />',
 
-QUnit.module('[glimmer-syntax] Code generation');
+  // void elements
+  '<br>',
+  '<br />',
 
-test('ElementNode: tag', function() {
-  printEqual('<h1></h1>');
+  // comments
+  '<!-- foo -->',
+  '<div {{!-- foo --}}></div>',
+  '<div>{{!-- foo bar --}}<b></b></div>',
+  '{{!-- {{foo-bar}} --}}',
+
+  // literals
+  '<Panel @arg={{"Foo"}}></Panel>',
+  '<Panel @arg={{true}}></Panel>',
+  '<Panel @arg={{5}}></Panel>',
+  '{{panel arg="Foo"}}',
+  '{{panel arg=true}}',
+  '{{panel arg=5}}',
+
+  // nested tags with indent
+  '<div>\n  <p>Test</p>\n</div>',
+
+  // attributes escaping
+  '<h1 class="foo" id="title" data-a="&quot;Foo&nbsp;&amp;&nbsp;Bar&quot;"></h1>',
+  '<h1 class="< &nbsp; {{if x "&" "<"}} &amp; &quot;">Test</h1>',
+
+  // slash in path
+  '{{namespace/foo "bar" baz="qux"}}',
+];
+
+QUnit.module('[glimmer-syntax] Code generation', function() {
+  function printTransform(template: string) {
+    return print(parse(template));
+  }
+
+  templates.forEach(template => {
+    test(`${template} is stable when printed`, function(assert) {
+      assert.equal(printTransform(template), template);
+    });
+  });
+
+  test('TextNode: chars escape - but do not match', assert => {
+    assert.equal(
+      printTransform('&lt; &amp; &nbsp; &gt; &copy;2018'),
+      '&lt; &amp; &nbsp; &gt; ©2018'
+    );
+  });
+
+  test('Handlebars comment', assert => {
+    assert.equal(printTransform('{{! foo }}'), '{{!-- foo --}}');
+  });
 });
 
-test('ElementNode: nested tags with indent', function() {
-  printEqual('<div>\n  <p>Test</p>\n</div>');
-});
+QUnit.module('[glimmer-syntax] Code generation - source -> source', function() {
+  function printTransform(template: string) {
+    let ast = parse(template, {
+      mode: 'codemod',
+      parseOptions: { ignoreStandalone: true },
+    });
 
-test('ElementNode: attributes', function() {
-  printEqual('<h1 class="foo" id="title"></h1>');
-});
+    return print(ast, { entityEncoding: 'raw' });
+  }
 
-test('ElementNode: attributes escaping', function() {
-  printEqual('<h1 class="foo" id="title" data-a="&quot;Foo&nbsp;&amp;&nbsp;Bar&quot;"></h1>');
-});
+  function buildTest(template: string) {
+    test(`${template} is stable when printed`, function(assert) {
+      assert.equal(printTransform(template), template);
+    });
+  }
 
-test('TextNode: chars escape', assert => {
-  assert.equal(printTransform('&lt; &amp; &nbsp; &gt; &copy;2018'), '&lt; &amp; &nbsp; &gt; ©2018');
-});
+  templates.forEach(buildTest);
 
-test('TextNode: chars', function() {
-  printEqual('<h1>Test</h1>');
-});
+  [
+    '&lt; &amp; &nbsp; &gt; &copy;2018',
 
-test('MustacheStatement: slash in path', function() {
-  printEqual('{{namespace/foo "bar" baz="qux"}}');
-});
+    // newlines after opening block
+    '{{#each}}\n  <li> foo </li>\n{{/each}}',
 
-test('MustacheStatement: path', function() {
-  printEqual('<h1>{{model.title}}</h1>');
-});
-
-test('MustacheStatement: StringLiteral param', function() {
-  printEqual('<h1>{{link-to "Foo"}}</h1>');
-});
-
-test('MustacheStatement: StringLiteral path', function() {
-  printEqual('<Panel @arg={{"Foo"}}></Panel>');
-});
-
-test('MustacheStatement: BooleanLiteral path', function() {
-  printEqual('<Panel @arg={{true}}></Panel>');
-});
-
-test('MustacheStatement: NumberLiteral path', function() {
-  printEqual('<Panel @arg={{5}}></Panel>');
-});
-
-test('MustacheStatement: hash', function() {
-  printEqual('<h1>{{link-to "Foo" class="bar"}}</h1>');
-});
-
-test('MustacheStatement: as element attribute', function() {
-  printEqual('<h1 class={{if foo "foo" "bar"}}>Test</h1>');
-});
-
-test('MustacheStatement: as element attribute with path', function() {
-  printEqual('<h1 class={{color}}>Test</h1>');
-});
-
-test('ConcatStatement: in element attribute string', function() {
-  printEqual('<h1 class="{{if active "active" "inactive"}} foo">Test</h1>');
-});
-
-test('ConcatStatement: in element attribute string escaping', function() {
-  printEqual('<h1 class="< &nbsp; {{if x "&" "<"}} &amp; &quot;">Test</h1>');
-});
-
-test('ElementModifierStatement', function() {
-  printEqual('<p {{action "activate"}} {{someting foo="bar"}}>Test</p>');
-});
-
-test('SubExpression', function() {
-  printEqual(
-    '<p>{{my-component submit=(action (mut model.name) (full-name model.firstName "Smith"))}}</p>'
-  );
-});
-
-test('BlockStatement: multiline', function() {
-  printEqual('<ul>{{#each foos as |foo index|}}\n  <li>{{foo}}: {{index}}</li>\n{{/each}}</ul>');
-});
-
-test('BlockStatement: inline', function() {
-  printEqual('{{#if foo}}<p>{{foo}}</p>{{/if}}');
-});
-
-test('UndefinedLiteral', assert => {
-  const ast = b.program([b.mustache(b.undefined())]);
-  assert.equal(print(ast), '{{undefined}}');
-});
-
-test('NumberLiteral', assert => {
-  const ast = b.program([b.mustache('foo', undefined, b.hash([b.pair('bar', b.number(5))]))]);
-  assert.equal(print(ast), '{{foo bar=5}}');
-});
-
-test('BooleanLiteral', assert => {
-  const ast = b.program([b.mustache('foo', undefined, b.hash([b.pair('bar', b.boolean(true))]))]);
-  assert.equal(print(ast), '{{foo bar=true}}');
-});
-
-test('HTML comment', function() {
-  printEqual('<!-- foo -->');
-});
-
-test('Handlebars comment', assert => {
-  assert.equal(printTransform('{{! foo }}'), '{{!-- foo --}}');
-});
-
-test('Handlebars comment: in ElementNode', function() {
-  printEqual('<div {{!-- foo --}}></div>');
-});
-
-test('Handlebars comment: in ElementNode children', function() {
-  printEqual('<div>{{!-- foo bar --}}<b></b></div>');
-});
-
-test('Handlebars in handlebar comment', function() {
-  printEqual('{{!-- {{foo-bar}} --}}');
-});
-
-test('Void elements', function() {
-  printEqual('<br>');
-});
-
-test('Void elements self closing', function() {
-  printEqual('<br />');
-});
-
-test('Angle bracket component', function() {
-  printEqual('<Foo>{{bar}}</Foo>');
-});
-
-test('Angle bracket component without content', function() {
-  printEqual('<Foo></Foo>');
-});
-
-test('Self-closing angle bracket component', function() {
-  printEqual('<Foo />');
-});
-
-test('Block params', function() {
-  printEqual('<Foo as |bar|>{{bar}}</Foo>');
-});
-
-test('Attributes without value', function() {
-  printEqual('<input disabled />');
+    // TODO: fix whitespace control in codemod mode
+    // '\n{{~#foo-bar~}} {{~/foo-bar~}}  ',
+  ].forEach(buildTest);
 });


### PR DESCRIPTION
Currently, setting `mode` to `'codemod'` will:

* Disable `entity` parsing in simple-html-tokenizer (ensures that parsing + printing is not lossy WRT entities)
* Enable `ignoreStandalone` mode in handlebars parser (ensures that standalone whitespace after a block opening or closing is not stripped).

In the future we can do other things to make the codemod world even better, but this is a really good first step (IMHO).