### PR TITLE
[BUGFIX] Prevents caching when a cycle exists in tags

### DIFF
--- a/packages/@glimmer/reference/lib/validators.ts
+++ b/packages/@glimmer/reference/lib/validators.ts
@@ -175,13 +175,24 @@ function _combine(tags: Tag[]): Tag {
 export abstract class CachedTag extends RevisionTag {
   private lastChecked: Option<Revision> = null;
   private lastValue: Option<Revision> = null;
+  private isUpdating = false;
 
   value(): Revision {
     let { lastChecked } = this;
 
     if (lastChecked !== $REVISION) {
+      this.isUpdating = true;
       this.lastChecked = $REVISION;
-      this.lastValue = this.compute();
+
+      try {
+        this.lastValue = this.compute();
+      } finally {
+        this.isUpdating = false;
+      }
+    }
+
+    if (this.isUpdating) {
+      this.lastChecked = ++$REVISION;
     }
 
     return this.lastValue as Revision;

--- a/packages/@glimmer/reference/test/validator-test.ts
+++ b/packages/@glimmer/reference/test/validator-test.ts
@@ -1,0 +1,28 @@
+import { combine, UpdatableTag, DirtyableTag, CONSTANT_TAG } from '@glimmer/reference';
+
+const { module, test } = QUnit;
+
+module('validators', () => {
+  module('CachedTag', () => {
+    test('tag cycles do not result in improperly cached tags', assert => {
+      let tag1 = combine([DirtyableTag.create(), UpdatableTag.create(CONSTANT_TAG)]);
+      let tag2 = combine([DirtyableTag.create(), UpdatableTag.create(CONSTANT_TAG)]);
+
+      // setup the cycle
+      (tag1.inner! as any).second.inner.update(tag2);
+      (tag2.inner! as any).second.inner.update(tag1);
+
+      // Cache the first tag
+      let revision = tag1.value();
+
+      // Dirty the second tag
+      (tag2.inner! as any).first.inner.dirty();
+
+      // Get the second tag, causing the first to recompute
+      tag2.value();
+
+      // Make sure the first tag didn't cache eagerly before the second tag finished calculating its value
+      assert.notOk(tag1.validate(revision));
+    });
+  });
+});


### PR DESCRIPTION
When a cycle exists between two or more tags, it's possible for the
cache to get into a bad state currently. For example, following these
steps:

1. Create two UpdatableDirtyableTags, Tag A and Tag B.
2. Update each tag to point to the other, creating a cycle.
3. Dirty Tag B
4. Get the value of Tag B, before getting the value of Tag A

When calculating the value of Tag B, it will look for the value of Tag A.
Tag A will then attempt to get the value of Tag B, will see that the
last checked revision has matches the current revision, and will return
the last known value.

This is logically consistent and prevents infinite recursion, but the
since Tag B was just updated, this value will be out of date just after
Tag A finishes calculating, by which time Tag A will unfortunately have
already cached its value against the latest revision. Tag A's cache will
remain in an inconsistent state until the next bump of the global
revision counter.

This PR places an `isUpdating` flag on CachedTags. If a cycle is
detected while updating, the last value is still returned, but we _also_
bump the global revision counter and reset the lastRevision for the tag.
This way, the tag which began the cycle will remain cached, but any tags
which were calculated _during_ the cycle will not, allowing them to
recalculate the next time they are retrieved with the updated entry
value (if it changed at all).

An unfortunate side effect of this is that any tags calculated and
cached _before_ entering the cycle will also be busted. We could
potentially avoid this by using additional bookkeeping - a set of cycle
endpoints, combined with a counter for the number of cycles seen
(potentially), but given this particular case is likely to be uncommon
in the future with autotracking (cycles can't occur if all your tags
represent leaves), I wanted to start simple.