### PR TITLE
interfaces: Remove unused imports

### DIFF
--- a/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
@@ -1,22 +1,13 @@
 import { CompileTimeConstants, CompileTimeHeap } from '../program';
 import { Dict, Option } from '../core';
+import { SingleBuilderOperand, BuilderHandleThunk, SingleBuilderOperands } from './operands';
 import {
-  EncoderOperands,
-  BuilderOperand,
-  SingleBuilderOperand,
-  BuilderHandleThunk,
-  SingleBuilderOperands,
-} from './operands';
-import {
-  STDLib,
-  ContainingMetadata,
   NamedBlocks,
   CompilableBlock,
   CompilableProgram,
   CompilableTemplate,
   HandleResult,
 } from '../template';
-import { CompileTimeResolverDelegate } from '../serialize';
 import { Op, MachineOp } from '../vm-opcodes';
 import * as WireFormat from './wire-format';
 import ComponentCapabilities from '../component-capabilities';

--- a/packages/@glimmer/interfaces/lib/compile/operands.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/operands.d.ts
@@ -1,16 +1,7 @@
 import { Option } from '../core';
 import * as WireFormat from './wire-format';
-import { NamedBlocks, HandleResult } from '../template';
-import {
-  HighLevelCompileOp,
-  HighLevelBuilderOp,
-  HighLevelBuilderOpcode,
-  BuilderOp,
-  HighLevelCompileOpcode,
-  CompileActions,
-  ArgsOptions,
-  EncoderError,
-} from './encoder';
+import { HandleResult } from '../template';
+import { HighLevelBuilderOp, CompileActions, ArgsOptions } from './encoder';
 
 export const enum PrimitiveType {
   IMMEDIATE = 0,

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -1,5 +1,4 @@
 import { Dict, Option } from '../core';
-import { SourceLocation } from 'acorn';
 
 export type TupleSyntax = Statement | TupleExpression;
 

--- a/packages/@glimmer/interfaces/lib/components/component-manager.d.ts
+++ b/packages/@glimmer/interfaces/lib/components/component-manager.d.ts
@@ -5,12 +5,11 @@ import ComponentCapabilities from '../component-capabilities';
 import { ComponentDefinitionState, PreparedArguments, ComponentInstanceState } from '../components';
 import { Destroyable, Option, SymbolDestroyable } from '../core';
 import { Bounds } from '../dom/bounds';
-import { SyntaxCompilationContext } from '../program';
 import { VMArguments } from '../runtime/arguments';
 import { ElementOperations } from '../runtime/element';
 import { DynamicScope, Environment } from '../runtime/environment';
 import { RuntimeResolverDelegate, JitRuntimeResolver, RuntimeResolver } from '../serialize';
-import { CompilableProgram, CompilableTemplate, Template } from '../template';
+import { CompilableProgram, Template } from '../template';
 import { ProgramSymbolTable } from '../tier1/symbol-table';
 
 export interface ComponentManager<

--- a/packages/@glimmer/interfaces/lib/dom/tree-construction.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/tree-construction.d.ts
@@ -1,4 +1,3 @@
-import { GlimmerDOMOperations } from './changes';
 import {
   Namespace,
   SimpleDocumentFragment,

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -1,6 +1,5 @@
-import { Option } from './core';
 import { STDLib, ContainingMetadata, HandleResult } from './template';
-import { StdlibOperand, CompileMode, Encoder, Macros, EncoderError } from './compile';
+import { StdlibOperand, CompileMode, Encoder, Macros } from './compile';
 import { Op } from './vm-opcodes';
 import { CompileTimeResolverDelegate } from './serialize';
 

--- a/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
@@ -6,12 +6,11 @@ import {
 } from '@glimmer/reference';
 import { AttributeOperation } from '@glimmer/runtime';
 import { AttrNamespace, SimpleElement, SimpleDocument } from '@simple-dom/interface';
-import { ComponentDefinitionState, ComponentInstanceState } from '../components';
+import { ComponentInstanceState } from '../components';
 import { ComponentManager } from '../components/component-manager';
 import { Drop, Option } from '../core';
 import { GlimmerTreeChanges, GlimmerTreeConstruction } from '../dom/changes';
 import { ModifierManager } from './modifier';
-import { Cursor } from '../dom/bounds';
 
 export interface EnvironmentOptions {
   document?: SimpleDocument;

--- a/packages/@glimmer/interfaces/lib/runtime/runtime.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/runtime.d.ts
@@ -1,11 +1,6 @@
 import { Environment } from './environment';
 import { RuntimeHeap, RuntimeConstants, RuntimeOp } from '../program';
-import {
-  RuntimeResolverDelegate,
-  RuntimeResolver,
-  JitRuntimeResolver,
-  AotRuntimeResolver,
-} from '../serialize';
+import { RuntimeResolver, JitRuntimeResolver, AotRuntimeResolver } from '../serialize';
 
 /**
   The Runtime is the set of static structures that contain the compiled

--- a/packages/@glimmer/interfaces/lib/serialize.d.ts
+++ b/packages/@glimmer/interfaces/lib/serialize.d.ts
@@ -56,16 +56,9 @@
 
 import ComponentCapabilities from './component-capabilities';
 import { Option } from './core';
-import { SymbolTable, ProgramSymbolTable } from './tier1/symbol-table';
+import { ProgramSymbolTable } from './tier1/symbol-table';
 import { ComponentDefinition } from './components';
-import {
-  ResolvedLayout,
-  STDLib,
-  CompilableProgram,
-  CompileTime,
-  Template,
-  HandleResult,
-} from './template';
+import { CompilableProgram, Template, HandleResult } from './template';
 import { SyntaxCompilationContext } from './program';
 import { Helper } from './runtime/vm';
 import { ModifierDefinition } from './runtime/modifier';


### PR DESCRIPTION
The imports don't seem to be used or exported anywhere else in these files.