### PR TITLE
Fix TravisCI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ language: node_js
 node_js:
   - 8
 
-matrix:
-  fast_finish: true
-
 cache: yarn
 
 before_install:
@@ -18,6 +15,7 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 jobs:
+  fast_finish: true
   include:
     - name: Tests (Chrome)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ node_js:
 cache: yarn
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.17.3
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 jobs:


### PR DESCRIPTION
We are currently only running a single job in CI even though we have separate jobs setup to run (linting, type tests, node tests, cross browser tests, and chrome tests).

See prior build [here](https://travis-ci.org/glimmerjs/glimmer-vm/builds/650105832) (it should have ran many jobs, but only ran one).