### PR TITLE
[BUGFIX] Converts partial meta to template meta in constants pool

### DIFF
--- a/packages/@glimmer/integration-tests/lib/compile.ts
+++ b/packages/@glimmer/integration-tests/lib/compile.ts
@@ -28,14 +28,20 @@ export function preprocess(
   return factory.create(meta || DEFAULT_TEST_META);
 }
 
-export function createTemplate<Locator>(
+export function createTemplate(
   templateSource: string,
-  options?: PrecompileOptions
-): TemplateFactory<Locator> {
-  let wrapper: SerializedTemplateWithLazyBlock<Locator> = JSON.parse(
+  options?: PrecompileOptions,
+  runtimeMeta?: unknown
+): TemplateFactory<AnnotatedModuleLocator> {
+  let wrapper: SerializedTemplateWithLazyBlock<AnnotatedModuleLocator> = JSON.parse(
     rawPrecompile(templateSource, options)
   );
-  return templateFactory<Locator>(wrapper);
+
+  if (runtimeMeta) {
+    wrapper.meta.meta = runtimeMeta;
+  }
+
+  return templateFactory<AnnotatedModuleLocator>(wrapper);
 }
 
 export interface TestCompileOptions extends PrecompileOptions {

--- a/packages/@glimmer/integration-tests/lib/components/static-tagless.ts
+++ b/packages/@glimmer/integration-tests/lib/components/static-tagless.ts
@@ -1,11 +1,6 @@
 import { BasicComponentManager } from './basic';
 import { TestComponentDefinitionState } from './test-component';
-import {
-  ComponentCapabilities,
-  CompilableProgram,
-  AnnotatedModuleLocator,
-  Option,
-} from '@glimmer/interfaces';
+import { ComponentCapabilities, CompilableProgram, Option } from '@glimmer/interfaces';
 import TestJitRuntimeResolver from '../modes/jit/resolver';
 import { createTemplate } from '../compile';
 import { unwrapTemplate } from '@glimmer/opcode-compiler';
@@ -25,7 +20,7 @@ export class StaticTaglessComponentManager extends BasicComponentManager {
 
     return unwrapTemplate(
       resolver.registry.customCompilableTemplate(handle, name, source =>
-        createTemplate<AnnotatedModuleLocator>(source).create()
+        createTemplate(source).create()
       )
     ).asLayout();
   }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/resolver.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/resolver.ts
@@ -26,7 +26,7 @@ export default class TestJitRuntimeResolver implements JitRuntimeResolver {
 
   compilable(locator: AnnotatedModuleLocator): Template {
     let compile = (source: string) => {
-      return createTemplate<AnnotatedModuleLocator>(source).create();
+      return createTemplate(source).create();
     };
 
     let handle = this.lookup('template-source', locator.module)!;

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -7,7 +7,7 @@ import {
   HighLevelResolutionOpcode,
 } from '@glimmer/interfaces';
 import { op } from '../opcode-builder/encoder';
-import { serializable, strArray, arr } from '../opcode-builder/operands';
+import { templateMeta, strArray, arr } from '../opcode-builder/operands';
 import { InvokeStaticComponent, InvokeComponent } from '../opcode-builder/helpers/components';
 import { ReplayableIf } from '../opcode-builder/helpers/conditional';
 import { YieldBlock } from '../opcode-builder/helpers/blocks';
@@ -136,7 +136,7 @@ STATEMENTS.add(SexpOpcodes.Partial, ([, name, evalInfo], meta) =>
       return [
         op(
           Op.InvokePartial,
-          serializable(meta.referrer),
+          templateMeta(meta.referrer),
           strArray(meta.evalSymbols!),
           arr(evalInfo)
         ),

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
@@ -15,7 +15,7 @@ APPEND_OPCODES.add(
     let name = check(stack.pop(), CheckReference).value();
     assert(typeof name === 'string', `Could not find a partial named "${String(name)}"`);
 
-    let meta = constants.getSerializable(_meta);
+    let meta = constants.getTemplateMeta(_meta);
     let outerSymbols = constants.getStringArray(_symbols);
     let evalInfo = constants.getArray(_evalInfo);
 


### PR DESCRIPTION
Partial metas are template metas as it turns out, but we don't have test
cases locally that attempt to serialize a recursive object (like the
`owner` in Ember) and the apps we tested didn't use partials so we
didn't catch it. I'm unsure how to test this, but have verified it fixes
things in Ember manually.