### PR TITLE
[PERF] Improves the autotracking transaction by creating fewer Errors

### DIFF
--- a/packages/@glimmer/validator/lib/debug.ts
+++ b/packages/@glimmer/validator/lib/debug.ts
@@ -22,7 +22,7 @@ export let assertTagNotConsumed:
   | undefined
   | (<T>(tag: Tag, obj?: T, keyName?: keyof T | string | symbol, forceHardError?: boolean) => void);
 
-export let markTagAsConsumed: undefined | ((_tag: Tag, sourceError: Error) => void);
+export let markTagAsConsumed: undefined | ((_tag: Tag, sourceError?: Error) => void);
 
 if (DEBUG) {
   let DEPRECATE_IN_AUTOTRACKING_TRANSACTION = false;
@@ -158,8 +158,10 @@ if (DEBUG) {
     return message.join('\n\n');
   };
 
-  markTagAsConsumed = (_tag: Tag, sourceError: Error) => {
-    if (!AUTOTRACKING_TRANSACTION || AUTOTRACKING_TRANSACTION.has(_tag)) return;
+  markTagAsConsumed = (_tag: Tag, _sourceError?: Error) => {
+    if (AUTOTRACKING_TRANSACTION === null || AUTOTRACKING_TRANSACTION.has(_tag)) return;
+
+    let sourceError = _sourceError || new Error();
 
     AUTOTRACKING_TRANSACTION.set(_tag, {
       context: debuggingContexts!.map(c => c.replace(/^/gm, '  ').replace(/^ /, '-')).join('\n\n'),

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -31,7 +31,7 @@ class Tracker {
     this.tags.add(tag);
 
     if (DEBUG) {
-      markTagAsConsumed!(tag, new Error());
+      markTagAsConsumed!(tag);
     }
 
     this.last = tag;


### PR DESCRIPTION
Currently we create an Error every time a value is consumed, regardless
of whether or not it is being consumed for the first time (and thus we
need the Error for its stack) or if we've already consumed it before,
and don't need an Error at all. This PR changes this so we do it only
when necessary.

This helps to alleviate some dev-mode performance issues we've been seeing in Ember: https://github.com/emberjs/ember.js/issues/18798. Creating the error at all seems to be causing slow down, but this makes the issues noticeably better.