### PR TITLE
Ensure spacing before `Hash` exists when printing with overrides.

### DIFF
--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -131,4 +131,22 @@ QUnit.module('[glimmer-syntax] Code generation - override', function() {
 
     assert.equal(actual, `<FooBar @baz="ZOMG!!!!" @derp="qux" />`);
   });
+
+  test('maintains proper spacing when overriding hash', function(assert) {
+    let ast = parse(`{{foo-bar blah=baz}}`);
+
+    let actual = print(ast, {
+      entityEncoding: 'transformed',
+
+      override(ast) {
+        if (ast.type === 'Hash') {
+          return 'baz="ZOMG!!!!"';
+        }
+
+        return;
+      },
+    });
+
+    assert.equal(actual, `{{foo-bar baz="ZOMG!!!!"}}`);
+  });
 });


### PR DESCRIPTION
Ensures that the override string for `Hash` begins with a whitespace character. Without this any users of the `PrinterOptions.overrides` API (codemods mostly) will not be able to properly implement and override `Hash`. This is due to the AST not representing the whitespace characters. For example, given the following:

```
{{foo-bar baz=qux}}
```

`foo-bar` is the printed result of the `PathExpression` and `baz=qux` is the printed result of the `Hash`, but there is no AST node that represents the ` ` separating them. If this `Hash` was printed with a `PrinterOptions.overrides` function that returned `baz=qux`, the result would be missing the whitespace between the path and hash (e.g. it would be `{{foo-barbaz=qux}}`).

The only places where this is important (to my knowledge) is with params and hash. Unfortunately, there is no top level `Params` object so it is currently impossible to run into the issue there (since there is nothing to override) which means we only need to ensure leading whitespace when processing overrides for `Hash`.