### PR TITLE
syntax: Add optional `path` argument to visitor functions

### DIFF
--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -18,6 +18,7 @@ export {
 } from './lib/traversal/errors';
 export { default as traverse } from './lib/traversal/traverse';
 export * from './lib/traversal/visitor';
+export { default as Path } from './lib/traversal/path';
 export { default as Walker } from './lib/traversal/walker';
 export { default as print } from './lib/generation/print';
 

--- a/packages/@glimmer/syntax/lib/traversal/path.ts
+++ b/packages/@glimmer/syntax/lib/traversal/path.ts
@@ -1,0 +1,17 @@
+import { Node } from '../types/nodes';
+
+export default class Path<N extends Node> {
+  node: N;
+  parent: Path<Node> | null;
+  parentKey: string | null;
+
+  constructor(node: N, parent: Path<Node> | null = null, parentKey: string | null = null) {
+    this.node = node;
+    this.parent = parent;
+    this.parentKey = parentKey;
+  }
+
+  get parentNode(): Node | null {
+    return this.parent ? this.parent.node : null;
+  }
+}

--- a/packages/@glimmer/syntax/lib/traversal/visitor.ts
+++ b/packages/@glimmer/syntax/lib/traversal/visitor.ts
@@ -1,13 +1,14 @@
 import * as AST from '../types/nodes';
 import { VisitorKey } from '../types/visitor-keys';
+import Path from './path';
 
 export interface FullNodeTraversal<N extends AST.Node> {
-  enter?(node: N): void;
-  exit?(node: N): void;
+  enter?(node: N, path: Path<N>): void;
+  exit?(node: N, path: Path<N>): void;
   keys?: KeysVisitor<N>;
 }
 
-export type NodeHandler<N extends AST.Node> = (node: N) => void;
+export type NodeHandler<N extends AST.Node> = (node: N, path: Path<N>) => void;
 export type NodeTraversal<N extends AST.Node> = FullNodeTraversal<N> | NodeHandler<N>;
 
 export type NodeVisitor = { [P in keyof AST.Nodes]?: NodeTraversal<AST.Nodes[P]> } & {


### PR DESCRIPTION
This PR adds path tracking to the `traverse()` function. The node visitor methods now receive a second argument, which is a `Path` object with `node` and `parent` keys. The `parent` key can be another `Path` or `null` if we've reached the root element of the traversal (usually the `Template` node).

This type of path tracking is roughly similar to ones used by e.g. ESLint and recast and can help in the development of template-lint rules and codemods.