### PR TITLE
[FEAT] Adds Owner API

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -77,5 +77,6 @@ export {
   rehydrationBuilder,
   SERIALIZATION_FIRST_NODE_STRING,
 } from './lib/vm/rehydrate-builder';
+export { getOwner, setOwner } from './lib/owner';
 
 export type IteratorResult<T> = RichIteratorResult<null, T>;

--- a/packages/@glimmer/runtime/lib/owner.ts
+++ b/packages/@glimmer/runtime/lib/owner.ts
@@ -1,0 +1,11 @@
+import { symbol } from '@glimmer/util';
+
+export const OWNER: unique symbol = symbol('OWNER') as any;
+
+export function getOwner<T = unknown>(object: any): T {
+  return object[OWNER] as T;
+}
+
+export function setOwner(object: any, owner: unknown): void {
+  object[OWNER] = owner;
+}

--- a/packages/@glimmer/runtime/test/capabilities-test.ts
+++ b/packages/@glimmer/runtime/test/capabilities-test.ts
@@ -1,6 +1,6 @@
 import { capabilityFlagsFrom, hasCapability, Capability } from '..';
 
-QUnit.module('Capabilities Bitmaps');
+QUnit.module('[@glimmer/runtime] Capabilities Bitmaps');
 
 QUnit.test('encodes a capabilities object into a bitmap', assert => {
   assert.equal(

--- a/packages/@glimmer/runtime/test/owner-test.ts
+++ b/packages/@glimmer/runtime/test/owner-test.ts
@@ -1,0 +1,14 @@
+import { getOwner, setOwner } from '..';
+
+QUnit.module('[@glimmer/runtime] Owner');
+
+QUnit.test('@test An owner can be set with `setOwner` and retrieved with `getOwner`', assert => {
+  let owner = {};
+  let obj = {};
+
+  assert.strictEqual(getOwner(obj), undefined, 'owner has not been set');
+
+  setOwner(obj, owner);
+
+  assert.strictEqual(getOwner(obj), owner, 'owner has been set');
+});


### PR DESCRIPTION
This PR upstreams the Owner API from Ember.js, for use in embedding
environments. The public component/modifier managers, and future
managers, that both Ember.js and Glimmer.js currently provide all have a
notion of an "owner" which is passed when creating the manager, so it is
already part both embedding environments.

Conceptually, the owner is an opaque value that the embedding
environment decides on how to handle. But for there to be interop
_between_ embedding environments, especially for _libraries_ like
`@glimmer/component`, etc. It's important to have a shared way to assign
and access the owner, even if the value is opaque to the rest of the
framework. These methods provide that.