### PR TITLE
Throw error if closing tag contains Muststache Statement

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -302,6 +302,9 @@ function validateEndTag(
     // <input> or <br />, so we need to check for that here. Otherwise, we would
     // throw an error for those cases.
     error = 'Invalid end tag ' + formatEndTagInfo(tag) + ' (void elements cannot have end tags).';
+  } else if (mustacheInClosingTag(tag, element)) {
+    error =
+      'Invalid end tag ' + formatEndTagInfo(tag) + '. (closing tags cannot contain modifiers).';
   } else if (element.tag === undefined) {
     error = 'Closing tag ' + formatEndTagInfo(tag) + ' without an open tag.';
   } else if (element.tag !== tag.name) {
@@ -318,6 +321,28 @@ function validateEndTag(
   if (error) {
     throw new SyntaxError(error, element.loc);
   }
+}
+
+function mustacheInClosingTag(tag: Tag<'StartTag' | 'EndTag'>, element: AST.ElementNode) {
+  let children = element.children || [];
+  return children.some(({ type, loc: { start, end } }) => {
+    if (
+      type === 'MustacheStatement' &&
+      start.line >= tag.loc.start.line &&
+      end.line <= tag.loc.end.line
+    ) {
+      if (start.line === tag.loc.start.line) {
+        return start.column > tag.loc.start.column;
+      }
+
+      if (end.line === tag.loc.end.line) {
+        return end.column < tag.loc.start.column;
+      }
+
+      return true;
+    }
+    return false;
+  });
 }
 
 function formatEndTagInfo(tag: Tag<'StartTag' | 'EndTag'>) {

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -610,6 +610,20 @@ test('disallowed mustaches in the tagName space', function(assert) {
   }, /Cannot use mustaches in an elements tagname: `{{bar` at L1:C6/);
 });
 
+test('disallowed mustaches in closing tag', function(assert) {
+  assert.throws(() => {
+    parse('\nbefore <div></ {{some-modifier}} div>');
+  }, 'Error: Invalid end tag `div` (on line 2). (closing tags cannot contain modifiers).');
+
+  assert.throws(() => {
+    parse('\nbefore <div></div {{some-modifier}}>');
+  }, 'Error: Invalid end tag `div` (on line 2). (closing tags cannot contain modifiers).');
+
+  assert.throws(() => {
+    parse('\nbefore <div><span></span {{some-modifier}}></div>');
+  }, 'Error: Invalid end tag `div` (on line 2). (closing tags cannot contain modifiers).');
+});
+
 test('mustache immediately followed by self closing tag does not error', function() {
   let ast = parse('<FooBar data-foo={{blah}}/>');
   let element = b.element('FooBar/', ['attrs', ['data-foo', b.mustache('blah')]]);


### PR DESCRIPTION
Made an attempt at resolving https://github.com/glimmerjs/glimmer-vm/issues/978

I wrote a helper method that checks whether or not a closing tag contains any `MustacheStatements`. A `SyntaxError` is thrown if it does.

---

I'm quite open to feedback as I feel like there's a cleaner way to do this.

The major issue I ran into was that `EndTag` itself doesn't contain any details about whether or not contains any `Nodes`/`Statements`. This meant that I had to parse the `element.children` to see if there were any `children` within the closing tag. 


Currently I explicitly only check for `MustacheStatement`s, since the original issue (https://github.com/glimmerjs/glimmer-vm/issues/978) was specific to modifiers, but this could be expanded to check for any children within the `EndTag`.