### PR TITLE
ESLint: Enable `node/no-missing-import` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,12 @@ module.exports = {
     'prettier/@typescript-eslint',
   ],
   plugins: ['@typescript-eslint', 'prettier', 'qunit'],
+  settings: {
+    node: {
+      resolvePaths: [`${__dirname}/packages/`],
+      tryExtensions: ['.js', '.ts', '.d.ts'],
+    },
+  },
   rules: {
     // disabled because we still have a few commented tests
     'qunit/no-commented-tests': 'off',
@@ -220,7 +226,6 @@ module.exports = {
       },
       rules: {
         'node/no-extraneous-import': 'off',
-        'node/no-missing-import': 'off',
         'node/no-unpublished-import': 'off',
         'node/no-unsupported-features/es-syntax': 'off',
         'node/no-unsupported-features/node-builtins': 'off',


### PR DESCRIPTION
see https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-import.md

This rule warns us if we're importing a file or module that doesn't exist at all. This does not check for correct dependency declarations yet though.