### PR TITLE
Handle missing remote element marker gracefully.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/qunit": "^2.0.31",
-    "amd-name-resolver": "^1.0.0",
+    "amd-name-resolver": "^1.3.1",
     "auto-dist-tag": "^1.0.0",
     "babel-plugin-nukable-import": "^0.4.2",
     "babel-plugin-strip-glimmer-utils": "^0.1.1",

--- a/packages/@glimmer/integration-tests/lib/modes/rehydration/builder.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/rehydration/builder.ts
@@ -12,7 +12,7 @@ export class DebugRehydrationBuilder extends RehydrateBuilder {
     if (node.nodeType !== 8) {
       if (el.nodeType === 1) {
         // don't stat serialized cursor positions
-        if (el.tagName !== 'SCRIPT' && !el.getAttribute('gmlr')) {
+        if (el.tagName !== 'SCRIPT' || !el.getAttribute('glmr')) {
           this.clearedNodes.push(node);
         }
       } else {

--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -269,7 +269,7 @@ class Rehydration extends AbstractRehydrationTests {
     this.element = assertElement(host.firstChild);
 
     this.renderClientSide(template, { remote: clientRemote });
-    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertRehydrationStats({ nodesRemoved: 1 });
     this.assert.equal(toInnerHTML(clientRemote), '<inner>Wat Wat</inner>');
   }
 
@@ -323,7 +323,7 @@ class Rehydration extends AbstractRehydrationTests {
       remoteParent: clientRemoteParent,
       remoteChild: clientRemoteChild,
     });
-    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertRehydrationStats({ nodesRemoved: 2 });
     this.assert.equal(toInnerHTML(clientRemoteParent), '<inner><!----></inner>');
     this.assert.equal(toInnerHTML(clientRemoteChild), 'Wat Wat');
   }

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -174,8 +174,8 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     if (currentCursor.openBlockDepth === this.blockDepth) {
       assert(
         currentCursor.nextSibling !== null &&
-          isComment(currentCursor.nextSibling) &&
-          getCloseBlockDepth(currentCursor.nextSibling) === openBlockDepth,
+        isComment(currentCursor.nextSibling) &&
+        getCloseBlockDepth(currentCursor.nextSibling) === openBlockDepth,
         'expected close block to match rehydrated open block'
       );
       currentCursor.candidate = this.remove(currentCursor.nextSibling!);
@@ -388,7 +388,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     if (marker.parentNode === element) {
       if (insertBefore === undefined) {
         while (element.lastChild !== marker) {
-          element.removeChild(element.lastChild!);
+          this.remove(element.lastChild!);
         }
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,9 +199,10 @@ amd-name-resolver@0.0.4:
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.4.tgz#aa19f1b9a0afcef975451b263b7dfb690a9c0ca3"
   integrity sha1-qhnxuaCvzvl1RRsmO337aQqcDKM=
 
-amd-name-resolver@^1.0.0, amd-name-resolver@^1.2.0:
+amd-name-resolver@^1.0.0, amd-name-resolver@^1.2.0, amd-name-resolver@^1.3.1:
   version "1.3.1"
-  resolved "https://github.com/ember-cli/amd-name-resolver.git#9d519b14987bcfa3f9c6012f3808ac24fac1e9c0"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.3.1.tgz#ffe71c683c6e7191fc4ae1bb3aaed15abea135d9"
+  integrity sha512-26qTEWqZQ+cxSYygZ4Cf8tsjDBLceJahhtewxtKZA3SRa4PluuqYCuheemDQD+7Mf5B7sr+zhTDWAHDh02a1Dw==
   dependencies:
     ensure-posix-path "^1.0.1"
     object-hash "^1.3.1"


### PR DESCRIPTION
This is a continuation of pairing with @tomdale.

Prior to this change, a missing marker for a remote element would cause rehydration to error which caused the app to completely cease working.

After this change, a missing marker for a remote element is gracefully ignored and the remote element is rendered on the client.

Context:
We have a use case when using FastBoot APIs to SSR where we would like to early flush without waiting for the visitPromise to resolve with the head content for non-seo bot users. When using the 'ember-cli-head' addon, this causes problems as rehydration expected the 'in-element' from 'ember-cli-head' to SSR with remote element markers (<script glmr="cursorId"></script>). This PR attempts to gracefully handle the missing remote element marker case.
