### PR TITLE
Specify tsconfigRootDir in parserOptions for TS files.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -222,6 +222,7 @@ module.exports = {
       parserOptions: {
         project: './tsconfig.json',
         sourceType: 'module',
+        tsconfigRootDir: __dirname,
       },
       rules: {
         'node/no-extraneous-import': 'off',


### PR DESCRIPTION
This allows VS Code's eslint plugin to work properly.