### PR TITLE
syntax: Add support for `chained` inverse blocks

### DIFF
--- a/packages/@glimmer/syntax/lib/builders.ts
+++ b/packages/@glimmer/syntax/lib/builders.ts
@@ -457,12 +457,14 @@ function buildProgram(
 function buildBlockItself(
   body?: AST.Statement[],
   blockParams?: string[],
+  chained = false,
   loc?: AST.SourceLocation
 ): AST.Block {
   return {
     type: 'Block',
     body: body || [],
     blockParams: blockParams || [],
+    chained,
     loc: buildLoc(loc || null),
   };
 }

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -35,7 +35,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
     if (this.isTopLevel) {
       node = b.template(body, program.blockParams, program.loc);
     } else {
-      node = b.blockItself(body, program.blockParams, false, program.loc);
+      node = b.blockItself(body, program.blockParams, program.chained, program.loc);
     }
 
     let i,

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -35,7 +35,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
     if (this.isTopLevel) {
       node = b.template(body, program.blockParams, program.loc);
     } else {
-      node = b.blockItself(body, program.blockParams, program.loc);
+      node = b.blockItself(body, program.blockParams, false, program.loc);
     }
 
     let i,

--- a/packages/@glimmer/syntax/lib/types/handlebars-ast.ts
+++ b/packages/@glimmer/syntax/lib/types/handlebars-ast.ts
@@ -51,6 +51,7 @@ export interface Program extends CommonNode {
   type: 'Program';
   body: Statement[];
   blockParams: string[];
+  chained?: boolean;
 }
 
 export type Statement =

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -1,4 +1,4 @@
-import { preprocess as parse, print, AST } from '@glimmer/syntax';
+import { preprocess as parse, print } from '@glimmer/syntax';
 
 const { test } = QUnit;
 
@@ -15,6 +15,7 @@ let templates = [
   '<p>{{my-component submit=(action (mut model.name) (full-name model.firstName "Smith"))}}</p>',
   '<ul>{{#each foos as |foo index|}}\n  <li>{{foo}}: {{index}}</li>\n{{/each}}</ul>',
   '{{#if foo}}<p>{{foo}}</p>{{/if}}',
+  '{{#if foo}}Foo{{else if bar}}Bar{{else}}Baz{{/if}}',
   '<Foo>{{bar}}</Foo>',
   '<Foo></Foo>',
   '<Foo />',
@@ -71,15 +72,6 @@ QUnit.module('[glimmer-syntax] Code generation', function() {
 
   test('Handlebars comment', assert => {
     assert.equal(printTransform('{{! foo }}'), '{{!-- foo --}}');
-  });
-
-  test('BlockStatement: chained', function(assert) {
-    let ast = parse('{{#if foo}}Foo{{else if bar}}Bar{{else}}Baz{{/if}}');
-
-    // adjust the AST manually because the parser does not set `chained` yet
-    (ast.body[0] as AST.BlockStatement).inverse!.chained = true;
-
-    assert.equal(print(ast), '{{#if foo}}Foo{{else if bar}}Bar{{else}}Baz{{/if}}');
   });
 });
 

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -1,4 +1,4 @@
-import { preprocess as parse, print } from '@glimmer/syntax';
+import { preprocess as parse, print, AST } from '@glimmer/syntax';
 
 const { test } = QUnit;
 
@@ -71,6 +71,15 @@ QUnit.module('[glimmer-syntax] Code generation', function() {
 
   test('Handlebars comment', assert => {
     assert.equal(printTransform('{{! foo }}'), '{{!-- foo --}}');
+  });
+
+  test('BlockStatement: chained', function(assert) {
+    let ast = parse('{{#if foo}}Foo{{else if bar}}Bar{{else}}Baz{{/if}}');
+
+    // adjust the AST manually because the parser does not set `chained` yet
+    (ast.body[0] as AST.BlockStatement).inverse!.chained = true;
+
+    assert.equal(print(ast), '{{#if foo}}Foo{{else if bar}}Bar{{else}}Baz{{/if}}');
   });
 });
 

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -212,7 +212,7 @@ test('Simple embedded block helpers', function() {
         b.path('if'),
         [b.path('foo')],
         b.hash(),
-        b.program([b.element('div', ['body', b.mustache(b.path('content'))])])
+        b.blockItself([b.element('div', ['body', b.mustache(b.path('content'))])])
       ),
     ])
   );
