### PR TITLE
[BUGFIX] Update HasBlockParams metadata

### DIFF
--- a/build/broccoli/build-packages.js
+++ b/build/broccoli/build-packages.js
@@ -9,7 +9,7 @@ const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 const transpileToES5 = require('./transpile-to-es5');
 const writePackageJSON = require('./write-package-json');
 const writeLicense = require('./write-license');
-const debugMacros = require('babel-plugin-debug-macros').default;
+const debugMacros = require('babel-plugin-debug-macros');
 
 const Project = require('../utils/project');
 const project = Project.from('packages');
@@ -155,14 +155,17 @@ function transpileCommonJS(pkgName, esVersion, tree) {
       [
         debugMacros,
         {
-          envFlags: {
-            source: '@glimmer/local-debug-flags',
-            flags: {
-              DEVMODE: process.env.EMBER_ENV !== 'production',
-              DEBUG: false,
+          flags: [
+            {
+              source: '@glimmer/local-debug-flags',
+              flags: {
+                LOCAL_DEBUG: false,
+                LOCAL_SHOULD_LOG: false,
+              },
             },
-          },
+          ],
           debugTools: {
+            isDebug: false,
             source: '@glimmer/util',
           },
           externalizeHelpers: {

--- a/build/broccoli/strip-glimmer-utilities.js
+++ b/build/broccoli/strip-glimmer-utilities.js
@@ -2,7 +2,7 @@
 
 const babel = require('broccoli-babel-transpiler');
 const stripGlimmerUtils = require('babel-plugin-strip-glimmer-utils');
-const debugMacros = require('babel-plugin-debug-macros').default;
+const debugMacros = require('babel-plugin-debug-macros');
 const nuke = require('babel-plugin-nukable-import');
 const nameResolver = require('amd-name-resolver').moduleResolve;
 
@@ -34,14 +34,17 @@ function stripFlags(glimmerUtils) {
   glimmerUtils.push([
     debugMacros,
     {
-      envFlags: {
-        source: '@glimmer/local-debug-flags',
-        flags: {
-          DEBUG: process.env.EMBER_ENV !== 'production',
-          DEVMODE: process.env.EMBER_ENV !== 'production',
+      flags: [
+        {
+          source: '@glimmer/local-debug-flags',
+          flags: {
+            LOCAL_DEBUG: process.env.EMBER_ENV !== 'production',
+            LOCAL_SHOULD_LOG: process.env.EMBER_ENV !== 'production',
+          },
         },
-      },
+      ],
       debugTools: {
+        isDebug: process.env.EMBER_ENV !== 'production',
         source: '@glimmer/util',
       },
       externalizeHelpers: {

--- a/build/broccoli/transpile-to-es5.js
+++ b/build/broccoli/transpile-to-es5.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const babel = require('broccoli-babel-transpiler');
-const debugMacros = require('babel-plugin-debug-macros').default;
+const debugMacros = require('babel-plugin-debug-macros');
 
 const PRODUCTION = process.env.EMBER_ENV === 'production';
 
@@ -21,16 +21,14 @@ module.exports = function transpileToES5(inputNode, modules = false) {
     plugins.push([
       debugMacros,
       {
-        envFlags: {
-          source: '@glimmer/env',
-          flags: {
-            DEBUG: true,
+        flags: [
+          {
+            source: '@glimmer/env',
+            flags: {
+              DEBUG: true,
+            },
           },
-        },
-        debugTools: {
-          // Need to upgrade the plugin debug macro
-          source: '@glimmer/dummy-util-not-a-real-thing',
-        },
+        ],
       },
     ]);
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@simple-dom/interface": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0",
-    "babel-plugin-debug-macros": "^0.1.11",
+    "babel-plugin-debug-macros": "^0.3.3",
     "handlebars": "^4.5.1",
     "simple-html-tokenizer": "^0.5.9"
   },

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -5,7 +5,7 @@ import { AST, isLiteral, SyntaxError } from '@glimmer/syntax';
 import { getAttrNamespace } from './utils';
 import { SymbolAllocator } from './allocate-symbols';
 import { Processor, InputOps, AllocateSymbolsOps, Ops, SourceLocation } from './compiler-ops';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { ExpressionContext } from '@glimmer/interfaces';
 import { locationToOffset } from './location';
 
@@ -34,7 +34,7 @@ export default class TemplateCompiler implements Processor<InputOps> {
 
     let out = JavaScriptCompiler.process(ops, allocationLocations, ast.symbols!, options);
 
-    if (DEBUG) {
+    if (LOCAL_SHOULD_LOG) {
       console.log(`Template ->`, out);
     }
 

--- a/packages/@glimmer/debug/lib/opcode-metadata.ts
+++ b/packages/@glimmer/debug/lib/opcode-metadata.ts
@@ -264,7 +264,7 @@ METADATA[Op.HasBlockParams] = {
   name: 'HasBlockParams',
   mnemonic: 'hasparamsload',
   before: null,
-  stackChange: 0,
+  stackChange: -2,
   ops: [],
   operands: 0,
   check: true,

--- a/packages/@glimmer/local-debug-flags/index.ts
+++ b/packages/@glimmer/local-debug-flags/index.ts
@@ -1,9 +1,15 @@
-export const DEBUG = (() => {
+export const LOCAL_DEBUG = (() => {
   let location = typeof window !== 'undefined' && window.location;
-  if (location && /[?&]glimmer_logging/.test(window.location.search)) {
+  if (location && /[?&]disable_local_debug/.test(window.location.search)) {
+    return false;
+  }
+  return true;
+})();
+
+export const LOCAL_SHOULD_LOG = (() => {
+  let location = typeof window !== 'undefined' && window.location;
+  if (location && /[?&]enable_local_should_log/.test(window.location.search)) {
     return true;
   }
   return false;
 })();
-
-export const DEVMODE = true;

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -16,7 +16,7 @@ import { meta } from './opcode-builder/helpers/shared';
 import { EMPTY_ARRAY } from '@glimmer/util';
 import { templateCompilationContext } from './opcode-builder/context';
 import { concatStatements } from './syntax/concat';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { debugCompiler } from './compiler';
 import { patchStdlibs } from '@glimmer/program';
 import { STATEMENTS } from './syntax/statements';
@@ -78,7 +78,7 @@ export function compileStatements(
 
   let handle = context.encoder.commit(syntaxContext.program.heap, meta.size);
 
-  if (DEBUG) {
+  if (LOCAL_SHOULD_LOG) {
     debugCompiler(context, handle);
   }
 

--- a/packages/@glimmer/opcode-compiler/lib/compiler.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compiler.ts
@@ -9,7 +9,7 @@ import {
   TemplateCompilationContext,
   HandleResult,
 } from '@glimmer/interfaces';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { namedBlocks, expectString } from './utils';
 import { extractHandle } from './template';
 
@@ -58,7 +58,7 @@ export function commit(heap: CompileTimeHeap, scopeSize: number, buffer: Compile
 
 export let debugCompiler: (context: TemplateCompilationContext, handle: HandleResult) => void;
 
-if (DEBUG) {
+if (LOCAL_SHOULD_LOG) {
   debugCompiler = (context: TemplateCompilationContext, result: HandleResult) => {
     let handle = extractHandle(result);
     let { heap } = context.syntax.program;

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -10,7 +10,7 @@ import {
 import { templateCompilationContext } from './opcode-builder/context';
 import { meta } from './opcode-builder/helpers/shared';
 import { WrappedComponent } from './opcode-builder/helpers/components';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { debugCompiler } from './compiler';
 import { ATTRS_BLOCK } from './syntax/compilers';
 import { concatStatements } from './syntax/concat';
@@ -58,7 +58,7 @@ export class WrappedBuilder implements CompilableProgram {
 
     this.compiled = handle;
 
-    if (DEBUG) {
+    if (LOCAL_SHOULD_LOG) {
       debugCompiler(context, handle);
     }
 

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -8,7 +8,7 @@ import {
   RuntimeProgram,
   CompilerArtifacts,
 } from '@glimmer/interfaces';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { RuntimeConstantsImpl } from './constants';
 import { RuntimeOpImpl } from './opcode';
 import { assert } from '@glimmer/util';
@@ -150,7 +150,7 @@ export class HeapImpl implements CompileTimeHeap, RuntimeHeap {
   }
 
   finishMalloc(handle: number, scopeSize: number): void {
-    if (DEBUG) {
+    if (LOCAL_DEBUG) {
       let start = this.table[handle];
       let finish = this.offset;
       let instructionSize = finish - start;
@@ -336,7 +336,7 @@ function slice(arr: Uint32Array, start: number, end: number): Uint32Array {
 }
 
 function sizeof(table: number[], handle: number) {
-  if (DEBUG) {
+  if (LOCAL_DEBUG) {
     return table[handle + Size.SIZE_OFFSET];
   } else {
     return -1;

--- a/packages/@glimmer/runtime/lib/lifetime.ts
+++ b/packages/@glimmer/runtime/lib/lifetime.ts
@@ -1,5 +1,5 @@
 import { takeAssociated, peekAssociated, snapshot, destructor, LINKED } from '@glimmer/util';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { clear } from './bounds';
 import { BlockOpcode } from './vm/update';
 import { Option, Bounds, Environment } from '@glimmer/interfaces';
@@ -22,8 +22,7 @@ export function asyncReset(parent: object, env: Environment) {
 }
 
 export function legacySyncDestroy(parent: object, env: Environment) {
-  // NOTE: This is LOCAL_DEBUG really, but we need to update it everywhere
-  if (DEBUG) {
+  if (LOCAL_SHOULD_LOG) {
     console.log('legacySyncDestroy', parent, LINKED.get(parent));
   }
 
@@ -31,7 +30,7 @@ export function legacySyncDestroy(parent: object, env: Environment) {
 }
 
 export function asyncDestroy(parent: object, env: Environment) {
-  if (DEBUG) {
+  if (LOCAL_SHOULD_LOG) {
     console.log('asyncDestroy', parent, LINKED.get(parent));
   }
 
@@ -39,7 +38,7 @@ export function asyncDestroy(parent: object, env: Environment) {
 }
 
 export function detach(parent: BlockOpcode, env: Environment) {
-  if (DEBUG) {
+  if (LOCAL_SHOULD_LOG) {
     console.log('asyncClear', parent, LINKED.get(parent));
   }
 
@@ -49,7 +48,7 @@ export function detach(parent: BlockOpcode, env: Environment) {
 }
 
 export function detachChildren(parent: Bounds, env: Environment): Option<SimpleNode> {
-  if (DEBUG) {
+  if (LOCAL_SHOULD_LOG) {
     console.log('asyncClear', parent, LINKED.get(parent));
   }
 

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -22,7 +22,7 @@ import {
   LiveBlock,
   ElementBuilder,
 } from '@glimmer/interfaces';
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { RuntimeOpImpl } from '@glimmer/program';
 import { PathReference, ReferenceIterator, VersionedPathReference } from '@glimmer/reference';
 import {
@@ -521,7 +521,7 @@ export default abstract class VM<C extends JitOrAotBlock> implements PublicVM, I
   /// EXECUTION
 
   execute(initialize?: (vm: this) => void): RenderResult {
-    if (DEBUG) {
+    if (LOCAL_SHOULD_LOG) {
       console.log(`EXECUTING FROM ${this[INNER_VM].fetchRegister($pc)}`);
     }
 

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -8,7 +8,7 @@ import {
 } from '@glimmer/interfaces';
 import { APPEND_OPCODES } from '../opcodes';
 import VM from './append';
-import { DEVMODE } from '@glimmer/local-debug-flags';
+import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { MachineRegister, $pc, $ra, $fp, $sp } from '@glimmer/vm';
 import { assert } from '@glimmer/util';
 
@@ -139,7 +139,7 @@ export default class LowLevelVM {
   }
 
   evaluateOuter(opcode: RuntimeOp, vm: VM<JitOrAotBlock>) {
-    if (DEVMODE) {
+    if (LOCAL_DEBUG) {
       let {
         externs: { debugBefore, debugAfter },
       } = this;

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -1,4 +1,4 @@
-import { DEBUG } from '@glimmer/local-debug-flags';
+import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { PrimitiveType } from '@glimmer/interfaces';
 import { unreachable } from '@glimmer/util';
 import { Stack as WasmStack } from '@glimmer/low-level';
@@ -113,7 +113,7 @@ export default class EvaluationStackImpl implements EvaluationStack {
   constructor(private stack: InnerStack, registers: LowLevelRegisters) {
     this[REGISTERS] = registers;
 
-    if (DEBUG) {
+    if (LOCAL_DEBUG) {
       Object.seal(this);
     }
   }

--- a/packages/@glimmer/syntax/lib/builders.ts
+++ b/packages/@glimmer/syntax/lib/builders.ts
@@ -1,7 +1,7 @@
 import * as AST from './types/nodes';
 import { Option, Dict } from '@glimmer/interfaces';
 import { deprecate, assign } from '@glimmer/util';
-import { DEVMODE } from '@glimmer/local-debug-flags';
+import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { StringLiteral, BooleanLiteral, NumberLiteral } from './types/handlebars-ast';
 
 // Statements
@@ -47,7 +47,7 @@ function buildBlock(
   let elseBlock: Option<AST.Block> | undefined;
 
   if (_defaultBlock.type === 'Template') {
-    if (DEVMODE) {
+    if (LOCAL_DEBUG) {
       deprecate(`b.program is deprecated. Use b.blockItself instead.`);
     }
 
@@ -57,7 +57,7 @@ function buildBlock(
   }
 
   if (_elseBlock !== undefined && _elseBlock !== null && _elseBlock.type === 'Template') {
-    if (DEVMODE) {
+    if (LOCAL_DEBUG) {
       deprecate(`b.program is deprecated. Use b.blockItself instead.`);
     }
 

--- a/packages/@glimmer/syntax/lib/traversal/traverse.ts
+++ b/packages/@glimmer/syntax/lib/traversal/traverse.ts
@@ -6,7 +6,7 @@ import {
 } from './errors';
 import * as AST from '../types/nodes';
 import { deprecate } from '@glimmer/util';
-import { DEVMODE } from '@glimmer/local-debug-flags';
+import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { NodeHandler, NodeVisitor, KeyHandler, NodeTraversal, KeyTraversal } from './visitor';
 import Path from './path';
 
@@ -65,7 +65,7 @@ function getNodeHandler<N extends AST.Node>(
 ): NodeTraversal<N> | NodeTraversal<AST.Node> | undefined {
   if (nodeType === 'Template' || nodeType === 'Block') {
     if (visitor.Program) {
-      if (DEVMODE) {
+      if (LOCAL_DEBUG) {
         deprecate(`TODO`);
       }
 

--- a/packages/@glimmer/util/lib/lifetimes.ts
+++ b/packages/@glimmer/util/lib/lifetimes.ts
@@ -9,7 +9,7 @@ import {
   ChildrenSymbol,
 } from '@glimmer/interfaces';
 import { LinkedList, LinkedListNode } from './list-utils';
-import { DEVMODE } from '@glimmer/local-debug-flags';
+import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { symbol } from './platform-utils';
 
 export const LINKED: WeakMap<object, Set<Drop>> = new WeakMap();
@@ -249,6 +249,6 @@ export function printDrop(inner: Drop) {
   console.groupEnd();
 }
 
-if (DEVMODE && typeof window !== 'undefined') {
+if (LOCAL_DEBUG && typeof window !== 'undefined') {
   (window as any).PRINT_DROP = printDropTree;
 }

--- a/packages/@glimmer/vm/lib/opcodes.toml
+++ b/packages/@glimmer/vm/lib/opcodes.toml
@@ -168,7 +168,7 @@ is bound *and* has at least one specified formal
 parameter, and FALSE otherwise.
 """
 operand-stack = [
-  ["block?"],
+  ["block?", "scope?", "symbol-table?"],
   ["bool"]
 ]
 

--- a/test/index.html
+++ b/test/index.html
@@ -51,10 +51,17 @@
         label: 'Disable TSLint',
         tooltip: 'Do not include any TSLint tests',
       });
+
       QUnit.config.urlConfig.push({
-        id: 'glimmer_logging',
-        label: 'Enable Glimmer Logging',
-        tooltip: 'Enable Glimmer Logging',
+        id: 'disable_local_debug',
+        label: 'Disable LOCAL_DEBUG (runs like prod)',
+        tooltip: 'Disable LOCAL_DEBUG (runs like prod)',
+      });
+
+      QUnit.config.urlConfig.push({
+        id: 'enable_local_should_log',
+        label: 'Enable LOCAL_SHOULD_LOG (extra debug logging info)',
+        tooltip: 'Enable LOCAL_SHOULD_LOG (extra debug logging info)',
       });
 
       QUnit.config.urlConfig.push({

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,10 +899,10 @@ babel-plugin-dead-code-elimination@^1.0.2:
   resolved "https://registry.yarnpkg.com/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
   integrity sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=
 
-babel-plugin-debug-macros@^0.1.11:
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
-  integrity sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==
+babel-plugin-debug-macros@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.3.tgz#29c3449d663f61c7385f5b8c72d8015b069a5cb7"
+  integrity sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
This PR is two changes combined, with the first refactor being driven by the bug that is fixed in the second change.

## [REFACTOR] Updates local-debug-flags to be more descriptive

We recently let through a regression that would have failed tests, if
the CI flag to enable LOCAL_DEBUG was on. This PR refactors the flags so
that:

1. They are distinguished from `DEBUG`, which is now imported from
   `@glimmer/env` and published.
2. They have clear separate purposes.
   * `LOCAL_DEBUG` is for code that is meant to verify correctness and
   assert if things are not correct. It is enabled by default.
   * `LOCAL_SHOULD_LOG` is for logging things for local debugging. It
   is not enabled by default, and should not be used to verify
   correctness as such.

## [BUGFIX] Update HasBlockParams metadata

Currently, a number of tests fail on master due to an assertion behind
the LOCAL_DEBUG flag. I'm not sure why these tests are failing, but it
seems like based on reading the code that the opcode metadata may not
have been correctly updated in one of the previous VM refactors. Given
that all tests were passing otherwise, I updated the metadata to match
the given amount.