### PR TITLE
syntax/traversal: Add `parents()` generator method to the `Path` class

### DIFF
--- a/packages/@glimmer/syntax/lib/traversal/path.ts
+++ b/packages/@glimmer/syntax/lib/traversal/path.ts
@@ -15,11 +15,28 @@ export default class Path<N extends Node> {
     return this.parent ? this.parent.node : null;
   }
 
-  *parents(): IterableIterator<Path<Node>> {
-    let path: Path<Node> = this;
-    while (path.parent) {
-      path = path.parent;
-      yield path;
-    }
+  parents(): PathParentsIterable {
+    return new PathParentsIterable(this);
+  }
+}
+
+class PathParentsIterable implements Iterable<Path<Node>> {
+  path: Path<Node>;
+
+  constructor(path: Path<Node>) {
+    this.path = path;
+  }
+
+  [Symbol.iterator]() {
+    let next: () => IteratorResult<Path<Node>, undefined> = () => {
+      if (this.path.parent) {
+        this.path = this.path.parent;
+        return { done: false, value: this.path };
+      } else {
+        return { done: true, value: undefined };
+      }
+    };
+
+    return { next };
   }
 }

--- a/packages/@glimmer/syntax/lib/traversal/path.ts
+++ b/packages/@glimmer/syntax/lib/traversal/path.ts
@@ -14,4 +14,12 @@ export default class Path<N extends Node> {
   get parentNode(): Node | null {
     return this.parent ? this.parent.node : null;
   }
+
+  *parents(): IterableIterator<Path<Node>> {
+    let path: Path<Node> = this;
+    while (path.parent) {
+      path = path.parent;
+      yield path;
+    }
+  }
 }

--- a/packages/@glimmer/syntax/lib/traversal/path.ts
+++ b/packages/@glimmer/syntax/lib/traversal/path.ts
@@ -15,28 +15,28 @@ export default class Path<N extends Node> {
     return this.parent ? this.parent.node : null;
   }
 
-  parents(): PathParentsIterable {
-    return new PathParentsIterable(this);
+  parents(): Iterable<Path<Node> | null> {
+    return {
+      [Symbol.iterator]: () => {
+        return new PathParentsIterator(this);
+      },
+    };
   }
 }
 
-class PathParentsIterable implements Iterable<Path<Node>> {
+class PathParentsIterator implements Iterator<Path<Node> | null> {
   path: Path<Node>;
 
   constructor(path: Path<Node>) {
     this.path = path;
   }
 
-  [Symbol.iterator]() {
-    let next: () => IteratorResult<Path<Node>, undefined> = () => {
-      if (this.path.parent) {
-        this.path = this.path.parent;
-        return { done: false, value: this.path };
-      } else {
-        return { done: true, value: undefined };
-      }
-    };
-
-    return { next };
+  next() {
+    if (this.path.parent) {
+      this.path = this.path.parent;
+      return { done: false, value: this.path };
+    } else {
+      return { done: true, value: null };
+    }
   }
 }

--- a/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
+++ b/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
@@ -328,7 +328,9 @@ test('Helper', function(assert) {
 });
 
 test('Modifier', function(assert) {
-  assert.expect(3);
+  let hasSymbol = typeof Symbol !== 'undefined';
+
+  assert.expect(hasSymbol ? 3 : 2);
 
   let ast = parse(`<div {{foo}}></div>`);
 
@@ -342,11 +344,13 @@ test('Modifier', function(assert) {
           { nodeType: 'PathExpression', key: null },
         ]);
 
-        assert.deepEqual(Array.from(path.parents()).map(it => (it as Path<AST.Node>).node.type), [
-          'ElementModifierStatement',
-          'ElementNode',
-          'Template',
-        ]);
+        if (hasSymbol) {
+          assert.deepEqual(Array.from(path.parents()).map(it => (it as Path<AST.Node>).node.type), [
+            'ElementModifierStatement',
+            'ElementNode',
+            'Template',
+          ]);
+        }
 
         assert.strictEqual((path.parent!.node as AST.ElementModifierStatement).path, node);
       }

--- a/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
+++ b/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
@@ -342,7 +342,7 @@ test('Modifier', function(assert) {
           { nodeType: 'PathExpression', key: null },
         ]);
 
-        assert.deepEqual(Array.from(path.parents()).map(it => it.node.type), [
+        assert.deepEqual(Array.from(path.parents()).map(it => (it as Path<AST.Node>).node.type), [
           'ElementModifierStatement',
           'ElementNode',
           'Template',

--- a/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
+++ b/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
@@ -328,7 +328,7 @@ test('Helper', function(assert) {
 });
 
 test('Modifier', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   let ast = parse(`<div {{foo}}></div>`);
 
@@ -340,6 +340,12 @@ test('Modifier', function(assert) {
           { nodeType: 'ElementNode', key: 'modifiers' },
           { nodeType: 'ElementModifierStatement', key: 'path' },
           { nodeType: 'PathExpression', key: null },
+        ]);
+
+        assert.deepEqual(Array.from(path.parents()).map(it => it.node.type), [
+          'ElementModifierStatement',
+          'ElementNode',
+          'Template',
         ]);
 
         assert.strictEqual((path.parent!.node as AST.ElementModifierStatement).path, node);


### PR DESCRIPTION
This makes it easier to iterate over all of the parent nodes of a node

Extracted from https://github.com/ember-template-lint/ember-template-lint/pull/1106

/cc @melsumner