### PR TITLE
runtime: Add missing `@glimmer/opcode-compiler` dependency

### DIFF
--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@glimmer/env": "0.1.7",
     "@glimmer/low-level": "^0.47.9",
+    "@glimmer/opcode-compiler": "^0.47.9",
     "@glimmer/util": "^0.47.9",
     "@glimmer/reference": "^0.47.9",
     "@glimmer/validator": "^0.47.9",


### PR DESCRIPTION
We are importing from `@glimmer/opcode-compiler` inside the `lib` folder of the `@glimmer/runtime` package, so we need to add this as a dependency.