### PR TITLE
Add ability to override printing of specific AST nodes.

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -9,6 +9,22 @@ function unreachable(): never {
 
 interface PrinterOptions {
   entityEncoding: 'transformed' | 'raw';
+
+  /**
+   * Used to override the mechanism of printing a given AST.Node.
+   *
+   * This will generally only be useful to source -> source codemods
+   * where you would like to specialize/override the way a given node is
+   * printed (e.g. you would like to preserve as much of the original
+   * formatting as possible).
+   *
+   * When the provided override returns undefined, the default built in printing
+   * will be done for the AST.Node.
+   *
+   * @param ast the ast node to be printed
+   * @param options the options specified during the print() invocation
+   */
+  override?(ast: AST.Node, options: PrinterOptions): void | string;
 }
 
 export default function build(
@@ -17,6 +33,14 @@ export default function build(
 ): string {
   if (!ast) {
     return '';
+  }
+
+  if (options.override) {
+    let result = options.override(ast, options);
+
+    if (result !== undefined) {
+      return result;
+    }
   }
 
   function buildEach(asts: AST.Node[]): string[] {

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -117,3 +117,23 @@ QUnit.module('[glimmer-syntax] Code generation - source -> source', function() {
     assert.equal(printTransform(before), after);
   });
 });
+
+QUnit.module('[glimmer-syntax] Code generation - override', function() {
+  test('can provide a custom options.override to be used', function(assert) {
+    let ast = parse(`<FooBar @baz="qux" @derp="qux" />`);
+
+    let actual = print(ast, {
+      entityEncoding: 'transformed',
+
+      override(ast) {
+        if (ast.type === 'AttrNode' && ast.name === '@baz') {
+          return '@baz="ZOMG!!!!"';
+        }
+
+        return;
+      },
+    });
+
+    assert.equal(actual, `<FooBar @baz="ZOMG!!!!" @derp="qux" />`);
+  });
+});


### PR DESCRIPTION
This will generally only be useful to source -> source codemods where you would like to specialize/override the way a given node is printed (e.g. you would like to preserve as much of the original formatting as possible).

Allows tooling like ember-template-recast (and possibly `prettier`) to remove the duplicated print functionality like what was added in https://github.com/ember-template-lint/ember-template-recast/pull/74.