### PR TITLE
[BUGFIX] Don't serialize template metas in the JIT constant pool

### DIFF
--- a/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
@@ -10,13 +10,13 @@ import {
   AnnotatedModuleLocator,
   CompileTimeComponent,
 } from '@glimmer/interfaces';
-import { Constants, HeapImpl, RuntimeProgramImpl } from '@glimmer/program';
+import { JitConstants, HeapImpl, RuntimeProgramImpl } from '@glimmer/program';
 import { TestJitRegistry } from './registry';
 import { compileStd, unwrapTemplate } from '@glimmer/opcode-compiler';
 import TestJitRuntimeResolver from './resolver';
 
 export class TestJitCompilationContext implements WholeProgramCompilationContext {
-  readonly constants = new Constants();
+  readonly constants = new JitConstants();
   readonly resolverDelegate: JitCompileTimeLookup;
   readonly heap = new HeapImpl();
   readonly mode = CompileMode.jit;

--- a/packages/@glimmer/opcode-compiler/lib/program-context.ts
+++ b/packages/@glimmer/opcode-compiler/lib/program-context.ts
@@ -8,7 +8,7 @@ import {
   CompileTimeConstants,
   RuntimeConstants,
 } from '@glimmer/interfaces';
-import { WriteOnlyConstants, HeapImpl, Constants } from '@glimmer/program';
+import { WriteOnlyConstants, HeapImpl, JitConstants } from '@glimmer/program';
 import { compileStd } from './opcode-builder/helpers/stdlib';
 
 export class ProgramCompilationContext implements WholeProgramCompilationContext {
@@ -24,7 +24,7 @@ export class ProgramCompilationContext implements WholeProgramCompilationContext
 }
 
 export class JitProgramCompilationContext implements JitProgramCompilationContext {
-  readonly constants: CompileTimeConstants & RuntimeConstants = new Constants();
+  readonly constants: CompileTimeConstants & RuntimeConstants = new JitConstants();
   readonly resolverDelegate: CompileTimeResolverDelegate;
   readonly heap: CompileTimeHeap & RuntimeHeap = new HeapImpl();
   readonly stdlib: STDLib;

--- a/packages/@glimmer/opcode-compiler/test/jit-context-test.ts
+++ b/packages/@glimmer/opcode-compiler/test/jit-context-test.ts
@@ -1,0 +1,13 @@
+import { JitContext } from '..';
+
+QUnit.module('Jit Context Test');
+
+QUnit.test('Jit template metas are not not stringified and parsed', assert => {
+  let context = JitContext();
+
+  let { constants } = context.program;
+
+  let meta = {};
+  let handle = constants.templateMeta(meta);
+  assert.equal(constants.getTemplateMeta(handle), meta, 'Meta is not serialized');
+});

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -138,7 +138,9 @@ export class RuntimeConstantsImpl implements RuntimeConstants {
   }
 }
 
-export class Constants extends WriteOnlyConstants implements RuntimeConstants {
+export class JitConstants extends WriteOnlyConstants implements RuntimeConstants {
+  protected metas: unknown[] = [];
+
   constructor(pool?: ConstantPool) {
     super();
 
@@ -151,6 +153,15 @@ export class Constants extends WriteOnlyConstants implements RuntimeConstants {
     }
 
     this.others = [];
+  }
+
+  templateMeta(meta: unknown): number {
+    let index = this.metas.indexOf(meta);
+    if (index > -1) {
+      return index;
+    }
+
+    return this.metas.push(meta) - 1;
   }
 
   getNumber(value: number): number {
@@ -177,8 +188,8 @@ export class Constants extends WriteOnlyConstants implements RuntimeConstants {
     return (this.arrays as number[][])[value];
   }
 
-  getTemplateMeta<T>(s: number): T {
-    return JSON.parse(this.strings[s]) as T;
+  getTemplateMeta<T>(m: number): T {
+    return this.metas[m] as T;
   }
 
   getOther<T>(value: number): T {

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -48,7 +48,7 @@ import { AttrNamespace, SimpleElement } from '@simple-dom/interface';
 import { DOMChangesImpl, DOMTreeConstruction } from './dom/helper';
 import { ConditionalReference, UNDEFINED_REFERENCE } from './references';
 import { DynamicAttribute, dynamicAttribute } from './vm/attributes/dynamic';
-import { RuntimeProgramImpl, Constants, HeapImpl } from '@glimmer/program';
+import { RuntimeProgramImpl, JitConstants, HeapImpl } from '@glimmer/program';
 
 export function isScopeReference(s: ScopeSlot): s is VersionedPathReference {
   if (s === null || Array.isArray(s)) return false;
@@ -666,7 +666,7 @@ export function JitRuntime<R, E>(
 ): JitRuntimeContext<R, E> {
   let env = new EnvironmentImpl(options, delegate);
 
-  let constants = new Constants();
+  let constants = new JitConstants();
   let heap = new HeapImpl();
   let program = new RuntimeProgramImpl(constants, heap);
 


### PR DESCRIPTION
Currently the JIT mode constant pool serializes template metas. This is
necessary for AOT mode, but is not needed in JIT mode, since templates
are compiled at runtime. Aside from being extra work, it also introduced
an issue in Ember where we could no longer correctly associate templates
with their owners.

This updates the `Constants` class to be `JitConstants` to reflect where
it should be used, and adds a pool specifically for metas.