### PR TITLE
Update simple-html-tokenizer to v0.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-debug-macros": "^0.1.11",
     "ember-cli-browserstack": "^0.0.7",
     "handlebars": "^4.0.13",
-    "simple-html-tokenizer": "^0.5.7"
+    "simple-html-tokenizer": "^0.5.8"
   },
   "devDependencies": {
     "@types/qunit": "^2.0.31",

--- a/packages/@glimmer/integration-tests/package.json
+++ b/packages/@glimmer/integration-tests/package.json
@@ -18,7 +18,7 @@
     "@simple-dom/document": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0",
-    "simple-html-tokenizer": "^0.5.7"
+    "simple-html-tokenizer": "^0.5.8"
   },
   "devDependencies": {
     "@types/qunit": "^2.0.31",

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -6,7 +6,7 @@
     "handlebars": "^4.0.13",
     "@glimmer/interfaces": "^0.41.4",
     "@glimmer/util": "^0.41.4",
-    "simple-html-tokenizer": "^0.5.7"
+    "simple-html-tokenizer": "^0.5.8"
   },
   "devDependencies": {
     "@glimmer/local-debug-flags": "^0.41.4",

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -50,7 +50,7 @@ test('html content with svg content inline', function() {
   astEqual(t, b.program([b.element('div', ['body', b.element('svg')])]));
 });
 
-let integrationPoints = ['foreignObject', 'desc', 'title'];
+let integrationPoints = ['foreignObject', 'desc'];
 function buildIntegrationPointTest(integrationPoint: string) {
   return function integrationPointTest() {
     let t = '<svg><' + integrationPoint + '><div></div></' + integrationPoint + '></svg>';
@@ -68,6 +68,14 @@ for (let i = 0, length = integrationPoints.length; i < length; i++) {
     buildIntegrationPointTest(integrationPoints[i])
   );
 }
+
+test('svg title with html content', function() {
+  let t = '<svg><title><div></div></title></svg>';
+  astEqual(
+    t,
+    b.program([b.element('svg', ['body', b.element('title', ['body', b.text('<div></div>')])])])
+  );
+});
 
 test('a piece of content with HTML', function() {
   let t = 'some <div>content</div> done';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8933,10 +8933,10 @@ simple-fmt@~0.1.0:
   resolved "https://registry.yarnpkg.com/simple-fmt/-/simple-fmt-0.1.0.tgz#191bf566a59e6530482cb25ab53b4a8dc85c3a6b"
   integrity sha1-GRv1ZqWeZTBILLJatTtKjchcOms=
 
-simple-html-tokenizer@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.7.tgz#8eca336ecfbe2b3c6166cbb31b2682088de79f40"
-  integrity sha512-APW9iYbkJ5cijjX4Ljhf3VG8SwYPUJT5gZrwci/wieMabQxWFiV5VwsrP5c6GMRvXKEQMGkAB1d9dvW66dTqpg==
+simple-html-tokenizer@^0.5.8:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.8.tgz#3417382f75954ee34515cc4fd32d9918e693f173"
+  integrity sha512-0Sq4FvLlQEQODVA6PH2MIrc7tzYO0KT2HzzwvaVLYClWgIsuvaNUOrhrAvTi1pZHrcq7GDB4WiI3ukjqBMxcGQ==
 
 simple-is@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Upgrade `simple-html-tokenizer` to get changes from https://github.com/tildeio/simple-html-tokenizer/pull/69. 

Unfortunately, this breaks a test. 
![Screen Shot 2019-07-22 at 4 27 47 PM](https://user-images.githubusercontent.com/230476/61671746-cf57ee00-ac9d-11e9-9508-a1c5a6e91a79.png)

https://github.com/glimmerjs/glimmer-vm/blob/master/packages/@glimmer/syntax/test/parser-node-test.ts#L53-L70

Should the changes in that PR affect SVG title? Happy to update the test if it makes sense.


Interestingly, MDN docs say that SVG title can be "Any elements or character data". 
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title#Usage_notes

