### PR TITLE
syntax/test/plugin-node: Replace relative imports with package imports

### DIFF
--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -6,8 +6,8 @@ import {
   ASTPluginEnvironment,
   ASTPluginBuilder,
 } from '@glimmer/syntax';
-import { ModuleLocator } from '../../interfaces';
-import { expect } from '../../util';
+import { ModuleLocator } from '@glimmer/interfaces';
+import { expect } from '@glimmer/util';
 
 const { test } = QUnit;
 


### PR DESCRIPTION
Packages shouldn't import files from other packages using relative import paths