### PR TITLE
Cleanup Node.js files

### DIFF
--- a/bin/publish.js
+++ b/bin/publish.js
@@ -235,7 +235,7 @@ function execWithSideEffects(cmd, options) {
 
   console.log(chalk.green('>') + ' ' + chalk.gray(cmd) + cwd);
   if (!DRY_RUN) {
-    return execSync.apply(null, arguments);
+    execSync(cmd, options);
   }
 }
 

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -32,7 +32,6 @@ let packages = Project.from(DIST_PATH)
   .packages
   .filter(pkg => pkg.isPublishable);
 
-let packageNames = packages.map(pkg => pkg.name);
 let newVersion;
 
 // Begin interactive CLI

--- a/bin/run-qunit.js
+++ b/bin/run-qunit.js
@@ -1,6 +1,5 @@
 const requireQUnit = require('qunit/src/cli/require-qunit');
 const FindReporter = require('qunit/src/cli/find-reporter');
-const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 const execa = require('execa');

--- a/bin/run-types-tests.js
+++ b/bin/run-types-tests.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const execa = require('execa');
-const chalk = require('chalk');
 const yaml = require('js-yaml');
 
 /**

--- a/bin/yarn-link-all.js
+++ b/bin/yarn-link-all.js
@@ -40,10 +40,9 @@ function link(dir) {
     if (stat.isDirectory()) {
       console.log(chalk.blue(command), dir);
       process.chdir(dir);
-      let result;
 
       try {
-        result = execSync(command, {
+        execSync(command, {
           stdio: ['ignore', 'ignore', 'pipe']
         });
       } catch (err) {

--- a/bin/yarn-link-all.js
+++ b/bin/yarn-link-all.js
@@ -54,8 +54,3 @@ function link(dir) {
     process.chdir(cwd);
   }
 }
-
-function exec(cmd) {
-  console.log(chalk.blue(cmd));
-  return execSync(cmd, { cwd });
-}

--- a/bin/yarn-link-local.js
+++ b/bin/yarn-link-local.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const glob = require('glob');
-const chalk = require('chalk');
 
 let cwd = path.resolve(__dirname, '..');
 let packages = glob.sync('dist/@glimmer/*/', { cwd }).map(f => path.resolve(cwd, f));
@@ -33,11 +32,6 @@ function link(dir) {
   } finally {
     process.chdir(cwd);
   }
-}
-
-function exec(cmd) {
-  console.log(chalk.blue(cmd));
-  return execSync(cmd, { cwd });
 }
 
 function isDirectory(file) {

--- a/bin/yarn-link-local.js
+++ b/bin/yarn-link-local.js
@@ -8,7 +8,6 @@ const glob = require('glob');
 let cwd = path.resolve(__dirname, '..');
 let packages = glob.sync('dist/@glimmer/*/', { cwd }).map(f => path.resolve(cwd, f));
 const node_modules = path.resolve(__dirname, '..', 'node_modules', '@glimmer');
-const package_root = path.resolve(__dirname, '..', 'packages', '@glimmer');
 
 mkdirp.sync(node_modules);
 

--- a/bin/yarn-link-local.js
+++ b/bin/yarn-link-local.js
@@ -7,15 +7,15 @@ const glob = require('glob');
 
 let cwd = path.resolve(__dirname, '..');
 let packages = glob.sync('dist/@glimmer/*/', { cwd }).map(f => path.resolve(cwd, f));
-const node_modules = path.resolve(__dirname, '..', 'node_modules', '@glimmer');
+const nodeModules = path.resolve(__dirname, '..', 'node_modules', '@glimmer');
 
-mkdirp.sync(node_modules);
+mkdirp.sync(nodeModules);
 
 packages.forEach(link);
 
 function link(dir) {
   try {
-    let target = path.join(node_modules, path.basename(dir));
+    let target = path.join(nodeModules, path.basename(dir));
 
     if (isDirectory(dir) && !isSymlink(target)) {
       let source = dir;

--- a/bin/yarn-link-local.js
+++ b/bin/yarn-link-local.js
@@ -20,7 +20,6 @@ function link(dir) {
     let target = path.join(node_modules, path.basename(dir));
 
     if (isDirectory(dir) && !isSymlink(target)) {
-      let target = path.join(node_modules, path.basename(dir));
       let source = dir;
 
       // console.log(chalk.blue(source), '->', chalk.blue(target));

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,5 +1,3 @@
-/*jshint node:true*/
-
 const merge = require('broccoli-merge-trees');
 const funnel = require('broccoli-funnel');
 const typescript = require('broccoli-typescript-compiler').default;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -17,7 +17,7 @@ const PRODUCTION = process.env.EMBER_ENV === 'production';
  * tests). For production builds, we omit tests but include all target
  * formats.
  */
-module.exports = function(_options) {
+module.exports = function() {
   // First, get all of our TypeScript packages while preserving their relative
   // path in the filesystem. This is important because tsconfig.json paths are
   // relative to the project root and we want to use the tsconfig as-is.


### PR DESCRIPTION
All of these issues would have caught by ESLint, but unfortunately ESLint was configured to only run for the `build` folder. I have a follow-up PR that enables ESLint to run on **all** JS files in the repo.