### PR TITLE
[BUGFIX] Gives tracked property initializers access to their `self`

### DIFF
--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -115,7 +115,7 @@ export function trackedData<T extends object, K extends keyof T>(
 
     // If the field has never been initialized, we should initialize it
     if (hasInitializer && !values.has(self)) {
-      value = initializer!();
+      value = initializer!.call(self);
       values.set(self, value);
     } else {
       value = values.get(self);

--- a/packages/@glimmer/validator/test/tracking-test.ts
+++ b/packages/@glimmer/validator/test/tracking-test.ts
@@ -145,6 +145,21 @@ module('@glimmer/validator: tracking', () => {
       assert.equal(foo.foo, 123, 'value is not set on the actual object');
     });
 
+    test('the initializer has access to the context', assert => {
+      class Foo {
+        foo = 123;
+        bar = 456;
+      }
+
+      let { getter } = trackedData<Foo, keyof Foo>('foo', function(this: Foo) {
+        return this.bar;
+      });
+
+      let foo = new Foo();
+
+      assert.equal(getter(foo), 456, 'value is initialized correctly');
+    });
+
     test('it tracks changes to the storage cell', assert => {
       class Foo {
         foo = 123;


### PR DESCRIPTION
Class initializers may use the instance that they are being initialized
on. This PR ensures we call initializers with the proper context.