### PR TITLE
Avoid double-clearing `{{in-element}}`

### DIFF
--- a/packages/@glimmer/integration-tests/lib/suites/in-element.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/in-element.ts
@@ -283,6 +283,28 @@ export class InElementSuite extends RenderTest {
   }
 
   @test
+  'Inside the current constructing element'() {
+    this.render(
+      stripTight`
+        Before
+        {{#in-element this.element insertBefore=null}}
+          {{this.foo}}
+        {{/in-element}}
+        After
+      `,
+      {
+        element: this.element,
+        foo: 'Yippie!',
+      }
+    );
+
+    this.assertHTML('BeforeYippie!<!---->After');
+    this.assertStableRerender();
+
+    this.renderResult!.destroy();
+  }
+
+  @test
   Multiple() {
     let firstElement = this.delegate.createElement('div');
     let secondElement = this.delegate.createElement('div');


### PR DESCRIPTION
This usually happens when the app uses `{{in-element}}` to append to `Ember.Application.rootElement` during initial render, which causes Glimmer to (incorrectly) include the "remoted content" in the root render result. When the render result is torn down, the "remoted content" gets removed as well, and so by the time its destructor runs it will be trying to clear its content again, which causes the double-clearing error ("The node to be removed is not a child of this node." in "removeChild").

This is probably a better fix to how Glimmer views the boundaries it manages, but this should be sufficient to suppress the error for now without too much undesirable side-effects.

Fixes emberjs/ember.js#18696

Co-authored-by: Yehuda Katz <wycats@gmail.com>