### PR TITLE
Ensure codemod mode ignores whitespace control.

### DIFF
--- a/packages/@glimmer/syntax/handlebars-shim.js
+++ b/packages/@glimmer/syntax/handlebars-shim.js
@@ -1,2 +1,1 @@
-import { parse } from './handlebars/compiler/base';
-export { parse };
+export { parse, parser as Parser } from './handlebars/compiler/base';

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -97,25 +97,19 @@ QUnit.module('[glimmer-syntax] Code generation - source -> source', function() {
   templates.forEach(buildTest);
 
   [
+    // custom HTML Entities
     '&lt; &amp; &nbsp; &gt; &copy;2018',
+
+    // whitespace control
+    '\n{{~var~}}  ',
+    '\n{{~#foo-bar~}} {{~else if x~}} {{~else~}} {{~/foo-bar~}}  ',
 
     // newlines after opening block
     '{{#each}}\n  <li> foo </li>\n{{/each}}',
+
+    // "stand alone"
+    ' {{#foo}}\n  {{bar}}\n {{/foo}}',
   ].forEach(buildTest);
-
-  test('whitespace control is preserved', function(assert) {
-    let before = '\n{{~var~}}  ';
-    let after = '{{~var~}}';
-
-    assert.equal(printTransform(before), after);
-  });
-
-  test('block whitespace control is preserved', function(assert) {
-    let before = '\n{{~#foo-bar~}} {{~else if x~}} {{~else~}} {{~/foo-bar~}}  ';
-    let after = '{{~#foo-bar~}}{{~else if x~}}{{~else~}}{{~/foo-bar~}}';
-
-    assert.equal(printTransform(before), after);
-  });
 });
 
 QUnit.module('[glimmer-syntax] Code generation - override', function() {


### PR DESCRIPTION
`handlebars.parse` automatically applies whitespace control to the AST before it is returned. For example, parsing the following template ([feel free to review the AST on ASTExplorer](https://astexplorer.net/#/gist/f850c5457b808756107c0bc5ad226989/b0366df64be5c01b5f9eadd93e795b3b9d65d2c7)):

```hbs
 {{#foo}}
   {{~bar~}} {{baz~}}
 {{/foo}}
```

Using `Handlebars.parse`, the AST returned would have truncated the following whitespace:

* The whitespace prior to the `{{#foo}}`
* The newline following `{{#foo}}`
* The leading whitespace before `{{~bar~}}`
* The whitespace between `{{~bar~}}` and `{{baz~}}`
* The newline after `{{baz~}}`
* The whitespace prior to the `{{/foo}}`

---

The inline `parseWithoutProcessing` method can be removed when we update to a version of `handlebars` that includes https://github.com/wycats/handlebars.js/pull/1584 (likely to be 4.5.0).