### PR TITLE
[CLEANUP][BREAKING] Simplifies JitRuntime, JitContext, Environment setup

### DIFF
--- a/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
@@ -1,36 +1,14 @@
 import {
-  WholeProgramCompilationContext,
   CompileTimeResolverDelegate,
-  CompileMode,
-  STDLib,
-  RuntimeProgram,
   ComponentCapabilities,
   Option,
   ComponentDefinition,
   AnnotatedModuleLocator,
   CompileTimeComponent,
 } from '@glimmer/interfaces';
-import { JitConstants, HeapImpl, RuntimeProgramImpl } from '@glimmer/program';
 import { TestJitRegistry } from './registry';
-import { compileStd, unwrapTemplate } from '@glimmer/opcode-compiler';
+import { unwrapTemplate } from '@glimmer/opcode-compiler';
 import TestJitRuntimeResolver from './resolver';
-
-export class TestJitCompilationContext implements WholeProgramCompilationContext {
-  readonly constants = new JitConstants();
-  readonly resolverDelegate: JitCompileTimeLookup;
-  readonly heap = new HeapImpl();
-  readonly mode = CompileMode.jit;
-  readonly stdlib: STDLib;
-
-  constructor(runtimeResolver: TestJitRuntimeResolver, registry: TestJitRegistry) {
-    this.stdlib = compileStd(this);
-    this.resolverDelegate = new JitCompileTimeLookup(runtimeResolver, registry);
-  }
-
-  program(): RuntimeProgram {
-    return new RuntimeProgramImpl(this.constants, this.heap);
-  }
-}
 
 export default class JitCompileTimeLookup implements CompileTimeResolverDelegate {
   constructor(private resolver: TestJitRuntimeResolver, private registry: TestJitRegistry) {}

--- a/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
@@ -10,7 +10,7 @@ import {
 } from '@glimmer/interfaces';
 import { SimpleDocument, SimpleElement } from '@simple-dom/interface';
 import { TestJitRegistry } from './registry';
-import { getDynamicVar, clientBuilder, JitRuntimeFromProgram } from '@glimmer/runtime';
+import { getDynamicVar, clientBuilder, JitRuntime } from '@glimmer/runtime';
 import {
   registerInternalHelper,
   registerStaticTaglessComponent,
@@ -20,7 +20,7 @@ import {
   registerHelper,
 } from './register';
 import { TestMacros } from '../../compile/macros';
-import { TestJitCompilationContext } from './compilation-context';
+import JitCompileTimeLookup from './compilation-context';
 import TestJitRuntimeResolver from './resolver';
 import RenderDelegate from '../../render-delegate';
 import { ComponentKind, ComponentTypes } from '../../components';
@@ -31,6 +31,7 @@ import { TestModifierConstructor } from '../../modifiers';
 import { UserHelper } from '../../helpers';
 import { UpdatableRootReference, ConstReference } from '@glimmer/reference';
 import { renderTemplate } from './render';
+import { JitContext } from '@glimmer/opcode-compiler';
 
 export interface JitTestDelegateContext {
   runtime: JitRuntimeContext;
@@ -43,10 +44,9 @@ export function JitDelegateContext(
   registry: TestJitRegistry
 ): JitTestDelegateContext {
   registerInternalHelper(registry, '-get-dynamic-var', getDynamicVar);
-  let context = new TestJitCompilationContext(resolver, registry);
-  let runtime = JitRuntimeFromProgram({ document: doc }, context.program(), resolver);
-  let syntax = { program: context, macros: new TestMacros() };
-  return { runtime, syntax };
+  let context = JitContext(new JitCompileTimeLookup(resolver, registry), new TestMacros());
+  let runtime = JitRuntime({ document: doc }, {}, context, resolver);
+  return { runtime, syntax: context };
 }
 
 export class JitRenderDelegate implements RenderDelegate {

--- a/packages/@glimmer/integration-tests/lib/modes/jit/test-context.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/test-context.ts
@@ -2,23 +2,22 @@ import TestJitRuntimeResolver from './resolver';
 import { TestJitRegistry } from './registry';
 import {
   SyntaxCompilationContext,
-  WholeProgramCompilationContext,
   JitRuntimeContext,
   Environment,
   Dict,
 } from '@glimmer/interfaces';
 import { SimpleDocument, SimpleElement } from '@simple-dom/interface';
-import { EnvironmentDelegate, JitRuntimeFromProgram } from '@glimmer/runtime';
+import { EnvironmentDelegate, JitRuntime } from '@glimmer/runtime';
 import { registerHelper } from './register';
-import { TestJitCompilationContext } from './compilation-context';
+import JitCompileTimeLookup from './compilation-context';
 import { TestMacros } from '../../compile/macros';
 import { assign } from '@glimmer/util';
+import { JitContext } from '@glimmer/opcode-compiler';
 
 export interface TestContext extends Dict {
   resolver: TestJitRuntimeResolver;
   registry: TestJitRegistry;
   syntax: SyntaxCompilationContext;
-  program: WholeProgramCompilationContext;
   doc: SimpleDocument;
   root: SimpleElement;
   runtime: JitRuntimeContext;
@@ -30,25 +29,27 @@ export function JitTestContext(delegate: EnvironmentDelegate = {}): TestContext 
   let registry = resolver.registry;
   registerHelper(registry, 'hash', (_positional, named) => named);
 
-  let context = new TestJitCompilationContext(resolver, registry);
-  let syntax: SyntaxCompilationContext = { program: context, macros: new TestMacros() };
+  let context = JitContext(new JitCompileTimeLookup(resolver, registry), new TestMacros());
   let doc = document as SimpleDocument;
 
-  let runtime = JitRuntimeFromProgram(
+  let runtime = JitRuntime(
     { document: document as SimpleDocument },
-    context.program(),
-    resolver,
-    assign(
-      {
-        toBool: emberToBool,
-      },
-      delegate
-    )
+    assign({ toBool: emberToBool }, delegate),
+    context,
+    resolver
   );
 
   let root = document.getElementById('qunit-fixture')! as SimpleElement;
 
-  return { resolver, registry, program: context, syntax, doc, root, runtime, env: runtime.env };
+  return {
+    resolver,
+    registry,
+    syntax: context,
+    doc,
+    root,
+    runtime,
+    env: runtime.env,
+  };
 }
 
 export function emberToBool(value: any): boolean {

--- a/packages/@glimmer/integration-tests/test/partial-test.ts
+++ b/packages/@glimmer/integration-tests/test/partial-test.ts
@@ -1,9 +1,4 @@
-import {
-  RenderResult,
-  RichIteratorResult,
-  SyntaxCompilationContext,
-  Template,
-} from '@glimmer/interfaces';
+import { RenderResult, RichIteratorResult, Template } from '@glimmer/interfaces';
 import { UpdatableRootReference } from '@glimmer/object-reference';
 import { clientBuilder, renderJitMain } from '@glimmer/runtime';
 import {
@@ -19,7 +14,6 @@ import {
   registerPartial,
   strip,
   TestContext,
-  TestMacros,
 } from '..';
 import { SimpleNode } from '@simple-dom/interface';
 import { unwrapTemplate, unwrapHandle } from '@glimmer/opcode-compiler';
@@ -41,13 +35,12 @@ function render(template: Template, state = {}) {
   context.env.begin();
   let cursor = { element: context.root, nextSibling: null };
 
-  let syntax: SyntaxCompilationContext = { program: context.program, macros: new TestMacros() };
   let compilable = unwrapTemplate(template).asLayout();
-  let handle = compilable.compile(syntax);
+  let handle = compilable.compile(context.syntax);
 
   let templateIterator = renderJitMain(
     context.runtime,
-    syntax,
+    context.syntax,
     self,
     clientBuilder(context.env, cursor),
     unwrapHandle(handle)

--- a/packages/@glimmer/reference/lib/iterable-impl.ts
+++ b/packages/@glimmer/reference/lib/iterable-impl.ts
@@ -29,7 +29,7 @@ const IDENTITY: KeyFor = item => {
 
 function keyForPath(path: string, getPath: (item: unknown, path: string) => any): KeyFor {
   if (DEBUG && path[0] === '@') {
-    throw new Error(`invalid keypath: '${keyForPath}'`);
+    throw new Error(`invalid keypath: '${path}', valid keys: @index, @identity, or a path`);
   }
   return uniqueKeyFor(item => getPath(item, path));
 }

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -28,12 +28,11 @@ export { normalizeProperty } from './lib/dom/props';
 export { DefaultDynamicScope } from './lib/dynamic-scope';
 export {
   AotRuntime,
-  default as EnvironmentImpl,
-  CustomJitRuntime,
-  JitRuntimeFromProgram,
   JitRuntime,
   EnvironmentDelegate,
   ScopeImpl,
+  JitProgramCompilationContext,
+  JitSyntaxCompilationContext,
   inTransaction,
 } from './lib/environment';
 export { default as getDynamicVar } from './lib/helpers/get-dynamic-var';


### PR DESCRIPTION
Currently there are three JitRuntime creation methods:

- `CustomJitRuntime`
- `JitRuntime`
- `JitRuntimeFromProgram`

With the recent refactors to Ember and Glimmer.js, we can consolidate
these to a single method. In addition, this PR updates that method to
take the `JitContext()` output directly, rather than requiring users
create a program themselves.

As part of this work, I also simplified tests to use the actual
`JitContext` method rather than making a custom one.

Finally, this PR makes `updateOperations` optional on the environment
delegate. This allows environments that do not want to update, such as
streaming SSR, to opt out of updates altogether.