### PR TITLE
possible bug fix in `pair` function

### DIFF
--- a/packages/@glimmer/reference/lib/validators.ts
+++ b/packages/@glimmer/reference/lib/validators.ts
@@ -153,9 +153,9 @@ export function pair(left: Tag, right: Tag): Tag {
   if (constLeft && constRight) {
     return CONSTANT_TAG;
   } else if (constLeft) {
-    return left;
-  } else if (constRight) {
     return right;
+  } else if (constRight) {
+    return left;
   } else {
     return TagsPair.create(left, right);
   }

--- a/packages/@glimmer/reference/test/combinator-test.ts
+++ b/packages/@glimmer/reference/test/combinator-test.ts
@@ -1,4 +1,12 @@
-import { State, VersionedPathReference, UpdatableReference, map } from '@glimmer/reference';
+import {
+  State,
+  VersionedPathReference,
+  UpdatableReference,
+  map,
+  pair,
+  DirtyableTag,
+  CONSTANT_TAG,
+} from '@glimmer/reference';
 import { tracked } from './support';
 
 QUnit.module('@glimmer/reference - combinators: map');
@@ -47,6 +55,17 @@ QUnit.test('mapping an object with interior mutability', () => {
     ['update-child', 'first', 'Tom'],
     ['eq', `Tom Dale`]
   );
+});
+
+QUnit.test('pair works correctly', () => {
+  let tag = DirtyableTag.create();
+  let constantTag = CONSTANT_TAG;
+
+  let snapshot = tag.value();
+  let paired = pair(tag, constantTag);
+
+  tag.inner.dirty();
+  QUnit.assert.notOk(paired.validate(snapshot));
 });
 
 export type Step<T, U, K extends keyof T> =


### PR DESCRIPTION
`pair` function probably should return non-constant tag when one of tags is constant, not sure how to test it