### PR TITLE
Remove outdated `typescript` dev dependencies

### DIFF
--- a/packages/@glimmer/bundle-compiler/package.json
+++ b/packages/@glimmer/bundle-compiler/package.json
@@ -12,7 +12,6 @@
     "@glimmer/opcode-compiler": "^0.45.2"
   },
   "devDependencies": {
-    "typescript": "^2.8.3",
     "@glimmer/runtime": "^0.45.2"
   }
 }

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -8,8 +8,5 @@
     "@glimmer/wire-format": "^0.45.2",
     "@glimmer/interfaces": "^0.45.2",
     "@simple-dom/interface": "^1.4.0"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "@types/qunit": "^2.0.31",
-    "typescript": "^2.8.3",
     "toml": "^2.3.3"
   }
 }

--- a/packages/@glimmer/dom-change-list/package.json
+++ b/packages/@glimmer/dom-change-list/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@simple-dom/serializer": "^1.4.0",
-    "@simple-dom/void-map": "^1.4.0",
-    "typescript": "^2.8.3"
+    "@simple-dom/void-map": "^1.4.0"
   }
 }

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -5,8 +5,5 @@
   "dependencies": {
     "@glimmer/interfaces": "^0.45.2",
     "@glimmer/vm": "^0.45.2"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }

--- a/packages/@glimmer/integration-tests/package.json
+++ b/packages/@glimmer/integration-tests/package.json
@@ -23,7 +23,6 @@
     "simple-html-tokenizer": "^0.5.8"
   },
   "devDependencies": {
-    "@types/qunit": "^2.0.31",
-    "typescript": "^2.8.3"
+    "@types/qunit": "^2.0.31"
   }
 }

--- a/packages/@glimmer/interfaces/package.json
+++ b/packages/@glimmer/interfaces/package.json
@@ -4,8 +4,5 @@
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/interfaces",
   "dependencies": {
     "@simple-dom/interface": "^1.4.0"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }

--- a/packages/@glimmer/low-level/package.json
+++ b/packages/@glimmer/low-level/package.json
@@ -1,8 +1,5 @@
 {
   "name": "@glimmer/low-level",
   "version": "0.45.2",
-  "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/low-level",
-  "devDependencies": {
-    "typescript": "^2.8.3"
-  }
+  "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/low-level"
 }

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -9,7 +9,6 @@
     "@simple-dom/interface": "^1.4.0"
   },
   "devDependencies": {
-    "typescript": "^2.8.3",
     "@types/qunit": "^2.0.31",
     "@glimmer/compiler": "^0.45.2"
   }

--- a/packages/@glimmer/object-reference/package.json
+++ b/packages/@glimmer/object-reference/package.json
@@ -8,8 +8,5 @@
     "@glimmer/util": "^0.45.2",
     "@glimmer/reference": "^0.45.2",
     "@glimmer/validator": "^0.45.2"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }

--- a/packages/@glimmer/object/package.json
+++ b/packages/@glimmer/object/package.json
@@ -10,7 +10,6 @@
     "@glimmer/util": "^0.45.2"
   },
   "devDependencies": {
-    "typescript": "^2.8.3",
     "@types/qunit": "^2.0.31"
   }
 }

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -12,7 +12,6 @@
     "@glimmer/reference": "^0.45.2"
   },
   "devDependencies": {
-    "@glimmer/local-debug-flags": "^0.45.2",
-    "typescript": "^2.8.3"
+    "@glimmer/local-debug-flags": "^0.45.2"
   }
 }

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -6,8 +6,5 @@
     "@glimmer/util": "^0.45.2",
     "@glimmer/interfaces": "^0.45.2",
     "@glimmer/encoder": "^0.45.2"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -7,8 +7,5 @@
     "@glimmer/env": "^0.1.7",
     "@glimmer/util": "^0.45.2",
     "@glimmer/validator": "^0.45.2"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -22,7 +22,6 @@
     "@glimmer/object-reference": "^0.45.2",
     "@glimmer/opcode-compiler": "^0.45.2",
     "@glimmer/debug": "^0.45.2",
-    "@types/qunit": "^2.0.31",
-    "typescript": "^2.8.3"
+    "@types/qunit": "^2.0.31"
   }
 }

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@glimmer/local-debug-flags": "^0.45.2",
-    "@types/qunit": "^2.0.31",
-    "typescript": "^2.8.3"
+    "@types/qunit": "^2.0.31"
   }
 }

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -11,7 +11,7 @@
     "@glimmer/local-debug-flags": "^0.45.2",
     "@glimmer/interfaces": "^0.45.2",
     "@types/qunit": "^2.0.31",
-    "typescript": "^2.8.3"
+    "@simple-dom/interface": "^1.4.0"
   },
   "typings": "index.ts"
 }

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -5,8 +5,5 @@
   "license": "MIT",
   "dependencies": {
     "@glimmer/env": "^0.1.7"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -6,8 +6,5 @@
     "@glimmer/util": "^0.45.2",
     "@glimmer/interfaces": "^0.45.2"
   },
-  "devDependencies": {
-    "typescript": "^2.8.3"
-  },
   "typings": "index.ts"
 }

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -7,8 +7,5 @@
   "dependencies": {
     "@glimmer/util": "^0.45.2",
     "@glimmer/interfaces": "^0.45.2"
-  },
-  "devDependencies": {
-    "typescript": "^2.8.3"
   }
 }


### PR DESCRIPTION
We're already bringing in the `typescript` dependency via `broccoli-typescript-compiler`, and the `typescript` dependencies in the packages are also on the wrong version 😅 