### PR TITLE
[BUGFIX] Avoid in operator with symbols

### DIFF
--- a/packages/@glimmer/util/lib/destroy.ts
+++ b/packages/@glimmer/util/lib/destroy.ts
@@ -6,7 +6,7 @@ export const DESTROY: DestroySymbol = symbol('DESTROY');
 export function isDestroyable(
   value: Maybe<object> | SymbolDestroyable
 ): value is SymbolDestroyable {
-  return !!(value && DESTROY in value);
+  return !!(value && (value as SymbolDestroyable)[DESTROY] !== undefined);
 }
 
 export function isStringDestroyable(value: Maybe<Partial<Destroyable>>): value is Destroyable {

--- a/packages/@glimmer/util/lib/lifetimes.ts
+++ b/packages/@glimmer/util/lib/lifetimes.ts
@@ -20,7 +20,7 @@ export const DESTRUCTORS = new WeakMap();
 
 export function isDrop(value: unknown): value is Drop {
   if (value === null || typeof value !== 'object') return false;
-  return DID_DROP in (value as object);
+  return (value as Drop)[DID_DROP] !== undefined;
 }
 
 export function associate(parent: object, child: object) {


### PR DESCRIPTION
Symbols don't work with the in operator when they are polyfilled.
This prevents us from relying on the in operator for symbols in general.

We should add a test suite in the future that includes the Babel polyfill to test this out.