### PR TITLE
Use Yarn workspaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,6 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier', 'qunit'],
   settings: {
     node: {
-      resolvePaths: [`${__dirname}/packages/`],
       tryExtensions: ['.js', '.ts', '.d.ts'],
     },
   },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "testem-failure-only-reporter": "^0.0.1",
     "toml": "^2.3.3"
   },
+  "workspaces": ["packages/*/*"],
   "changelog": {
     "repo": "glimmerjs/glimmer-vm",
     "labels": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,7 +18,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@glimmer/env@0.1.7":
+"@glimmer/env@0.1.7", "@glimmer/env@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=


### PR DESCRIPTION
This automatically sets up links for each of the local packages in the main `node_modules` folder. That makes it easier for the Node.js module resolution to find things and works better with `eslint-plugin-node`.