### PR TITLE
Failing test for ConcatStatement parts location.

### DIFF
--- a/packages/@glimmer/syntax/test/loc-node-test.ts
+++ b/packages/@glimmer/syntax/test/loc-node-test.ts
@@ -349,7 +349,7 @@ foo"
 
     if (assertNodeType(dataDerpValue, 'ConcatStatement')) {
       let [fooStaticText, concat, huzzahStaticText] = dataDerpValue.parts;
-      locEqual(fooStaticText, 9, 14, 10, 0);
+      locEqual(fooStaticText, 9, 13, 10, 0);
       locEqual(concat, 10, 0, 10, 13);
       locEqual(huzzahStaticText, 10, 13, 11, 10);
     }


### PR DESCRIPTION
When a ConcatStatement has a `TextNode` as its first part, the location information of that `TextNode` is wrong.

A specific test for this existed, but the location information used in the assertion was wrong :weary:.