### PR TITLE
Enable eslint-plugin-node's no-extraneous-import rule (mostly).

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,7 +226,6 @@ module.exports = {
         tsconfigRootDir: __dirname,
       },
       rules: {
-        'node/no-extraneous-import': 'off',
         'node/no-unsupported-features/es-syntax': 'off',
         'node/no-unsupported-features/node-builtins': 'off',
 
@@ -284,6 +283,23 @@ module.exports = {
         'prefer-rest-params': 'off',
         'prefer-spread': 'off',
         'spaced-comment': 'off',
+      },
+    },
+    {
+      // these packages need to be fixed to avoid these warnings, but in the
+      // meantime we should not regress the other packages
+      files: [
+        // @glimmer/interfaces should not import for any other @glimmer package
+        // but it currently imports from @glimmer/reference and @glimmer/validator
+        'packages/@glimmer/interfaces/**/*.ts',
+
+        // this specific test imports from @glimmer/runtime (causing a cyclic
+        // dependency), it should either be refactored to use the interfaces
+        // directly (instead of the impls) or moved into @glimmer/runtime
+        'packages/@glimmer/reference/test/template-test.ts',
+      ],
+      rules: {
+        'node/no-extraneous-import': 'warn',
       },
     },
   ],

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "dependencies": {
     "@glimmer/interfaces": "^0.47.9",
+    "@glimmer/program": "^0.47.9",
+    "@glimmer/util": "^0.47.9",
+    "@glimmer/vm": "^0.47.9",
     "@simple-dom/interface": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@glimmer/runtime": "^0.47.9",
     "@glimmer/interfaces": "^0.47.9",
+    "@glimmer/util": "^0.47.9",
     "@simple-dom/document": "^1.4.0",
     "@simple-dom/interface": "^1.4.0"
   },

--- a/packages/@glimmer/object-reference/package.json
+++ b/packages/@glimmer/object-reference/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@glimmer/util": "^0.47.9",
+    "@glimmer/interfaces": "^0.47.9",
     "@glimmer/reference": "^0.47.9",
     "@glimmer/validator": "^0.47.9"
   }

--- a/packages/@glimmer/program/test/heap-test.ts
+++ b/packages/@glimmer/program/test/heap-test.ts
@@ -1,12 +1,16 @@
 import { HeapImpl } from '..';
-import { StdLib } from '@glimmer/opcode-compiler';
+import { STDLib } from '@glimmer/interfaces';
 
 QUnit.module('Heap');
 
 QUnit.test('Can grow', assert => {
   let size = 0x100000;
   let heap = new HeapImpl();
-  let stdlib = new StdLib(0, 0, 0);
+  let stdlib: STDLib = {
+    main: 0,
+    'trusting-append': 0,
+    'cautious-append': 0,
+  };
 
   let i = 0;
 

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@glimmer/env": "^0.1.7",
+    "@glimmer/interfaces": "^0.47.9",
     "@glimmer/util": "^0.47.9",
     "@glimmer/validator": "^0.47.9"
   }


### PR DESCRIPTION
This enables eslint-plugin-node's `no-extraneous-import` rule (which is part of its recommended set) for all packages _except_ `@glimmer/interfaces`.

I've excluded `@glimmer/interfaces` specifically because IMHO it **should not** have any external dependencies, and the imports here need to be refactored to avoid needing to add the dependency.

This change however helps us ensure we don't _accidentally_ regress for all of the other packages...