### PR TITLE
CI: Use Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 language: node_js
 node_js:
-  - 6
+  - 8
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Node 6 is no longer officially supported so we should update to at least Node 8 on our CI system

Luckily, since we use TypeScript for everything here this does not have to be considered a breaking change 🎉 

This should hopefully unblock https://github.com/glimmerjs/glimmer-vm/pull/976