### PR TITLE
Update to handlebars@4.5.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0",
     "babel-plugin-debug-macros": "^0.1.11",
-    "handlebars": "^4.0.13",
+    "handlebars": "^4.5.1",
     "simple-html-tokenizer": "^0.5.8"
   },
   "devDependencies": {

--- a/packages/@glimmer/syntax/handlebars-shim.js
+++ b/packages/@glimmer/syntax/handlebars-shim.js
@@ -1,1 +1,1 @@
-export { parse, parser as Parser } from './handlebars/compiler/base';
+export { parse, parseWithoutProcessing } from './handlebars/compiler/base';

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -379,16 +379,6 @@ const syntax: Syntax = {
   Walker,
 };
 
-// emulate parseWithoutProcessing (from https://github.com/wycats/handlebars.js/pull/1584)
-// can be removed when we update to Handlebars 4.5.0
-function codemodParse(html: string, parseOptions?: HandlebarsParseOptions) {
-  // this sets up parser.yy and parser.yy.locInfo
-  handlebars.parse(html, parseOptions);
-
-  // casting to any here, because Parser is not listed in the types
-  return (handlebars as any).Parser.parse(html);
-}
-
 export function preprocess(html: string, options: PreprocessOptions = {}): AST.Template {
   let mode = options.mode || 'precompile';
 
@@ -396,7 +386,7 @@ export function preprocess(html: string, options: PreprocessOptions = {}): AST.T
   if (typeof html === 'object') {
     ast = html;
   } else if (mode === 'codemod') {
-    ast = codemodParse(html, options.parseOptions);
+    ast = handlebars.parseWithoutProcessing(html, options.parseOptions) as HBS.Program;
   } else {
     ast = handlebars.parse(html, options.parseOptions) as HBS.Program;
   }

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -3,7 +3,7 @@
   "version": "0.43.0",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/syntax",
   "dependencies": {
-    "handlebars": "^4.0.13",
+    "handlebars": "^4.5.1",
     "@glimmer/interfaces": "^0.43.0",
     "@glimmer/util": "^0.43.0",
     "simple-html-tokenizer": "^0.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4743,17 +4743,6 @@ handlebars@^4.0.11:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-handlebars@^4.0.13:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
-  integrity sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==
-  dependencies:
-    async "^2.5.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
 handlebars@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
@@ -4764,6 +4753,17 @@ handlebars@^4.0.4:
     source-map "^0.4.4"
   optionalDependencies:
     uglify-js "^2.6"
+
+handlebars@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.1.tgz#8a01c382c180272260d07f2d1aa3ae745715c7ba"
+  integrity sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -7057,6 +7057,11 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+
+neo-async@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
 next-tick@1:
   version "1.0.0"


### PR DESCRIPTION
handlebars@4.5.0+ has a new method `handlebars.parseWithoutProcessing`, which we were emulating.

This PR updates the minimum Handlebars version to ensure that we have the new API available (from https://github.com/wycats/handlebars.js/pull/1584), and removes the work around added in https://github.com/glimmerjs/glimmer-vm/pull/983.