### PR TITLE
[BUGFIX] glimmer reports possible XSS when static styles are used with element modifier applied to the same element

### DIFF
--- a/packages/@glimmer/compiler/lib/allocate-symbols.ts
+++ b/packages/@glimmer/compiler/lib/allocate-symbols.ts
@@ -211,7 +211,7 @@ export class SymbolAllocator implements Processor<AllocateSymbolsOps> {
   }
 
   trustingComponentAttr([name, ns]: [string, Option<string>]) {
-    return ['trustedComponentAttr', [name, ns]];
+    return ['trustingComponentAttr', [name, ns]];
   }
 
   append(trusted: boolean) {

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -178,16 +178,11 @@ export default class TemplateCompiler implements Processor<InputOps> {
         this.opcode(['attrSplat'], action);
       } else if (isStatic && !isComponent) {
         this.opcode(['staticAttr', [name, namespace]], action);
-      } else if (isTrusting) {
+      } else if ((isStatic && name === 'style') || isTrusting) {
         this.opcode(
           isComponent
             ? ['trustingComponentAttr', [name, namespace]]
             : ['trustingAttr', [name, namespace]],
-          action
-        );
-      } else if (action.value.type === 'MustacheStatement') {
-        this.opcode(
-          isComponent ? ['componentAttr', [name, namespace]] : ['dynamicAttr', [name, namespace]],
           action
         );
       } else {


### PR DESCRIPTION
Fix for glimmer warning about possible XSS when static styles are used with element modifier applied to the same element.

- style-warnings-test.js - added test demonstrating problem
- template-compiler.ts - extended condition for trusting static styles attributes and removed duplicate branches
- allocate-symbols.ts - my guess is that there was a typo, so I fixed it - without it, tests fail - please double check this change