### PR TITLE
[BUGFIX] Ensure Iterables work with dictionaries

### DIFF
--- a/packages/@glimmer/reference/lib/iterable-impl.ts
+++ b/packages/@glimmer/reference/lib/iterable-impl.ts
@@ -1,8 +1,8 @@
 import { AbstractIterable, IterationItem, OpaqueIterator, OpaqueIterationItem } from './iterable';
 import { Tag } from '@glimmer/validator';
 import { Option, Dict } from '@glimmer/interfaces';
-import { EMPTY_ARRAY, isObject } from '@glimmer/util';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { EMPTY_ARRAY, isObject, debugToString } from '@glimmer/util';
+import { DEBUG } from '@glimmer/env';
 import { IterationItemReference, TemplateReferenceEnvironment } from './template';
 import { VersionedPathReference } from './reference';
 
@@ -178,7 +178,7 @@ export class IterableImpl
   valueReferenceFor(item: IterationItem<unknown, unknown>): IterationItemReference<unknown> {
     let { parentRef, env } = this;
 
-    return new IterationItemReference(parentRef, item.value, item.key, env);
+    return new IterationItemReference(parentRef, item.value, item.memo, env);
   }
 
   updateValueReference(
@@ -191,7 +191,12 @@ export class IterableImpl
   memoReferenceFor(item: IterationItem<unknown, unknown>): IterationItemReference<unknown> {
     let { parentRef, env } = this;
 
-    return new IterationItemReference(parentRef, item.memo, item.key, env);
+    return new IterationItemReference(
+      parentRef,
+      item.memo,
+      DEBUG ? `(key: ${debugToString!(item.key)}` : '',
+      env
+    );
   }
 
   updateMemoReference(

--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -1,5 +1,5 @@
 import { ComponentInstanceState, CapturedArguments, Option } from '@glimmer/interfaces';
-import { dict, isDict, symbol } from '@glimmer/util';
+import { dict, isDict, symbol, debugToString } from '@glimmer/util';
 import {
   CONSTANT_TAG,
   Tag,
@@ -298,7 +298,7 @@ export class IterationItemReference<T = unknown> implements TemplatePathReferenc
     private env: TemplateReferenceEnvironment
   ) {
     if (DEBUG) {
-      env.setTemplatePathDebugContext(this, String(itemKey), parentReference);
+      env.setTemplatePathDebugContext(this, debugToString!(itemKey), parentReference);
     }
   }
 

--- a/packages/@glimmer/reference/test/iterable-impl-test.ts
+++ b/packages/@glimmer/reference/test/iterable-impl-test.ts
@@ -172,5 +172,13 @@ module('@glimmer/reference: IterableImpl', () => {
 
       assert.deepEqual(target.toKeys(), ['a', 'b']);
     });
+
+    test('it works with dictionaries', assert => {
+      let arr = [Object.create(null), Object.create(null)];
+      let { target } = initialize(arr);
+
+      assert.deepEqual(target.toValues(), arr);
+      assert.deepEqual(target.toKeys(), arr);
+    });
   });
 });

--- a/packages/@glimmer/util/index.ts
+++ b/packages/@glimmer/util/index.ts
@@ -22,6 +22,8 @@ export { assign, fillNulls, values } from './lib/object-utils';
 export * from './lib/platform-utils';
 export * from './lib/string';
 
+export { default as debugToString } from './lib/debug-to-string';
+
 export type FIXME<T, S extends string> = T & S | T;
 
 export function assertNever(value: never, desc = 'unexpected unreachable branch'): void {

--- a/packages/@glimmer/util/lib/debug-to-string.ts
+++ b/packages/@glimmer/util/lib/debug-to-string.ts
@@ -1,0 +1,25 @@
+import { DEBUG } from '@glimmer/env';
+
+let debugToString: undefined | ((value: unknown) => string);
+
+if (DEBUG) {
+  debugToString = (value: unknown) => {
+    let string;
+
+    if (typeof value === 'function') {
+      string = value.name;
+    } else if (typeof value === 'object' && value !== null) {
+      let className = (value.constructor && value.constructor.name) || '(unknown class)';
+
+      string = `(an instance of ${className})`;
+    } else if (value === undefined) {
+      string = '(an unknown tag)';
+    } else {
+      string = String(value);
+    }
+
+    return string;
+  };
+}
+
+export default debugToString;

--- a/packages/@glimmer/util/lib/debug-to-string.ts
+++ b/packages/@glimmer/util/lib/debug-to-string.ts
@@ -3,22 +3,64 @@ import { DEBUG } from '@glimmer/env';
 let debugToString: undefined | ((value: unknown) => string);
 
 if (DEBUG) {
-  debugToString = (value: unknown) => {
-    let string;
+  let getFunctionName = (fn: Function) => {
+    let functionName = fn.name;
 
-    if (typeof value === 'function') {
-      string = value.name;
-    } else if (typeof value === 'object' && value !== null) {
-      let className = (value.constructor && value.constructor.name) || '(unknown class)';
+    if (functionName === undefined) {
+      let match = Function.prototype.toString.call(fn).match(/function (\w+)\s*\(/);
 
-      string = `(an instance of ${className})`;
-    } else if (value === undefined) {
-      string = '(an unknown tag)';
-    } else {
-      string = String(value);
+      functionName = (match && match[1]) || '';
     }
 
-    return string;
+    return functionName.replace(/^bound /, '');
+  };
+
+  let getObjectName = (obj: object) => {
+    let name;
+    let className;
+
+    if (obj.constructor && obj.constructor !== Object) {
+      className = getFunctionName(obj.constructor);
+    }
+
+    if (
+      'toString' in obj &&
+      obj.toString !== Object.prototype.toString &&
+      obj.toString !== Function.prototype.toString
+    ) {
+      name = obj.toString();
+    }
+
+    // If the class has a decent looking name, and the `toString` is one of the
+    // default Ember toStrings, replace the constructor portion of the toString
+    // with the class name. We check the length of the class name to prevent doing
+    // this when the value is minified.
+    if (
+      name &&
+      name.match(/<.*:ember\d+>/) &&
+      className &&
+      className[0] !== '_' &&
+      className.length > 2 &&
+      className !== 'Class'
+    ) {
+      return name.replace(/<.*:/, `<${className}:`);
+    }
+
+    return name || className;
+  };
+
+  let getPrimitiveName = (value: any) => {
+    return String(value);
+  };
+
+  debugToString = (value: unknown) => {
+    if (typeof value === 'function') {
+      return getFunctionName(value) || `(unknown function)`;
+    } else if (typeof value === 'object' && value !== null) {
+      return getObjectName(value) || `(unknown object)`;
+    } else {
+      return getPrimitiveName(value);
+    }
   };
 }
 


### PR DESCRIPTION
In the recent VM upgrade, a general API for adding debug information to
references was added. This included debug information for iteration
items, which have dynamic path segments. There were two issues with the
implementation:

1. We were using the `key` instead of the `memo` property for displaying
   which item in the collection was being used. Counterintuitively,
   `memo` is the actual key for the value in the collection, whereas
   `key` is the memoization key used to determine if the item should be
   updated. This has been updated, so that `memo` is used to show users
   where they are in the collection.

2. Since keys can be arbitrary objects, we can't always safely coerce
   them to be strings, so we have to add some debug-only logic for
   coercion.