### PR TITLE
Fix AST loc info for `ConcatStatement`s containing `TextNode`s

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -206,10 +206,12 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
         this.tokenizer.column
       );
 
-      // correct for `\n` as first char
+      // the tokenizer line/column have already been advanced, correct location info
       if (char === '\n') {
         loc.start.line -= 1;
         loc.start.column = lastPart ? lastPart.loc.end.column : this.currentAttr.valueStartColumn;
+      } else {
+        loc.start.column -= 1;
       }
 
       let text = b.text(char, loc);

--- a/packages/@glimmer/syntax/test/loc-node-test.ts
+++ b/packages/@glimmer/syntax/test/loc-node-test.ts
@@ -326,20 +326,24 @@ foo"
   data-derp="foo
 {{concat ''}}
     huzzah"
+  data-qux="{{zomg}} static"
     ></div>
   `);
 
   let [, div] = ast.body;
   if (assertNodeType(div, 'ElementNode')) {
-    let [dataFoo, dataBar, dataDerp] = div.attributes;
+    let [dataFoo, dataBar, dataDerp, dataQux] = div.attributes;
     let dataFooValue = dataFoo.value;
     let dataBarValue = dataBar.value;
     let dataDerpValue = dataDerp.value;
+    let dataQuxValue = dataQux.value;
     locEqual(dataFoo, 2, 9, 6, 5);
     locEqual(dataBar, 7, 2, 8, 4);
+    locEqual(dataQux, 12, 2, 12, 28);
     locEqual(dataBarValue, 7, 11, 8, 4);
     locEqual(dataDerpValue, 9, 12, 11, 11);
     locEqual(dataFooValue, 2, 18, 6, 5);
+    locEqual(dataQuxValue, 12, 11, 12, 28);
 
     if (assertNodeType(dataFooValue, 'ConcatStatement')) {
       let [inlineIf, staticDerpText] = dataFooValue.parts;
@@ -349,9 +353,15 @@ foo"
 
     if (assertNodeType(dataDerpValue, 'ConcatStatement')) {
       let [fooStaticText, concat, huzzahStaticText] = dataDerpValue.parts;
-      locEqual(fooStaticText, 9, 14, 10, 0);
+      locEqual(fooStaticText, 9, 13, 10, 0);
       locEqual(concat, 10, 0, 10, 13);
       locEqual(huzzahStaticText, 10, 13, 11, 10);
+    }
+
+    if (assertNodeType(dataQuxValue, 'ConcatStatement')) {
+      let [mustacheZomg, staticStatic] = dataQuxValue.parts;
+      locEqual(mustacheZomg, 12, 12, 12, 20);
+      locEqual(staticStatic, 12, 20, 12, 27);
     }
   }
 });


### PR DESCRIPTION
Prior to this change, the following snippet would show the `static ` `TextNode` portion of the `ConcatStatement` as starting at column 13, but it actually starts at 12.

```hbs
<div class="static {{dynamic}}"></div>
```

**All** `TextNode`'s that were part of a `ConcatStatement` were off by one in the same way.

The main issue here is that when `simple-html-tokenizer` calls `appendToAttributeValue` the `this.tokenizer.line`/`this.tokenizer.column` counters have already been incremented, and since we are using those as the starting location information for the new `TextNode` they were wrong (in an "off by one" way). We had already identified that this was an issue when the `TextNode` started with `\n`, but failed to realize that it **also** applies to non-newline cases as well.