### PR TITLE
[BUGFIX] Fixes {{has-block}} when used with curry components as a variable

### DIFF
--- a/packages/@glimmer/integration-tests/lib/suites/has-block.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/has-block.ts
@@ -262,4 +262,70 @@ export class HasBlockSuite extends RenderTest {
     this.assertComponent('', { 'data-has-block': 'false' });
     this.assertStableRerender();
   }
+
+  @test({ kind: 'glimmer' })
+  'has-block works within a yielded curried component invoked within mustaches'() {
+    this.registerComponent(
+      'Glimmer',
+      'ComponentWithHasBlock',
+      `<div data-has-block="{{has-block}}" ...attributes></div>`
+    );
+
+    this.registerComponent('Glimmer', 'Yielder', `{{yield (component 'ComponentWithHasBlock')}}`);
+
+    this.registerComponent(
+      'Glimmer',
+      'TestComponent',
+      `<Yielder as |componentWithHasBlock|>{{componentWithHasBlock}}</Yielder>`
+    );
+
+    this.render(`<TestComponent />`);
+
+    this.assertComponent('', { 'data-has-block': 'false' });
+    this.assertStableRerender();
+  }
+
+  @test({ kind: 'glimmer' })
+  'has-block works within a yielded curried component invoked with angle bracket invocation (falsy)'() {
+    this.registerComponent(
+      'Glimmer',
+      'ComponentWithHasBlock',
+      `<div data-has-block="{{has-block}}" ...attributes></div>`
+    );
+
+    this.registerComponent('Glimmer', 'Yielder', `{{yield (component 'ComponentWithHasBlock')}}`);
+
+    this.registerComponent(
+      'Glimmer',
+      'TestComponent',
+      `<Yielder as |componentWithHasBlock|><componentWithHasBlock/></Yielder>`
+    );
+
+    this.render(`<TestComponent />`);
+
+    this.assertComponent('', { 'data-has-block': 'false' });
+    this.assertStableRerender();
+  }
+
+  @test({ kind: 'glimmer' })
+  'has-block works within a yielded curried component invoked with angle bracket invocation (truthy)'() {
+    this.registerComponent(
+      'Glimmer',
+      'ComponentWithHasBlock',
+      `<div data-has-block="{{has-block}}" ...attributes></div>`
+    );
+
+    this.registerComponent('Glimmer', 'Yielder', `{{yield (component 'ComponentWithHasBlock')}}`);
+
+    this.registerComponent(
+      'Glimmer',
+      'TestComponent',
+      `<Yielder as |componentWithHasBlock|><componentWithHasBlock></componentWithHasBlock></Yielder>`
+    );
+
+    this.render(`<TestComponent />`);
+
+    this.assertComponent('', { 'data-has-block': 'true' });
+    this.assertStableRerender();
+  }
 }


### PR DESCRIPTION
When invoked directly as a variable, curry components go through a
different codepath than they normally would. This leads to blocks and
such not being setup correctly. Since blocks aren't used in this case,
this isn't problematic in and of itself. But, the `HasBlock` opcode only
checked for truthiness of a value, and the in this case it would return
`UNDEFINED_REFERENCE` instead of `null`, thus returning truthy.

The temporary fix is to check for `UNDEFINED_REFERENCE` directly. Long
term, we should try to ensure that blocks are always setup correctly, no
matter what codepath a component is invoked by.