### PR TITLE
[CLEANUP][BREAKING] Remove runtime dep on opcode-compiler

### DIFF
--- a/build/broccoli/strip-glimmer-utilities.js
+++ b/build/broccoli/strip-glimmer-utilities.js
@@ -53,6 +53,13 @@ function stripFlags(glimmerUtils) {
     },
   ]);
 
+  glimmerUtils.push([
+    nuke,
+    {
+      source: '@glimmer/debug',
+      delegate: removeLogging,
+    },
+  ]);
   glimmerUtils.push([nuke, { source: '@glimmer/debug' }]);
   glimmerUtils.push([nuke, { source: '@glimmer/vm/lib/-debug-strip' }]);
   glimmerUtils.push([nuke, { source: '@glimmer/runtime/lib/compiled/opcodes/-debug-strip' }]);
@@ -62,13 +69,6 @@ function stripFlags(glimmerUtils) {
     {
       source: '@glimmer/vm',
       delegate: removeMetaData,
-    },
-  ]);
-  glimmerUtils.push([
-    nuke,
-    {
-      source: '@glimmer/opcode-compiler',
-      delegate: removeLogging,
     },
   ]);
 }

--- a/packages/@glimmer/debug/index.ts
+++ b/packages/@glimmer/debug/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/stack-check';
 export * from './lib/metadata';
 export { opcodeMetadata } from './lib/opcode-metadata';
+export { debug, debugSlice, logOpcode } from './lib/debug';

--- a/packages/@glimmer/debug/lib/debug.ts
+++ b/packages/@glimmer/debug/lib/debug.ts
@@ -7,11 +7,12 @@ import {
   Maybe,
   TemplateCompilationContext,
 } from '@glimmer/interfaces';
-import { Register, $s0, $s1, $t0, $t1, $v0, $fp, $sp, $pc, $ra } from '@glimmer/vm';
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
-import { opcodeMetadata, Primitive } from '@glimmer/debug';
 import { RuntimeOpImpl } from '@glimmer/program';
+import { Register, $s0, $s1, $t0, $t1, $v0, $fp, $sp, $pc, $ra } from '@glimmer/vm';
 import { decodeImmediate, isHandle, HandleConstants, decodeHandle } from '@glimmer/util';
