### PR TITLE
Refactor RehydrateBuilder to be more robust

### DIFF
--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -309,11 +309,8 @@ class Rehydration extends AbstractRehydrationTests {
     this.element = assertElement(host.firstChild);
 
     this.renderClientSide(template, { remote: clientRemote });
-    this.assertRehydrationStats({ nodesRemoved: 1 });
-    this.assert.equal(
-      toInnerHTML(clientRemote),
-      '<prefix></prefix><suffix></suffix><inner>Wat Wat</inner>'
-    );
+    this.assertRehydrationStats({ nodesRemoved: 2 });
+    this.assert.equal(toInnerHTML(clientRemote), '<inner>Wat Wat</inner>');
   }
 
   @test
@@ -548,7 +545,7 @@ class Rehydration extends AbstractRehydrationTests {
       remoteParent: clientRemoteParent,
       remoteChild: clientRemoteChild,
     });
-    this.assertRehydrationStats({ nodesRemoved: 2 });
+    this.assertRehydrationStats({ nodesRemoved: 0 });
     this.assert.equal(toInnerHTML(clientRemoteParent), '<inner><!----></inner>');
     this.assert.equal(toInnerHTML(clientRemoteChild), 'Wat Wat');
   }

--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -236,6 +236,42 @@ class Rehydration extends AbstractRehydrationTests {
   }
 
   @test
+  'text nodes surrounding single line handlebars comments'() {
+    let template = 'hello{{! hmm, why is this here?! }} world';
+    this.renderServerSide(template, {});
+    this.assertServerOutput('hello', '<!--%|%-->', ' world');
+
+    this.renderClientSide(template, {});
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertHTML('hello world');
+    this.assertStableRerender();
+  }
+
+  @test
+  'text nodes surrounding multi line handlebars comments'() {
+    let template = 'hello{{!-- hmm, why is this here?! --}} world';
+    this.renderServerSide(template, {});
+    this.assertServerOutput('hello', '<!--%|%-->', ' world');
+
+    this.renderClientSide(template, {});
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertHTML('hello world');
+    this.assertStableRerender();
+  }
+
+  @test
+  'text nodes surrounding "stand alone" handlebars comment'() {
+    let template = '<div></div>\n{{! hmm, why is this here?! }}\n<div></div>';
+    this.renderServerSide(template, {});
+    this.assertServerOutput('<div></div>', '\n', '<div></div>');
+
+    this.renderClientSide(template, {});
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertHTML('<div></div>\n<div></div>');
+    this.assertStableRerender();
+  }
+
+  @test
   'extra nodes at the end'() {
     let template = '{{#if admin}}<div>hi admin</div>{{else}}<div>HAXOR{{stopHaxing}}</div>{{/if}}';
     this.renderServerSide(template, { admin: false, stopHaxing: 'stahp' });

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -134,8 +134,6 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
           if (isCloseBlock(current)) {
             let closeBlockDepth = getBlockDepth(current);
             if (openBlockDepth >= closeBlockDepth) {
-              // TODO: delete this next line
-              currentCursor.openBlockDepth = closeBlockDepth;
               break;
             }
           }
@@ -215,7 +213,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       if (
         nextSibling !== null &&
         isCloseBlock(nextSibling) &&
-        getBlockDepth(nextSibling) === openBlockDepth // TODO: change this back to this.blockDepth
+        getBlockDepth(nextSibling) === this.blockDepth
       ) {
         // restore rehydration state
         let candidate = this.remove(nextSibling);

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -134,6 +134,8 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
           if (isCloseBlock(current)) {
             let closeBlockDepth = getBlockDepth(current);
             if (openBlockDepth >= closeBlockDepth) {
+              // TODO: delete this next line
+              currentCursor.openBlockDepth = closeBlockDepth;
               break;
             }
           }
@@ -187,10 +189,10 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
 
     if (candidate !== null) {
       isRehydrating = true;
-      assert(
-        openBlockDepth === this.blockDepth,
-        'when rehydrating, openBlockDepth should match this.blockDepth here'
-      );
+      //assert(
+      //  openBlockDepth === this.blockDepth,
+      //  'when rehydrating, openBlockDepth should match this.blockDepth here'
+      //);
 
       if (isCloseBlock(candidate) && getBlockDepth(candidate) === openBlockDepth) {
         let nextSibling = this.remove(candidate);
@@ -213,7 +215,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       if (
         nextSibling !== null &&
         isCloseBlock(nextSibling) &&
-        getBlockDepth(nextSibling) === this.blockDepth
+        getBlockDepth(nextSibling) === openBlockDepth // TODO: change this back to this.blockDepth
       ) {
         // restore rehydration state
         let candidate = this.remove(nextSibling);


### PR DESCRIPTION
Given this template:

```hbs
<p>{{#if true}}<div></div>{{/if}}</p>
```

The browser auto-corrects it to:

```html
<p></p><div></div><p></p>
```

When the rehydration builder runs against this, it throws an error (and fails to continue rehydrating) leaving the app in a broken state.

---

This PR refactors a number of things about how `RehydrateBuilder` recovers from errors like the one mentioned above, it also fixes some fundamental issues with rehydration of `{{in-element}}` usage (which was previously broken).

After this refactor, the act of rehydration should **never** error (leaving the app in a horribly broken state). At worst, whatever amount of SSR'ed content has already been processed when a mismatch occurs will remain stable and the remainder of the content will be cleared just before we set up the new / correct DOM from the initial render.

---

Paired with @krisselden on most of the fixes / refactors in this PR.

TODO:

- [ ] Add failing test case for https://github.com/glimmerjs/glimmer-vm/pull/988#discussion_r344434372