### PR TITLE
syntax/print: Fix self-closing angle bracket component invocations

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -48,6 +48,8 @@ export default function build(ast: AST.Node): string {
         }
 
         output.push('>');
+      } else if (ast.selfClosing) {
+        output.push(' />');
       } else {
         output.push('>');
         output.push.apply(output, buildEach(ast.children));

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -141,6 +141,18 @@ test('Void elements self closing', function() {
   printEqual('<br />');
 });
 
+test('Angle bracket component', function() {
+  printEqual('<Foo>{{bar}}</Foo>');
+});
+
+test('Angle bracket component without content', function() {
+  printEqual('<Foo></Foo>');
+});
+
+test('Self-closing angle bracket component', function() {
+  printEqual('<Foo />');
+});
+
 test('Block params', function() {
   printEqual('<Foo as |bar|>{{bar}}</Foo>');
 });


### PR DESCRIPTION
Previously `<Foo />` would have been printed as `<Foo></Foo>`. After this PR the printer uses the `selfClosing` property correctly and prints out `<Foo />`.

/cc @rwjblue @tylerturdenpants