### PR TITLE
feat:  performance improvements for keyed lists changes

### DIFF
--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -1,4 +1,4 @@
-import { LinkedList, ListNode, Option, expect } from '@glimmer/util';
+import { LinkedList, ListNode, Option } from '@glimmer/util';
 import { VersionedPathReference as PathReference, Tag } from './validators';
 
 export interface IterationItem<T, U> {
@@ -115,6 +115,16 @@ export class IterationArtifacts {
     return iterator;
   }
 
+  advanceToKey(key: unknown, current: ListItem): Option<ListItem> {
+    let seek = current;
+
+    while (seek !== null && seek.key !== key) {
+      seek = this.advanceNode(seek);
+    }
+
+    return seek;
+  }
+
   has(key: unknown): boolean {
     return this.map.has(key);
   }
@@ -126,6 +136,12 @@ export class IterationArtifacts {
   wasSeen(key: unknown): boolean {
     let node = this.map.get(key);
     return node !== undefined && node.seen;
+  }
+
+  update(item: OpaqueIterationItem): ListItem {
+    let found = this.get(item.key);
+    found.update(item);
+    return found;
   }
 
   append(item: OpaqueIterationItem): ListItem {
@@ -163,6 +179,11 @@ export class IterationArtifacts {
   }
 
   nextNode(item: ListItem): ListItem {
+    return this.list.nextNode(item);
+  }
+
+  advanceNode(item: ListItem): ListItem {
+    item.seen = true;
     return this.list.nextNode(item);
   }
 
@@ -263,23 +284,29 @@ export class IteratorSynchronizer<Env> {
   }
 
   private advanceToKey(key: unknown) {
-    let { current, artifacts, target } = this;
-    let seek = current;
+    let { current, artifacts } = this;
 
-    while (seek !== null && seek.key !== key) {
-      seek.seen = true;
-      seek = artifacts.nextNode(seek);
+    if (current === null) return;
+
+    let next = artifacts.advanceNode(current);
+
+    if (next.key === key) {
+      this.current = artifacts.advanceNode(next);
+      return;
     }
 
-    if (seek !== null) {
-      if (current && current.next === seek) {
-        this.current = artifacts.nextNode(seek);
-        return;
-      }
-      artifacts.move(seek, current);
-      target.move(this.env, seek.key, seek.value, seek.memo, current ? current.key : END);
+    let seek = artifacts.advanceToKey(key, current);
 
-      this.current = artifacts.nextNode(current as ListItem);
+    if (seek) {
+      this.move(seek, current);
+      this.current = artifacts.nextNode(current);
+    }
+  }
+
+  private move(item: ListItem, reference: Option<ListItem>) {
+    if (item.next !== reference) {
+      this.artifacts.move(item, reference);
+      this.target.move(this.env, item.key, item.value, item.memo, reference ? reference.key : END);
     }
   }
 
@@ -295,7 +322,7 @@ export class IteratorSynchronizer<Env> {
     let { key } = item;
 
     if (current !== null && current.key === key) {
-      this.nextRetain(item);
+      this.nextRetain(item, current);
     } else if (artifacts.has(key)) {
       this.nextMove(item);
     } else {
@@ -305,10 +332,10 @@ export class IteratorSynchronizer<Env> {
     return Phase.Append;
   }
 
-  private nextRetain(item: OpaqueIterationItem) {
-    let { artifacts, current } = this;
+  private nextRetain(item: OpaqueIterationItem, current: ListItem) {
+    let { artifacts } = this;
 
-    current = expect(current, 'BUG: current is empty');
+    // current = expect(current, 'BUG: current is empty');
 
     current.update(item);
     this.current = artifacts.nextNode(current);
@@ -316,18 +343,13 @@ export class IteratorSynchronizer<Env> {
   }
 
   private nextMove(item: OpaqueIterationItem) {
-    let { current, artifacts, target } = this;
+    let { current, artifacts } = this;
     let { key } = item;
 
-    let found = artifacts.get(item.key);
-    found.update(item);
+    let found = artifacts.update(item);
 
-    if (artifacts.wasSeen(item.key)) {
-      if (current && current.prev === found) {
-        return;
-      }
-      artifacts.move(found, current);
-      target.move(this.env, found.key, found.value, found.memo, current ? current.key : END);
+    if (artifacts.wasSeen(key)) {
+      this.move(found, current);
     } else {
       this.advanceToKey(key);
     }

--- a/packages/@glimmer/reference/test/iterable-test.ts
+++ b/packages/@glimmer/reference/test/iterable-test.ts
@@ -358,7 +358,7 @@ QUnit.test('When re-iterated via swap #1, the original references are updated', 
   );
   assert.equal(target.historyStats.move, 2, 'moved nodes count');
   assert.equal(target.historyStats.retain, 6, 'retained nodes count');
-  assert.deepEqual(target.toValues(), arr);
+  assert.deepEqual(target.toValues(), arr, 'the array is correct');
 });
 
 QUnit.test('When re-iterated via swap #2, the original references are updated', assert => {

--- a/packages/@glimmer/reference/test/iterable-test.ts
+++ b/packages/@glimmer/reference/test/iterable-test.ts
@@ -19,15 +19,41 @@ import { Option, LinkedList, ListNode } from '@glimmer/util';
 
 QUnit.module('Reference iterables');
 
+type IteratorAction = 'retain' | 'append' | 'insert' | 'move' | 'delete';
+type HistoryZip = [IteratorAction, any];
 class Target implements IteratorSynchronizerDelegate<null> {
   private map = new Map<unknown, ListNode<BasicReference<unknown>>>();
   private list = new LinkedList<ListNode<BasicReference<unknown>>>();
   public tag = CURRENT_TAG;
+  public history: HistoryZip[] = [];
+
+  cleanHistory() {
+    this.history = [];
+  }
+
+  serializeHistory() {
+    return this.history.map((item: any) => item.join(':')).join(',');
+  }
+
+  get historyStats() {
+    const stats = {
+      retain: 0,
+      append: 0,
+      insert: 0,
+      move: 0,
+      delete: 0,
+    };
+    this.history.forEach(([key]: HistoryZip) => {
+      stats[key]++;
+    });
+    return stats;
+  }
 
   retain(_env: null, key: unknown, item: BasicReference<unknown>) {
     if (item !== this.map.get(key)!.value) {
       throw new Error('unstable reference');
     }
+    this.history.push(['retain', key]);
   }
 
   done() {}
@@ -36,6 +62,7 @@ class Target implements IteratorSynchronizerDelegate<null> {
     let node = new ListNode(item);
     this.map.set(key, node);
     this.list.append(node);
+    this.history.push(['append', key]);
   }
 
   insert(
@@ -49,6 +76,7 @@ class Target implements IteratorSynchronizerDelegate<null> {
     let node = new ListNode(item);
     this.map.set(key, node);
     this.list.insertBefore(node, referenceNode);
+    this.history.push(['insert', key]);
   }
 
   move(
@@ -67,12 +95,14 @@ class Target implements IteratorSynchronizerDelegate<null> {
 
     this.list.remove(node);
     this.list.insertBefore(node, referenceNode);
+    this.history.push(['move', key]);
   }
 
   delete(_env: null, key: string) {
     let node = this.map.get(key)!;
     this.map.delete(key);
     this.list.remove(node);
+    this.history.push(['delete', key]);
   }
 
   toArray(): BasicReference<unknown>[] {
@@ -177,6 +207,25 @@ function initialize(
   }
 
   return { reference, target, artifacts: iterator.artifacts };
+}
+
+function shuffleArray(array: any) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+function getInitialArray(length = 10, firstItem = 0, namePrefix = 'i-') {
+  // Array.fill don't work in IE, going to Grow array manually.
+  const result = [];
+  for (let i = 0; i < length; i++) {
+    result.push({
+      key: String(i + firstItem),
+      name: `${namePrefix}${String(i + firstItem)}`,
+    });
+  }
+  return result;
 }
 
 function sync(target: Target, artifacts: IterationArtifacts) {
@@ -286,4 +335,299 @@ QUnit.test('When re-iterated via replacement, the original references are update
   sync(target, artifacts);
 
   assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #1, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let a = arr[1];
+  let b = arr[7];
+  arr[7] = a;
+  arr[1] = b;
+
+  reference.update(arr);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'retain:1,move:8,retain:3,retain:4,retain:5,retain:6,retain:7,move:2'
+  );
+  assert.equal(target.historyStats.move, 2, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #2, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let a = arr[0];
+  let b = arr[7];
+  arr[7] = a;
+  arr[0] = b;
+
+  reference.update(arr);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'move:8,retain:2,retain:3,retain:4,retain:5,retain:6,retain:7,move:1',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 2, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #3, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let a = arr[0];
+  let b = arr[6];
+  arr[6] = a;
+  arr[0] = b;
+
+  reference.update(arr);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'move:7,retain:2,retain:3,retain:4,retain:5,retain:6,move:1,retain:8',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 2, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #4, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let a = arr[1];
+  let b = arr[3];
+  let c = arr[4];
+  let d = arr[6];
+  arr[6] = b;
+  arr[4] = a;
+  arr[3] = d;
+  arr[1] = c;
+
+  reference.update(arr);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'retain:1,move:5,retain:3,move:7,move:2,retain:6,move:4,retain:8',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 4, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 4, 'retained nodes count');
+  assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #5, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let a = arr[1];
+  let b = arr[3];
+  arr[3] = a;
+  arr[1] = b;
+  arr.push({ key: '9', name: 'i-9' });
+
+  reference.update(arr);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'retain:1,move:4,retain:3,move:2,retain:5,retain:6,retain:7,retain:8,insert:9',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 2, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.equal(target.historyStats.insert, 1, 'inserted nodes count');
+  assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #6, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let a = arr[1];
+  let b = arr[6];
+  arr[6] = a;
+  arr[1] = b;
+
+  arr.splice(2, 0, { key: '9', name: 'i-9' });
+
+  reference.update(arr);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'retain:1,move:7,insert:9,retain:3,retain:4,retain:5,retain:6,move:2,retain:8',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 2, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.equal(target.historyStats.insert, 1, 'inserted nodes count');
+  assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #7, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  arr.shift();
+  arr.splice(2, 0, { key: '9', name: 'i-9' });
+
+  reference.update(arr);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'retain:3,insert:9,retain:4,retain:5,retain:6,retain:7,retain:8,delete:1',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 0, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.equal(target.historyStats.insert, 1, 'inserted nodes count');
+  assert.equal(target.historyStats.delete, 1, 'deleted nodes count');
+  assert.deepEqual(target.toValues(), arr);
+});
+
+QUnit.test('When re-iterated via swap #8, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let shiftedArray = [arr[7], arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6]];
+
+  reference.update(shiftedArray);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'move:8,retain:2,retain:3,retain:4,retain:5,retain:6,retain:7',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 1, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.equal(target.historyStats.insert, 0, 'inserted nodes count');
+  assert.equal(target.historyStats.delete, 0, 'deleted nodes count');
+  assert.deepEqual(target.toValues(), shiftedArray);
+});
+
+QUnit.test('When re-iterated via swap #9, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  let shiftedArray = [arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7], arr[0]];
+
+  reference.update(shiftedArray);
+
+  target.cleanHistory();
+  sync(target, artifacts);
+
+  assert.equal(
+    target.serializeHistory(),
+    'retain:3,retain:4,retain:5,retain:6,retain:7,retain:8,move:1',
+    'has valid changeset history'
+  );
+  assert.equal(target.historyStats.move, 1, 'moved nodes count');
+  assert.equal(target.historyStats.retain, 6, 'retained nodes count');
+  assert.equal(target.historyStats.insert, 0, 'inserted nodes count');
+  assert.equal(target.historyStats.delete, 0, 'deleted nodes count');
+  assert.deepEqual(target.toValues(), shiftedArray);
+});
+
+QUnit.test('When re-iterated via swap #10, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  for (let i = 0; i < 1000; i++) {
+    shuffleArray(arr);
+    reference.update(arr);
+    target.cleanHistory();
+    sync(target, artifacts);
+    let history = target.historyStats;
+    const changedNodes = history.move + history.retain;
+    assert.equal(changedNodes <= arr.length, true, target.serializeHistory());
+    assert.equal(history.insert, 0, 'inserted nodes count');
+    assert.equal(history.delete, 0, 'deleted nodes count');
+    assert.deepEqual(target.toValues(), arr);
+  }
+});
+
+QUnit.test('When re-iterated via swap #11, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  for (let i = 0; i < 1000; i++) {
+    let newArr = arr.slice();
+    shuffleArray(newArr);
+    let semiArr = newArr.slice(0, 5);
+    reference.update(semiArr);
+    target.cleanHistory();
+    sync(target, artifacts);
+    let history = target.historyStats;
+    const changedNodes = history.move + history.retain;
+    assert.equal(changedNodes <= arr.length, true, target.serializeHistory());
+    assert.equal(history.insert <= 3, true, 'inserted nodes count');
+    assert.equal(history.delete <= 3, true, 'deleted nodes count');
+    assert.deepEqual(target.toValues(), semiArr);
+  }
+});
+
+QUnit.test('When re-iterated via swap #12, the original references are updated', assert => {
+  let arr = getInitialArray(8, 1, 'i-');
+  let { target, reference, artifacts } = initialize(arr);
+  assert.deepEqual(target.toValues(), arr);
+
+  for (let i = 0; i < 1000; i++) {
+    let newArr = arr.slice(0);
+    shuffleArray(newArr);
+    let semiArr = [].concat(
+      newArr.slice(0, 5) as any,
+      [{ key: '11', name: 'i-11' }, { key: '12', name: 'i-12' }] as any
+    );
+    reference.update(semiArr);
+    target.cleanHistory();
+    sync(target, artifacts);
+    let history = target.historyStats;
+    const changedNodes = history.move + history.retain + history.insert + history.delete;
+    assert.equal(changedNodes <= semiArr.length + 3, true, target.serializeHistory());
+    assert.equal(history.insert <= 3, true, 'inserted nodes count');
+    assert.equal(history.delete <= 3, true, 'deleted nodes count');
+    assert.deepEqual(target.toValues(), semiArr);
+  }
 });


### PR DESCRIPTION
this is failing tests related to https://github.com/glimmerjs/glimmer-vm/issues/940

This PR must increase keyed lists swap perf up to 10x! Moon

(See swap rows row)

from this:
![image](https://user-images.githubusercontent.com/1360552/58828893-2272d480-864f-11e9-816e-6a2d5232aa40.png)


to this:
![image](https://user-images.githubusercontent.com/1360552/58828927-33234a80-864f-11e9-80e4-872d1103f0ba.png)