@@ -230,7 +230,7 @@ test('Involved block helper', function() {
         b.path('testing'),
         [b.path('shouldRender')],
         b.hash(),
-        b.program([b.element('p', ['body', b.text('Appears!')])])
+        b.blockItself([b.element('p', ['body', b.text('Appears!')])])
       ),
       b.text(' more '),
       b.element('em', ['body', b.text('content')]),
@@ -291,13 +291,21 @@ test('Stripping - blocks', function() {
   let t = 'foo {{~#wat}}{{/wat}} bar';
   astEqual(
     t,
-    b.program([b.text('foo'), b.block(b.path('wat'), [], b.hash(), b.program()), b.text(' bar')])
+    b.program([
+      b.text('foo'),
+      b.block(b.path('wat'), [], b.hash(), b.blockItself()),
+      b.text(' bar'),
+    ])
   );
 
   t = 'foo {{#wat}}{{/wat~}} bar';
   astEqual(
     t,
-    b.program([b.text('foo '), b.block(b.path('wat'), [], b.hash(), b.program()), b.text('bar')])
+    b.program([
+      b.text('foo '),
+      b.block(b.path('wat'), [], b.hash(), b.blockItself()),
+      b.text('bar'),
+    ])
   );
 });
 
@@ -305,25 +313,33 @@ test('Stripping - programs', function() {
   let t = '{{#wat~}} foo {{else}}{{/wat}}';
   astEqual(
     t,
-    b.program([b.block(b.path('wat'), [], b.hash(), b.program([b.text('foo ')]), b.program())])
+    b.program([
+      b.block(b.path('wat'), [], b.hash(), b.blockItself([b.text('foo ')]), b.blockItself()),
+    ])
   );
 
   t = '{{#wat}} foo {{~else}}{{/wat}}';
   astEqual(
     t,
-    b.program([b.block(b.path('wat'), [], b.hash(), b.program([b.text(' foo')]), b.program())])
+    b.program([
+      b.block(b.path('wat'), [], b.hash(), b.blockItself([b.text(' foo')]), b.blockItself()),
+    ])
   );
 
   t = '{{#wat}}{{else~}} foo {{/wat}}';
   astEqual(
     t,
-    b.program([b.block(b.path('wat'), [], b.hash(), b.program(), b.program([b.text('foo ')]))])
+    b.program([
+      b.block(b.path('wat'), [], b.hash(), b.blockItself(), b.blockItself([b.text('foo ')])),
+    ])
   );
 
   t = '{{#wat}}{{else}} foo {{~/wat}}';
   astEqual(
     t,
-    b.program([b.block(b.path('wat'), [], b.hash(), b.program(), b.program([b.text(' foo')]))])
+    b.program([
+      b.block(b.path('wat'), [], b.hash(), b.blockItself(), b.blockItself([b.text(' foo')])),
+    ])
   );
 });
 
@@ -337,7 +353,7 @@ test('Stripping - removes unnecessary text nodes', function() {
         b.path('each'),
         [],
         b.hash(),
-        b.program([b.element('li', ['body', b.text(' foo ')])]),
+        b.blockItself([b.element('li', ['body', b.text(' foo ')])]),
         null
       ),
     ])
@@ -354,7 +370,7 @@ test('Whitespace control - linebreaks after blocks removed by default', function
         b.path('each'),
         [],
         b.hash(),
-        b.program([b.text('  '), b.element('li', ['body', b.text(' foo ')]), b.text('\n')]),
+        b.blockItself([b.text('  '), b.element('li', ['body', b.text(' foo ')]), b.text('\n')]),
         null
       ),
     ])
@@ -371,7 +387,7 @@ test('Whitespace control - preserve all whitespace if config is set', function()
         b.path('each'),
         [],
         b.hash(),
-        b.program([b.text('\n  '), b.element('li', ['body', b.text(' foo ')]), b.text('\n')]),
+        b.blockItself([b.text('\n  '), b.element('li', ['body', b.text(' foo ')]), b.text('\n')]),
         null
       ),
     ]),


### PR DESCRIPTION
It seems that some code was added lately to support the `chained` property of the Handlebars AST in the printer, but the parser was not correctly hooked up yet. This PR adds the missing pieces so that `else if` is correctly represented in the Glimmer AST now.

Since the `b.blockItself()` signature was changed this should be considered a breaking change.

Closes https://github.com/glimmerjs/glimmer-vm/pull/366

/cc @rwjblue @wycats 