### PR TITLE
[BUGFIX] Removes compile from CompileTimeResolverDelegate

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/lookup.ts
+++ b/packages/@glimmer/bundle-compiler/lib/lookup.ts
@@ -6,11 +6,9 @@ import {
   CompileTimeResolverDelegate,
   ModuleLocator,
   CompileTimeComponent,
-  Template,
 } from '@glimmer/interfaces';
 import { expect, Option } from '@glimmer/util';
 import { ModuleLocatorMap } from '..';
-import { preprocess } from '@glimmer/opcode-compiler';
 
 /**
  * The BundleCompilerResolver resolves references to objects inside a template into
@@ -106,9 +104,5 @@ export default class BundleCompilerLookup<R> implements CompileTimeResolverDeleg
 
   lookupPartial(_name: string, _meta: R): Option<number> {
     throw new Error('Method not implemented.');
-  }
-
-  compile(source: string): Template {
-    return preprocess(source, {});
   }
 }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
@@ -8,14 +8,12 @@ import {
   Option,
   ComponentDefinition,
   AnnotatedModuleLocator,
-  Template,
   CompileTimeComponent,
 } from '@glimmer/interfaces';
 import { Constants, HeapImpl, RuntimeProgramImpl } from '@glimmer/program';
 import { TestJitRegistry } from './registry';
 import { compileStd, unwrapTemplate } from '@glimmer/opcode-compiler';
 import TestJitRuntimeResolver from './resolver';
-import { createTemplate } from '../../compile';
 
 export class TestJitCompilationContext implements WholeProgramCompilationContext {
   readonly constants = new Constants();
@@ -55,17 +53,6 @@ export default class JitCompileTimeLookup implements CompileTimeResolverDelegate
     return this.resolver.lookupModifier(name, referrer);
   }
 
-  // name is a cache key
-  compile(source: string, name: string): Template {
-    // throw new Error('NOPE');
-    // TODO: This whole thing probably should have a more first-class
-    // structure.
-    return this.registry.templateFromSource(source, name, source => {
-      let factory = createTemplate<AnnotatedModuleLocator>(source);
-      return factory.create();
-    });
-  }
-
   lookupComponent(name: string, referrer: AnnotatedModuleLocator): Option<CompileTimeComponent> {
     let definitionHandle = this.registry.lookupComponentHandle(name, referrer);
 
@@ -97,7 +84,7 @@ export default class JitCompileTimeLookup implements CompileTimeResolverDelegate
       throw new Error('UH OH');
     }
 
-    let template = unwrapTemplate(this.compile(source, name));
+    let template = unwrapTemplate(this.registry.templateFromSource(source, name));
     let compilable = capabilities.wrapped ? template.asWrappedLayout() : template.asLayout();
 
     return {

--- a/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
@@ -38,7 +38,6 @@ import { preprocess } from '../../compile';
 import { StaticTaglessComponentManager } from '../../components/static-tagless';
 
 const BASIC_COMPONENT_MANAGER = new BasicComponentManager();
-const EMBERISH_CURLY_COMPONENT_MANAGER = new EmberishCurlyComponentManager();
 const EMBERISH_GLIMMER_COMPONENT_MANAGER = new EmberishGlimmerComponentManager();
 const STATIC_TAGLESS_COMPONENT_MANAGER = new StaticTaglessComponentManager();
 
@@ -111,7 +110,7 @@ export function registerEmberishCurlyComponent(
     registry,
     name,
     'Curly',
-    EMBERISH_CURLY_COMPONENT_MANAGER,
+    new EmberishCurlyComponentManager(registry),
     handle,
     ComponentClass,
     CURLY_CAPABILITIES

--- a/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
@@ -94,18 +94,16 @@ export class TestJitRegistry {
     return compilable;
   }
 
-  templateFromSource(
-    source: string,
-    templateName: string,
-    create: (source: string) => Template
-  ): Template {
+  templateFromSource(source: string, templateName: string): Template {
     let compilableHandle = this.lookup('compilable', templateName);
 
     if (compilableHandle) {
       return this.resolve<Template>(compilableHandle);
     }
 
-    let template = create(source);
+    let factory = createTemplate<AnnotatedModuleLocator>(source);
+    let template = factory.create();
+
     this.register('compilable', templateName, template);
     return template;
   }

--- a/packages/@glimmer/interfaces/lib/components/component-manager.d.ts
+++ b/packages/@glimmer/interfaces/lib/components/component-manager.d.ts
@@ -167,7 +167,7 @@ export interface WithJitDynamicLayout<
   // *after* the component instance has been created, because you might
   // want to return a different layout per-instance for optimization reasons
   // or to implement features like Ember's "late-bound" layouts.
-  getJitDynamicLayout(component: I, resolver: R, context: SyntaxCompilationContext): Template;
+  getJitDynamicLayout(component: I, resolver: R): Template;
 }
 
 export interface WithAotDynamicLayout<

--- a/packages/@glimmer/interfaces/lib/serialize.d.ts
+++ b/packages/@glimmer/interfaces/lib/serialize.d.ts
@@ -87,10 +87,6 @@ export interface CompileTimeResolverDelegate<M = unknown> extends HandleResolver
   lookupComponent(name: string, referrer: M): Option<CompileTimeComponent>;
   lookupPartial(name: string, referrer: M): Option<number>;
 
-  // `name` is a cache key.
-  // TODO: The caller should cache
-  compile(source: string, name: string): Template;
-
   // For debugging
   resolve(handle: number): M;
 }

--- a/packages/@glimmer/opcode-compiler/index.ts
+++ b/packages/@glimmer/opcode-compiler/index.ts
@@ -5,7 +5,7 @@ export { UNHANDLED, NONE } from './lib/syntax/concat';
 
 export { debugCompiler } from './lib/compiler';
 
-export { compileStatements, compilable, preprocess } from './lib/compilable-template';
+export { compileStatements, compilable } from './lib/compilable-template';
 export { StaticComponent as staticComponent } from './lib/opcode-builder/helpers/components';
 
 export * from './lib/opcode-builder/context';

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -10,7 +10,6 @@ import {
   SyntaxCompilationContext,
   CompilableBlock,
   CompilableProgram,
-  Template,
   HandleResult,
 } from '@glimmer/interfaces';
 import { meta } from './opcode-builder/helpers/shared';
@@ -21,8 +20,6 @@ import { DEBUG } from '@glimmer/local-debug-flags';
 import { debugCompiler } from './compiler';
 import { patchStdlibs } from '@glimmer/program';
 import { STATEMENTS } from './syntax/statements';
-import { precompile } from '@glimmer/compiler';
-import templateFactory from './template';
 
 export const PLACEHOLDER_HANDLE = -1;
 
@@ -40,12 +37,6 @@ class CompilableTemplateImpl<S extends SymbolTable> implements CompilableTemplat
   compile(context: SyntaxCompilationContext): HandleResult {
     return maybeCompile(this, context);
   }
-}
-
-export function preprocess<M>(template: string, meta: M): Template<M> {
-  let wrapper = JSON.parse(precompile(template));
-  let factory = templateFactory<M>(wrapper);
-  return factory.create(meta);
 }
 
 export function compilable<R>(layout: LayoutWithContext<R>): CompilableProgram {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/delegate.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/delegate.ts
@@ -4,9 +4,7 @@ import {
   Option,
   CompileTimeComponent,
   CompilableProgram,
-  Template,
 } from '@glimmer/interfaces';
-import { preprocess } from '../compilable-template';
 
 export const DEFAULT_CAPABILITIES: ComponentCapabilities = {
   dynamicLayout: true,
@@ -129,10 +127,6 @@ export class DefaultCompileTimeResolverDelegate implements CompileTimeResolverDe
         `Can't compile global partial invocations without an implementation of lookupPartial`
       );
     }
-  }
-
-  compile(source: string): Template {
-    return preprocess(source, {});
   }
 
   // For debugging

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -516,7 +516,7 @@ APPEND_OPCODES.add(
       layout = manager.getJitStaticLayout(definition.state, vm.runtime.resolver);
     } else if (hasDynamicLayoutCapability(capabilities, manager)) {
       let template = unwrapTemplate(
-        manager.getJitDynamicLayout(instance.state, vm.runtime.resolver, vm.context)
+        manager.getJitDynamicLayout(instance.state, vm.runtime.resolver)
       );
 
       if (hasCapability(capabilities, Capability.Wrapped)) {


### PR DESCRIPTION
This PR removes the `compile` function from the
`CompileTimeResolverDelegate` interface. This function was being used by
tests to compile source to templates, specifically because there was no
other convenient way to pass it to component managers since the testing
managers in this codebase don't have an owner/container to refer to.

The solution was to remove it, and to provide the registry directly to
the testing component managers. This mirrors what embedding environments
would be expected to do more closely, and keeps the APIs of the resolver
delegates pretty clean and simple/non-extensible, preventing them from
becoming "god objects".

## Impact on consumers

There shouldn't be a noticeable impact except that `@glimmer/compiler`
will no longer be a dependency of `@glimmer/opcode-compiler`. The
`compile` functions for the delegates were only being used by tests.