### PR TITLE
Add a failing test for preprocess(`<TITLE></TITLE>`)

### DIFF
--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -744,6 +744,28 @@ class Rehydration extends AbstractRehydrationTests {
   }
 
   @test
+  'TITLE tag'() {
+    let template = '<TITLE>{{pageTitle}} some {{{other}}}{{thing}} <b>hey!</b></TITLE>';
+    this.renderServerSide(template, { pageTitle: 'kiwi', other: 'other', thing: 'thing' });
+    let b = blockStack();
+    this.assertHTML(strip`
+      ${b(0)}
+      <TITLE>
+        kiwi some otherthing <b>hey!</b>
+      </TITLE>
+      ${b(0)}
+    `);
+    this.renderClientSide(template, { pageTitle: 'kiwi', other: 'other', thing: 'thing' });
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertHTML(strip`
+      <TITLE>
+        kiwi some otherthing <b>hey!</b>
+      </TITLE>
+    `);
+    this.assertStableRerender();
+  }
+
+  @test
   'script tag'() {
     let template = strip`
       <script type="application/ld+json">{{data}}</script>


### PR DESCRIPTION
Parsing `<TITLE>{{aVariable}} a title</TITLE>` with `@glimmer-vm/syntax` fails with the following error:
```
SyntaxError: Unclosed element `TITLE`
```

The error is thrown on this line: https://github.com/glimmerjs/glimmer-vm/blob/v0.45.3/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts#L59

I get the same error for `SCRIPT` and `STYLE`. Is this something expected?