### PR TITLE
Update run-types-test.js to use local `tsc`.

### DIFF
--- a/bin/run-types-tests.js
+++ b/bin/run-types-tests.js
@@ -3,30 +3,30 @@
 const execa = require('execa');
 const yaml = require('js-yaml');
 
-/**
- * Runs a smoke test of the generated type definitions by importing every module
- * and running it through the TypeScript compiler.
- */
-try {
-  console.log('TAP version 13');
-  console.log('1..1');
-  console.log('# Smoke testing types');
-  execa.sync('tsc', [
-    '--noEmit',
-    '--target',
-    'ES2015',
-    '--module',
-    'commonjs',
-    '-p',
-    'dist/tsconfig.json',
-  ]);
-  console.log('ok 1 - types passed smoke test');
-} catch (err) {
-  let { message } = err;
-  console.log('not ok 1 - types failed smoke test');
-  console.log(`  ---
+async function main() {
+  /**
+   * Runs a smoke test of the generated type definitions by importing every module
+   * and running it through the TypeScript compiler.
+   */
+  try {
+    console.log('TAP version 13');
+    console.log('1..1');
+    console.log('# Smoke testing types');
+    await execa(
+      'tsc',
+      ['--noEmit', '--target', 'ES2015', '--module', 'commonjs', '-p', 'dist/tsconfig.json'],
+      { preferLocal: true }
+    );
+    console.log('ok 1 - types passed smoke test');
+  } catch (err) {
+    let { message } = err;
+    console.log('not ok 1 - types failed smoke test');
+    console.log(`  ---
 ${yaml.safeDump({ message })}
   ...`);
 
-  process.exit(1);
+    process.exitCode = 1;
+  }
 }
+
+main();


### PR DESCRIPTION
Previous versions of execa defaulted `preferLocal` to `true`, but 3.0+ default to `false`. This results in a failure when attempting to call `./bin/publish.js` to publish a new release.