### PR TITLE
Fix table thead and tfoot rehydration

### DIFF
--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -84,7 +84,11 @@ class SerializeBuilder extends NewElementBuilder implements ElementBuilder {
 
   openElement(tag: string) {
     if (tag === 'tr') {
-      if (this.element.tagName !== 'TBODY') {
+      if (
+        this.element.tagName !== 'TBODY' &&
+        this.element.tagName !== 'THEAD' &&
+        this.element.tagName !== 'TFOOT'
+      ) {
         this.openElement('tbody');
         // This prevents the closeBlock comment from being re-parented
         // under the auto inserted tbody. Rehydration builder needs to

--- a/packages/@glimmer/runtime/test/initial-render-test.ts
+++ b/packages/@glimmer/runtime/test/initial-render-test.ts
@@ -134,6 +134,28 @@ class Rehydration extends AbstractRehydrationTests {
   }
 
   @test
+  'table with thead'() {
+    let template = '<table><thead><tr><th>standards</th></tr></thead></table>';
+    this.renderServerSide(template, {});
+    this.assertServerOutput('<table><thead><tr><th>standards</th></tr></thead></table>');
+    this.renderClientSide(template, {});
+    this.assertHTML('<table><thead><tr><th>standards</th></tr></thead></table>');
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertStableNodes();
+  }
+
+  @test
+  'table with tfoot'() {
+    let template = '<table><tfoot><tr><th>standards</th></tr></tfoot></table>';
+    this.renderServerSide(template, {});
+    this.assertServerOutput('<table><tfoot><tr><th>standards</th></tr></tfoot></table>');
+    this.renderClientSide(template, {});
+    this.assertHTML('<table><tfoot><tr><th>standards</th></tr></tfoot></table>');
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertStableNodes();
+  }
+
+  @test
   'mismatched text nodes'() {
     let template = '{{content}}';
     this.renderServerSide(template, { content: 'hello' });


### PR DESCRIPTION
Same as #956, but targeting `release-0-38-alpha`.

Fixes emberjs/ember.js#18184. 