### PR TITLE
[PERF] Splits out template metas and serializables in constant pool

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -32,8 +32,12 @@ export default class DebugConstants extends WriteOnlyConstants implements Runtim
     return ({ handle: s } as any) as T;
   }
 
-  getTemplateMeta(s: number): unknown {
+  getSerializable(s: number): unknown {
     return JSON.parse(this.strings[s]);
+  }
+
+  getTemplateMeta(m: number): unknown {
+    return this.getSerializable(m);
   }
 
   getOther(s: number): unknown {

--- a/packages/@glimmer/interfaces/lib/compile/operands.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/operands.d.ts
@@ -48,6 +48,11 @@ export interface SerializableOperand {
   value: unknown;
 }
 
+export interface TemplateMetaOperand {
+  type: 'template-meta';
+  value: unknown;
+}
+
 export interface OtherOperand {
   type: 'other';
   value: unknown;
@@ -99,6 +104,7 @@ export type NonlabelBuilderOperand =
   | ArrayOperand
   | StringArrayOperand
   | SerializableOperand
+  | TemplateMetaOperand
   | OtherOperand
   | StdlibOperand
   | LookupHandleOperand

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -102,6 +102,7 @@ export interface CompileTimeConstants {
   string(value: string): number;
   stringArray(strings: string[]): number;
   array(values: number[]): number;
+  serializable(value: unknown): number;
   templateMeta(value: unknown): number;
   number(value: number): number;
   other(value: unknown): number;
@@ -121,6 +122,7 @@ export interface RuntimeConstants {
   getString(handle: number): string;
   getStringArray(value: number): string[];
   getArray(value: number): number[];
+  getSerializable(handle: number): unknown;
   getTemplateMeta(s: number): unknown;
   getOther(s: number): unknown;
 }

--- a/packages/@glimmer/opcode-compiler/lib/debug.ts
+++ b/packages/@glimmer/opcode-compiler/lib/debug.ts
@@ -18,7 +18,8 @@ export interface DebugConstants {
   getString(value: number): string;
   getStringArray(value: number): string[];
   getArray(value: number): number[];
-  getTemplateMeta(s: number): unknown;
+  getSerializable(s: number): unknown;
+  getTemplateMeta(m: number): unknown;
 }
 
 interface LazyDebugConstants {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -211,6 +211,8 @@ function constant(
     case 'string-array':
       return constants.stringArray(operand.value);
     case 'serializable':
+      return constants.serializable(operand.value);
+    case 'template-meta':
       return constants.templateMeta(operand.value);
     case 'other':
       // TODO: Bad cast

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
@@ -17,7 +17,7 @@ import {
   CompileTimeComponent,
 } from '@glimmer/interfaces';
 
-import { label, serializable } from '../operands';
+import { label, templateMeta } from '../operands';
 import { resolveLayoutForTag } from '../../resolver';
 import { $s0, $sp, $s1, $v0, SavedRegister } from '@glimmer/vm';
 import { meta } from './shared';
@@ -256,7 +256,7 @@ export function InvokeDynamicComponent(
     body: () => {
       return [
         op(Op.JumpUnless, label('ELSE')),
-        op(Op.ResolveDynamicComponent, serializable(meta.referrer)),
+        op(Op.ResolveDynamicComponent, templateMeta(meta.referrer)),
         op(Op.PushDynamicComponentInstance),
         InvokeComponent({
           capabilities: true,
@@ -452,7 +452,7 @@ export function curryComponent(
     op('SimpleArgs', { params, hash, atNames }),
     op(Op.CaptureArgs),
     op('Expr', definition),
-    op(Op.CurryComponent, serializable(referrer)),
+    op(Op.CurryComponent, templateMeta(referrer)),
     op(MachineOp.PopFrame),
     op(Op.Fetch, $v0),
   ];

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
@@ -14,6 +14,7 @@ import {
   PrimitiveType,
   SerializableOperand,
   StringArrayOperand,
+  TemplateMetaOperand,
   WireFormat,
   NonlabelBuilderOperand,
 } from '@glimmer/interfaces';
@@ -38,6 +39,10 @@ export function strArray(value: string[]): StringArrayOperand {
 
 export function serializable(value: unknown): SerializableOperand {
   return { type: 'serializable', value };
+}
+
+export function templateMeta(value: unknown): TemplateMetaOperand {
+  return { type: 'template-meta', value };
 }
 
 export function other(value: unknown): OtherOperand {

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -60,7 +60,7 @@ export class WriteOnlyConstants implements CompileTimeConstants {
     return (this.arrays as number[][]).push(values) - 1;
   }
 
-  templateMeta(value: unknown): number {
+  serializable(value: unknown): number {
     let str = JSON.stringify(value);
     let index = this.strings.indexOf(str);
     if (index > -1) {
@@ -68,6 +68,10 @@ export class WriteOnlyConstants implements CompileTimeConstants {
     }
 
     return this.strings.push(str) - 1;
+  }
+
+  templateMeta(value: unknown): number {
+    return this.serializable(value);
   }
 
   number(number: number): number {
@@ -129,8 +133,12 @@ export class RuntimeConstantsImpl implements RuntimeConstants {
     return (this.arrays as number[][])[value];
   }
 
-  getTemplateMeta<T>(s: number): T {
+  getSerializable<T>(s: number): T {
     return JSON.parse(this.strings[s]) as T;
+  }
+
+  getTemplateMeta<T>(m: number): T {
+    return this.getSerializable(m);
   }
 
   getOther<T>(value: number): T {
@@ -186,6 +194,10 @@ export class JitConstants extends WriteOnlyConstants implements RuntimeConstants
 
   getArray(value: number): number[] {
     return (this.arrays as number[][])[value];
+  }
+
+  getSerializable<T>(s: number): T {
+    return JSON.parse(this.strings[s]) as T;
   }
 
   getTemplateMeta<T>(m: number): T {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
@@ -15,7 +15,7 @@ APPEND_OPCODES.add(
     let name = check(stack.pop(), CheckReference).value();
     assert(typeof name === 'string', `Could not find a partial named "${String(name)}"`);
 
-    let meta = constants.getTemplateMeta(_meta);
+    let meta = constants.getSerializable(_meta);
     let outerSymbols = constants.getStringArray(_symbols);
     let evalInfo = constants.getArray(_evalInfo);
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -101,7 +101,7 @@ APPEND_OPCODES.add(Op.Exit, vm => {
 
 APPEND_OPCODES.add(Op.PushSymbolTable, (vm, { op1: _table }) => {
   let stack = vm.stack;
-  stack.push(vm[CONSTANTS].getTemplateMeta(_table));
+  stack.push(vm[CONSTANTS].getSerializable(_table));
 });
 
 APPEND_OPCODES.add(Op.PushBlockScope, vm => {


### PR DESCRIPTION
Currently, `templateMeta` and `getTemplateMeta` are used for a few
different values:

1. Template metas (Referrers)
2. Symbol tables
3. Partial meta

Symbol tables and partial meta are highly redundant, the same meta value
being entered into the constants pool repeatedly. Template meta, on the
other hand, is usually unique, and provided by the embedding
environment, so it is not guaranteed to be serializable.

This PR separates the two concepts in the constant pool, so that
referrers are stored as objects (and not fully serialized), and other
forms of meta like symbol tables _are_ fully serialized and stored in
the string pool. This has shown an overall performance improvement over
storing all of the meta values as objects.

Benchmark prior to this change (master is `without-meta-serialize`):
[results.pdf](https://github.com/glimmerjs/glimmer-vm/files/4101037/results.pdf)

Benchmark with this change:
[results.pdf](https://github.com/glimmerjs/glimmer-vm/files/4101039/results.pdf)