+import { opcodeMetadata } from './opcode-metadata';
+import { Primitive } from './stack-check';
 
 export interface DebugConstants {
   getNumber(value: number): number;

--- a/packages/@glimmer/integration-tests/lib/components/basic.ts
+++ b/packages/@glimmer/integration-tests/lib/components/basic.ts
@@ -10,10 +10,9 @@ import {
   ComponentCapabilities,
 } from '@glimmer/interfaces';
 import { TestComponentDefinitionState } from './test-component';
-import { unreachable, expect } from '@glimmer/util';
+import { unreachable, expect, unwrapTemplate } from '@glimmer/util';
 import { VersionedPathReference, UpdatableRootReference } from '@glimmer/reference';
 import { Tag, CONSTANT_TAG } from '@glimmer/validator';
-import { unwrapTemplate } from '@glimmer/opcode-compiler';
 
 export interface BasicComponentFactory {
   new (): BasicComponent;

--- a/packages/@glimmer/integration-tests/lib/components/emberish-glimmer.ts
+++ b/packages/@glimmer/integration-tests/lib/components/emberish-glimmer.ts
@@ -18,12 +18,11 @@ import {
   Invocation,
   Destroyable,
 } from '@glimmer/interfaces';
-import { keys, assign } from '@glimmer/util';
+import { keys, assign, unwrapTemplate } from '@glimmer/util';
 import { BASIC_CAPABILITIES } from './capabilities';
 import { TestComponentDefinitionState } from './test-component';
 import { TestComponentConstructor } from './types';
 import { EmberishCurlyComponentFactory } from './emberish-curly';
-import { unwrapTemplate } from '@glimmer/opcode-compiler';
 
 export type Attrs = Dict;
 export type AttrsDiff = { oldAttrs: Option<Attrs>; newAttrs: Attrs };

--- a/packages/@glimmer/integration-tests/lib/components/emberish-root-view.ts
+++ b/packages/@glimmer/integration-tests/lib/components/emberish-root-view.ts
@@ -4,8 +4,7 @@ import { assertElement, firstElementChild } from '../dom/simple-utils';
 import { UpdatableRootReference } from '@glimmer/reference';
 import { renderJitMain, clientBuilder } from '@glimmer/runtime';
 import { SimpleElement } from '@simple-dom/interface';
-import { assign } from '@glimmer/util';
-import { unwrapTemplate, unwrapHandle } from '@glimmer/opcode-compiler';
+import { assign, unwrapTemplate, unwrapHandle } from '@glimmer/util';
 
 export class EmberishRootView {
   private template: Template;

--- a/packages/@glimmer/integration-tests/lib/components/static-tagless.ts
+++ b/packages/@glimmer/integration-tests/lib/components/static-tagless.ts
@@ -3,7 +3,7 @@ import { TestComponentDefinitionState } from './test-component';
 import { ComponentCapabilities, CompilableProgram, Option } from '@glimmer/interfaces';
 import TestJitRuntimeResolver from '../modes/jit/resolver';
 import { createTemplate } from '../compile';
-import { unwrapTemplate } from '@glimmer/opcode-compiler';
+import { unwrapTemplate } from '@glimmer/util';
 
 export class StaticTaglessComponentManager extends BasicComponentManager {
   getCapabilities(state: TestComponentDefinitionState): ComponentCapabilities {

--- a/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
@@ -7,7 +7,7 @@ import {
   CompileTimeComponent,
 } from '@glimmer/interfaces';
 import { TestJitRegistry } from './registry';
-import { unwrapTemplate } from '@glimmer/opcode-compiler';
+import { unwrapTemplate } from '@glimmer/util';
 import TestJitRuntimeResolver from './resolver';
 
 export default class JitCompileTimeLookup implements CompileTimeResolverDelegate {

--- a/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
@@ -12,6 +12,7 @@ import {
   ComponentManager,
   ComponentCapabilities,
   ComponentDefinition,
+  PartialDefinition,
 } from '@glimmer/interfaces';
 import {
   EmberishCurlyComponent,
@@ -28,7 +29,7 @@ import {
   TestModifierDefinitionState,
   TestModifierManager,
 } from '../../modifiers';
-import { PartialDefinition } from '@glimmer/opcode-compiler';
+import { PartialDefinitionImpl } from '@glimmer/opcode-compiler';
 import TestJitRuntimeResolver from './resolver';
 import { ComponentKind, ComponentTypes } from '../../components';
 import { TestComponentDefinitionState } from '../../components/test-component';
@@ -186,7 +187,7 @@ export function registerPartial(
   name: string,
   source: string
 ): PartialDefinition {
-  let definition = new PartialDefinition(name, preprocess(source));
+  let definition = new PartialDefinitionImpl(name, preprocess(source));
   registry.register('partial', name, definition);
   return definition;
 }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
@@ -13,7 +13,7 @@ import {
 } from '@glimmer/interfaces';
 import { dict } from '@glimmer/util';
 import { createTemplate } from '../../compile';
-import { unwrapTemplate } from '@glimmer/opcode-compiler';
+import { unwrapTemplate } from '@glimmer/util';
 
 export interface Lookup {
   helper: GlimmerHelper;

--- a/packages/@glimmer/integration-tests/lib/modes/jit/render.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/render.ts
@@ -3,7 +3,7 @@ import { VersionedPathReference } from '@glimmer/reference';
 import { ElementBuilder, RenderResult } from '@glimmer/interfaces';
 import { preprocess } from '../../compile';
 import { renderJitMain, renderSync } from '@glimmer/runtime';
-import { unwrapTemplate, unwrapHandle } from '@glimmer/opcode-compiler';
+import { unwrapTemplate, unwrapHandle } from '@glimmer/util';
 
 export function renderTemplate(
   src: string,

--- a/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
@@ -1,8 +1,7 @@
 import { precompile } from '@glimmer/compiler';
 import { preprocess, DEFAULT_TEST_META } from '../..';
 import { module } from '../support';
-import { assign } from '@glimmer/util';
-import { unwrapTemplate } from '@glimmer/opcode-compiler';
+import { assign, unwrapTemplate } from '@glimmer/util';
 
 module('[glimmer-compiler] Compile options', ({ test }) => {
   test('moduleName option is passed into meta', assert => {

--- a/packages/@glimmer/integration-tests/test/ember-component-tests.ts
+++ b/packages/@glimmer/integration-tests/test/ember-component-tests.ts
@@ -7,12 +7,11 @@ import {
   SyntaxCompilationContext,
   Dict,
 } from '@glimmer/interfaces';
-import { unwrapTemplate, unwrapHandle } from '@glimmer/opcode-compiler';
 import EmberObject from '@glimmer/object';
 import { CLASS_META, setProperty as set, UpdatableRootReference } from '@glimmer/object-reference';
 import { bump } from '@glimmer/validator';
 import { clientBuilder, renderJitMain } from '@glimmer/runtime';
-import { assign, dict, unwrap } from '@glimmer/util';
+import { assign, dict, unwrap, unwrapTemplate, unwrapHandle } from '@glimmer/util';
 import { SimpleElement } from '@simple-dom/interface';
 import { assert } from './support';
 import {

--- a/packages/@glimmer/integration-tests/test/partial-test.ts
+++ b/packages/@glimmer/integration-tests/test/partial-test.ts
@@ -16,7 +16,7 @@ import {
   TestContext,
 } from '..';
 import { SimpleNode } from '@simple-dom/interface';
-import { unwrapTemplate, unwrapHandle } from '@glimmer/opcode-compiler';
+import { unwrapTemplate, unwrapHandle } from '@glimmer/util';
 
 let context: TestContext;
 let result: RenderResult;

--- a/packages/@glimmer/integration-tests/test/precompile-test.ts
+++ b/packages/@glimmer/integration-tests/test/precompile-test.ts
@@ -1,7 +1,7 @@
-import { templateFactory, unwrapTemplate } from '@glimmer/opcode-compiler';
 import { precompile } from '@glimmer/compiler';
 import { SerializedTemplateWithLazyBlock, AnnotatedModuleLocator } from '@glimmer/interfaces';
-import { assign } from '@glimmer/util';
+import { assign, unwrapTemplate } from '@glimmer/util';
+import { templateFactory } from '@glimmer/opcode-compiler';
 
 let serializedTemplate: SerializedTemplateWithLazyBlock<AnnotatedModuleLocator>;
 let serializedTemplateNoId: SerializedTemplateWithLazyBlock<AnnotatedModuleLocator>;

--- a/packages/@glimmer/integration-tests/test/style-warnings-test.ts
+++ b/packages/@glimmer/integration-tests/test/style-warnings-test.ts
@@ -25,7 +25,7 @@ import {
   equalTokens,
   registerModifier,
 } from '..';
-import { unwrapTemplate, unwrapHandle } from '@glimmer/opcode-compiler';
+import { unwrapTemplate, unwrapHandle } from '@glimmer/util';
 
 let context: TestContext;
 let root: SimpleElement;

--- a/packages/@glimmer/integration-tests/test/updating-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-test.ts
@@ -38,7 +38,7 @@ import {
 } from '..';
 import { Namespace, SimpleElement, SimpleNode } from '@simple-dom/interface';
 import { assert, module, test } from './support';
-import { unwrapHandle } from '@glimmer/opcode-compiler';
+import { unwrapHandle } from '@glimmer/util';
 
 const SVG_NAMESPACE = Namespace.SVG;
 const XLINK_NAMESPACE = Namespace.XLink;

--- a/packages/@glimmer/opcode-compiler/index.ts
+++ b/packages/@glimmer/opcode-compiler/index.ts
@@ -20,20 +20,9 @@ export { meta } from './lib/opcode-builder/helpers/shared';
 
 export { StdLib } from './lib/opcode-builder/stdlib';
 
-export { PartialDefinition } from './lib/partial-template';
+export { PartialDefinitionImpl } from './lib/partial-template';
 
-export {
-  default as templateFactory,
-  TemplateFactory,
-  Component,
-  unwrapTemplate,
-  unwrapHandle,
-  isOkHandle,
-  isErrHandle,
-  extractHandle,
-} from './lib/template';
-
-export { debug, debugSlice, logOpcode } from './lib/debug';
+export { default as templateFactory, TemplateFactory, Component } from './lib/template';
 
 export { WrappedBuilder } from './lib/wrapped-component';
 

--- a/packages/@glimmer/opcode-compiler/lib/compiler.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compiler.ts
@@ -1,4 +1,4 @@
-import { debugSlice } from './debug';
+import { debugSlice } from '@glimmer/debug';
 import {
   CompilerBuffer,
   CompileTimeHeap,
@@ -10,8 +10,8 @@ import {
   HandleResult,
 } from '@glimmer/interfaces';
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
+import { extractHandle } from '@glimmer/util';
 import { namedBlocks, expectString } from './utils';
-import { extractHandle } from './template';
 
 export function compileInline(
   sexp: Statements.Append,

--- a/packages/@glimmer/opcode-compiler/lib/partial-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/partial-template.ts
@@ -3,10 +3,11 @@ import {
   Template,
   SyntaxCompilationContext,
   HandleResult,
+  PartialDefinition,
 } from '@glimmer/interfaces';
-import { unwrapTemplate } from './template';
+import { unwrapTemplate } from '@glimmer/util';
 
-export class PartialDefinition {
+export class PartialDefinitionImpl implements PartialDefinition {
   constructor(
     public name: string, // for debugging
     private template: Template

--- a/packages/@glimmer/opcode-compiler/lib/template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/template.ts
@@ -6,11 +6,8 @@ import {
   SerializedTemplateWithLazyBlock,
   Template,
   TemplateOk,
-  HandleResult,
-  OkHandle,
-  ErrHandle,
 } from '@glimmer/interfaces';
-import { assign } from '@glimmer/util';
+import { assign, unwrapTemplate } from '@glimmer/util';
 import { compilable } from './compilable-template';
 import { WrappedBuilder } from './wrapped-component';
 
@@ -126,39 +123,4 @@ export function Component(serialized: string, envMeta?: {}): CompilableProgram {
 
   let template = unwrapTemplate(factory.create(envMeta));
   return template.asLayout();
-}
-
-export function unwrapTemplate<M>(template: Template<M>): TemplateOk<M> {
-  if (template.result === 'error') {
-    throw new Error(
-      `Compile Error: ${template.problem} @ ${template.span.start}..${template.span.end}`
-    );
-  }
-
-  return template;
-}
-
-export function unwrapHandle(handle: HandleResult): number {
-  if (typeof handle === 'number') {
-    return handle;
-  } else {
-    let error = handle.errors[0];
-    throw new Error(`Compile Error: ${error.problem} @ ${error.span.start}..${error.span.end}`);
-  }
-}
-
-export function extractHandle(handle: HandleResult): number {
-  if (typeof handle === 'number') {
-    return handle;
-  } else {
-    return handle.handle;
-  }
-}
-
-export function isOkHandle(handle: HandleResult): handle is OkHandle {
-  return typeof handle === 'number';
-}
-
-export function isErrHandle(handle: HandleResult): handle is ErrHandle {
-  return typeof handle === 'number';
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -39,7 +39,7 @@ import {
 } from '@glimmer/interfaces';
 import { VersionedPathReference, VersionedReference } from '@glimmer/reference';
 import { CONSTANT_TAG, isConst, isConstTag, Tag } from '@glimmer/validator';
-import { assert, dict, expect, Option, unreachable, symbol } from '@glimmer/util';
+import { assert, dict, expect, Option, unreachable, symbol, unwrapTemplate } from '@glimmer/util';
 import { $t0, $t1, $v0 } from '@glimmer/vm';
 import {
   Capability,
@@ -72,7 +72,6 @@ import {
 import { ContentTypeReference } from './content';
 import { UpdateDynamicAttributeOpcode } from './dom';
 import { ConditionalReference, PrimitiveReference } from '../../references';
-import { unwrapTemplate } from '@glimmer/opcode-compiler';
 import { DEBUG } from '@glimmer/env';
 
 /**

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
@@ -1,9 +1,8 @@
 import { VersionedPathReference } from '@glimmer/reference';
 import { APPEND_OPCODES } from '../../opcodes';
-import { PartialDefinition, unwrapHandle } from '@glimmer/opcode-compiler';
-import { assert } from '@glimmer/util';
+import { assert, unwrapHandle } from '@glimmer/util';
 import { check } from '@glimmer/debug';
-import { Op, Dict } from '@glimmer/interfaces';
+import { Op, Dict, PartialDefinition } from '@glimmer/interfaces';
 import { CheckReference } from './-debug-strip';
 import { CONSTANTS } from '../../symbols';
 

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -7,7 +7,7 @@ import { Tag } from '@glimmer/validator';
 import { RuntimeOp, Op, JitOrAotBlock, Maybe, Dict } from '@glimmer/interfaces';
 import { LOCAL_DEBUG, LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 // these import bindings will be stripped from build
-import { debug, logOpcode } from '@glimmer/opcode-compiler';
+import { debug, logOpcode } from '@glimmer/debug';
 import { DESTRUCTOR_STACK, INNER_VM, CONSTANTS, STACKS } from './symbols';
 import { InternalVM, InternalJitVM } from './vm/append';
 import { CURSOR_STACK } from './vm/element-builder';

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -17,7 +17,7 @@ import {
   ElementBuilder,
 } from '@glimmer/interfaces';
 import { PathReference } from '@glimmer/reference';
-import { expect } from '@glimmer/util';
+import { expect, unwrapHandle } from '@glimmer/util';
 import { capabilityFlagsFrom } from './capabilities';
 import { hasStaticLayoutCapability } from './compiled/opcodes/component';
 import { resolveComponent } from './component/resolve';
@@ -26,7 +26,6 @@ import { AotVM, InternalVM, JitVM } from './vm/append';
 import { NewElementBuilder } from './vm/element-builder';
 import { DefaultDynamicScope } from './dynamic-scope';
 import { UNDEFINED_REFERENCE } from './references';
-import { unwrapHandle } from '@glimmer/opcode-compiler';
 
 class TemplateIteratorImpl<C extends JitOrAotBlock> implements TemplateIterator {
   constructor(private vm: InternalVM<C>) {}

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -50,6 +50,8 @@ import {
   Register,
   SyscallRegister,
 } from '@glimmer/vm';
+import { CheckNumber, check } from '@glimmer/debug';
+import { unwrapHandle } from '@glimmer/util';
 import { combineSlice } from '../utils/tags';
 import { DidModifyOpcode, JumpIfNotModifiedOpcode, LabelOpcode } from '../compiled/opcodes/vm';
 import { ScopeImpl } from '../environment';
@@ -68,8 +70,6 @@ import {
   TryOpcode,
   VMState,
 } from './update';
-import { CheckNumber, check } from '@glimmer/debug';
-import { unwrapHandle } from '@glimmer/opcode-compiler';
 
 /**
  * This interface is used by internal opcodes, and is more stable than

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@glimmer/env": "0.1.7",
     "@glimmer/low-level": "^0.47.9",
-    "@glimmer/opcode-compiler": "^0.47.9",
     "@glimmer/util": "^0.47.9",
     "@glimmer/reference": "^0.47.9",
     "@glimmer/validator": "^0.47.9",

--- a/packages/@glimmer/util/index.ts
+++ b/packages/@glimmer/util/index.ts
@@ -22,6 +22,7 @@ export { assign, fillNulls, values } from './lib/object-utils';
 export * from './lib/platform-utils';
 export * from './lib/string';
 export * from './lib/immediate';
+export * from './lib/template';
 
 export { default as debugToString } from './lib/debug-to-string';
 

--- a/packages/@glimmer/util/lib/template.ts
+++ b/packages/@glimmer/util/lib/template.ts
@@ -1,0 +1,36 @@
+import { HandleResult, Template, TemplateOk, OkHandle, ErrHandle } from '@glimmer/interfaces';
+
+export function unwrapHandle(handle: HandleResult): number {
+  if (typeof handle === 'number') {
+    return handle;
+  } else {
+    let error = handle.errors[0];
+    throw new Error(`Compile Error: ${error.problem} @ ${error.span.start}..${error.span.end}`);
+  }
+}
+
+export function unwrapTemplate<M>(template: Template<M>): TemplateOk<M> {
+  if (template.result === 'error') {
+    throw new Error(
+      `Compile Error: ${template.problem} @ ${template.span.start}..${template.span.end}`
+    );
+  }
+
+  return template;
+}
+
+export function extractHandle(handle: HandleResult): number {
+  if (typeof handle === 'number') {
+    return handle;
+  } else {
+    return handle.handle;
+  }
+}
+
+export function isOkHandle(handle: HandleResult): handle is OkHandle {
+  return typeof handle === 'number';
+}
+
+export function isErrHandle(handle: HandleResult): handle is ErrHandle {
+  return typeof handle === 'number';
+}


### PR DESCRIPTION
Breaking: rename PartialDefinition to PartialDefinitionImpl so an editor doesn't pull in the implementation from @glimmer/opcode-compiler when you wanted the interface in @glimmer/interfaces.

Move template handle/error unwrap utils to @glimmer/util.

Move all debug logging functions to @glimmer/debug.
