### PR TITLE
 [FEAT] Adds `memoizeTracked`

### DIFF
--- a/packages/@glimmer/integration-tests/lib/components/emberish-curly.ts
+++ b/packages/@glimmer/integration-tests/lib/components/emberish-curly.ts
@@ -22,7 +22,7 @@ import {
 } from '@glimmer/interfaces';
 import { Attrs, AttrsDiff } from './emberish-glimmer';
 import { VersionedPathReference, PathReference } from '@glimmer/reference';
-import { combine, createTag, dirty, DirtyableTag, Tag } from '@glimmer/validator';
+import { combine, createTag, dirtyTag, DirtyableTag, Tag } from '@glimmer/validator';
 import { keys, EMPTY_ARRAY, assign } from '@glimmer/util';
 import { TestComponentDefinitionState } from './test-component';
 import { PrimitiveReference } from '@glimmer/runtime';
@@ -78,7 +78,7 @@ export class EmberishCurlyComponent {
 
   set(key: string, value: unknown) {
     (this as any)[key] = value;
-    dirty(this.dirtinessTag);
+    dirtyTag(this.dirtinessTag);
   }
 
   setProperties(dict: Dict) {
@@ -87,11 +87,11 @@ export class EmberishCurlyComponent {
     }
 
     SELF_REF.get(this)!.dirty();
-    dirty(this.dirtinessTag);
+    dirtyTag(this.dirtinessTag);
   }
 
   recompute() {
-    dirty(this.dirtinessTag);
+    dirtyTag(this.dirtinessTag);
   }
 
   destroy() {}

--- a/packages/@glimmer/integration-tests/lib/reference.ts
+++ b/packages/@glimmer/integration-tests/lib/reference.ts
@@ -1,5 +1,5 @@
 import { RootReference, TemplateReferenceEnvironment } from '@glimmer/reference';
-import { createUpdatableTag, dirty, UpdatableTag } from '@glimmer/validator';
+import { createUpdatableTag, dirtyTag, UpdatableTag } from '@glimmer/validator';
 import { Dict } from '@glimmer/interfaces';
 
 /**
@@ -21,18 +21,18 @@ export class UpdatableRootReference<T = unknown> extends RootReference<T> {
     let { inner } = this;
 
     if (value !== inner) {
-      dirty(this.tag);
+      dirtyTag(this.tag);
       this.inner = value;
     }
   }
 
   forceUpdate(value: T) {
-    dirty(this.tag);
+    dirtyTag(this.tag);
     this.inner = value;
   }
 
   dirty() {
-    dirty(this.tag);
+    dirtyTag(this.tag);
   }
 
   getDebugPath() {

--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -1,5 +1,5 @@
 import { Option, symbol } from '@glimmer/util';
-import { Revision, Tag, Tagged, value, validate } from '@glimmer/validator';
+import { Revision, Tag, Tagged, valueForTag, validateTag } from '@glimmer/validator';
 
 export interface Reference<T> {
   value(): T;
@@ -28,9 +28,9 @@ export abstract class CachedReference<T> implements VersionedReference<T> {
   value(): T {
     let { tag, lastRevision, lastValue } = this;
 
-    if (lastRevision === null || !validate(tag, lastRevision)) {
+    if (lastRevision === null || !validateTag(tag, lastRevision)) {
       lastValue = this.lastValue = this.compute();
-      this.lastRevision = value(tag);
+      this.lastRevision = valueForTag(tag);
     }
 
     return lastValue as T;
@@ -74,11 +74,11 @@ export class ReferenceCache<T> implements Tagged {
     let { reference, lastRevision } = this;
     let tag = reference.tag;
 
-    if (validate(tag, lastRevision as number)) return NOT_MODIFIED;
+    if (validateTag(tag, lastRevision as number)) return NOT_MODIFIED;
 
     let { lastValue } = this;
     let currentValue = reference.value();
-    this.lastRevision = value(tag);
+    this.lastRevision = valueForTag(tag);
 
     if (currentValue === lastValue) return NOT_MODIFIED;
     this.lastValue = currentValue;
@@ -90,7 +90,7 @@ export class ReferenceCache<T> implements Tagged {
     let { reference } = this;
 
     let currentValue = (this.lastValue = reference.value());
-    this.lastRevision = value(reference.tag);
+    this.lastRevision = valueForTag(reference.tag);
     this.initialized = true;
 
     return currentValue;

--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -6,14 +6,14 @@ import {
   combine,
   createUpdatableTag,
   UpdatableTag,
-  dirty,
-  update,
+  dirtyTag,
+  updateTag,
   track,
   Revision,
   isConst,
   isConstTag,
-  value,
-  validate,
+  valueForTag,
+  validateTag,
 } from '@glimmer/validator';
 import { VersionedPathReference } from './reference';
 import { DEBUG } from '@glimmer/env';
@@ -160,15 +160,15 @@ export class HelperRootReference<T = unknown> extends RootReference<T> {
       // If the args are constant, and the first computation is constant, then
       // the helper itself is constant and will never update.
       tag = this.tag = CONSTANT_TAG;
-      this.computeRevision = value(tag);
+      this.computeRevision = valueForTag(tag);
     } else {
       let valueTag = (this.valueTag = createUpdatableTag());
       tag = this.tag = combine([args.tag, valueTag]);
 
       if (computeTag !== null) {
         // We computed once, so setup the cache state correctly
-        update(valueTag, computeTag);
-        this.computeRevision = value(tag);
+        updateTag(valueTag, computeTag);
+        this.computeRevision = valueForTag(tag);
       }
     }
   }
@@ -182,10 +182,10 @@ export class HelperRootReference<T = unknown> extends RootReference<T> {
   value(): T {
     let { tag, computeRevision } = this;
 
-    if (computeRevision === null || !validate(tag, computeRevision)) {
+    if (computeRevision === null || !validateTag(tag, computeRevision)) {
       this.compute();
-      update(this.valueTag!, this.computeTag!);
-      this.computeRevision = value(tag);
+      updateTag(this.valueTag!, this.computeTag!);
+      this.computeRevision = valueForTag(tag);
     }
 
     return this.computeValue!;
@@ -225,7 +225,7 @@ export class PropertyReference implements TemplatePathReference {
   value() {
     let { tag, lastRevision, lastValue, parentReference, valueTag, propertyKey } = this;
 
-    if (lastRevision === null || !validate(tag, lastRevision)) {
+    if (lastRevision === null || !validateTag(tag, lastRevision)) {
       let parentValue = parentReference.value();
 
       if (isDict(parentValue)) {
@@ -233,13 +233,13 @@ export class PropertyReference implements TemplatePathReference {
           lastValue = this.env.getPath(parentValue, propertyKey);
         }, DEBUG && this.env.getTemplatePathDebugContext(this));
 
-        update(valueTag, combined);
+        updateTag(valueTag, combined);
       } else {
         lastValue = undefined;
       }
 
       this.lastValue = lastValue;
-      this.lastRevision = value(tag);
+      this.lastRevision = valueForTag(tag);
     }
 
     return lastValue;
@@ -307,7 +307,7 @@ export class IterationItemReference<T = unknown> implements TemplatePathReferenc
   }
 
   update(value: T) {
-    dirty(this.tag);
+    dirtyTag(this.tag);
     this.itemValue = value;
   }
 

--- a/packages/@glimmer/reference/test/references-test.ts
+++ b/packages/@glimmer/reference/test/references-test.ts
@@ -6,8 +6,8 @@ import {
   UpdatableTag,
   createTag,
   createUpdatableTag,
-  dirty,
-  update,
+  dirtyTag,
+  updateTag,
 } from '@glimmer/validator';
 import { dict } from '@glimmer/util';
 
@@ -24,7 +24,7 @@ class UpdatableRootReference<T> implements Reference<T> {
   }
 
   update(content: T) {
-    dirty(this._tag);
+    dirtyTag(this._tag);
     return (this.content = content);
   }
 }
@@ -43,7 +43,7 @@ class TaggedDict<T> {
   }
 
   set(key: string, value: T) {
-    dirty(this._tag);
+    dirtyTag(this._tag);
     return (this.data[key] = value);
   }
 }
@@ -125,7 +125,7 @@ QUnit.test('CachedReference caches nested computation correctly', assert => {
 
       let dict = parent.value();
 
-      update(_tag, dict.tag);
+      updateTag(_tag, dict.tag);
 
       return dict.get(key);
     }

--- a/packages/@glimmer/reference/test/template-test.ts
+++ b/packages/@glimmer/reference/test/template-test.ts
@@ -1,6 +1,13 @@
 import { module, test } from './utils/qunit';
 
-import { CONSTANT_TAG, createTag, consume, dirty, value, validate } from '@glimmer/validator';
+import {
+  CONSTANT_TAG,
+  createTag,
+  consumeTag,
+  dirtyTag,
+  valueForTag,
+  validateTag,
+} from '@glimmer/validator';
 
 import {
   ComponentRootReference,
@@ -81,7 +88,7 @@ module('@glimmer/reference: template', () => {
       let tag = createTag();
       let ref = new HelperRootReference(
         () => {
-          consume(tag);
+          consumeTag(tag);
           return 123;
         },
         EMPTY_ARGS,
@@ -152,12 +159,12 @@ module('@glimmer/reference: template', () => {
         _foo: 123,
 
         get foo() {
-          consume(tag);
+          consumeTag(tag);
           return this._foo;
         },
 
         set foo(value) {
-          dirty(tag);
+          dirtyTag(tag);
           this._foo = value;
         },
       };
@@ -167,12 +174,12 @@ module('@glimmer/reference: template', () => {
       let fooRef = ref.get('foo');
       assert.equal(fooRef.value(), component.foo);
 
-      let snapshot = value(fooRef.tag);
-      assert.equal(validate(fooRef.tag, snapshot), true);
+      let snapshot = valueForTag(fooRef.tag);
+      assert.equal(validateTag(fooRef.tag, snapshot), true);
 
       component.foo = 234;
 
-      assert.equal(validate(fooRef.tag, snapshot), false);
+      assert.equal(validateTag(fooRef.tag, snapshot), false);
     });
 
     test('it correctly caches values', assert => {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -1,5 +1,5 @@
 import { Reference, ReferenceCache, VersionedReference } from '@glimmer/reference';
-import { Revision, Tag, isConst, isConstTag, value, validate } from '@glimmer/validator';
+import { Revision, Tag, isConst, isConstTag, valueForTag, validateTag } from '@glimmer/validator';
 import { check, CheckString, CheckElement, CheckOption, CheckNode } from '@glimmer/debug';
 import { Op, Option, ModifierManager } from '@glimmer/interfaces';
 import { $t0 } from '@glimmer/vm';
@@ -134,15 +134,15 @@ export class UpdateModifierOpcode extends UpdatingOpcode {
     private modifier: ModifierInstanceState
   ) {
     super();
-    this.lastUpdated = value(tag);
+    this.lastUpdated = valueForTag(tag);
   }
 
   evaluate(vm: UpdatingVM) {
     let { manager, modifier, tag, lastUpdated } = this;
 
-    if (!validate(tag, lastUpdated)) {
+    if (!validateTag(tag, lastUpdated)) {
       vm.env.scheduleUpdateModifier(modifier, manager);
-      this.lastUpdated = value(tag);
+      this.lastUpdated = valueForTag(tag);
     }
   }
 }
@@ -178,14 +178,14 @@ export class UpdateDynamicAttributeOpcode extends UpdatingOpcode {
     super();
     let { tag } = reference;
     this.tag = tag;
-    this.lastRevision = value(tag);
+    this.lastRevision = valueForTag(tag);
   }
 
   evaluate(vm: UpdatingVM) {
     let { attribute, reference, tag } = this;
-    if (!validate(tag, this.lastRevision)) {
+    if (!validateTag(tag, this.lastRevision)) {
       attribute.update(reference.value(), vm.env);
-      this.lastRevision = value(tag);
+      this.lastRevision = valueForTag(tag);
     }
   }
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -1,6 +1,6 @@
 import { CompilableTemplate, Option, Op } from '@glimmer/interfaces';
 import { isModified, ReferenceCache } from '@glimmer/reference';
-import { CONSTANT_TAG, isConst, Revision, Tag, value, validate } from '@glimmer/validator';
+import { CONSTANT_TAG, isConst, Revision, Tag, valueForTag, validateTag } from '@glimmer/validator';
 import { initializeGuid, assert, isHandle, HandleConstants, decodeHandle } from '@glimmer/util';
 import {
   CheckNumber,
@@ -252,19 +252,19 @@ export class JumpIfNotModifiedOpcode extends UpdatingOpcode {
   constructor(tag: Tag, private target: LabelOpcode) {
     super();
     this.tag = tag;
-    this.lastRevision = value(tag);
+    this.lastRevision = valueForTag(tag);
   }
 
   evaluate(vm: UpdatingVM) {
     let { tag, target, lastRevision } = this;
 
-    if (!vm.alwaysRevalidate && validate(tag, lastRevision)) {
+    if (!vm.alwaysRevalidate && validateTag(tag, lastRevision)) {
       vm.goto(target);
     }
   }
 
   didModify() {
-    this.lastRevision = value(this.tag);
+    this.lastRevision = valueForTag(this.tag);
   }
 }
 

--- a/packages/@glimmer/runtime/lib/helpers/get-dynamic-var.ts
+++ b/packages/@glimmer/runtime/lib/helpers/get-dynamic-var.ts
@@ -1,5 +1,5 @@
 import { PathReference } from '@glimmer/reference';
-import { Tag, UpdatableTag, combine, createUpdatableTag, update } from '@glimmer/validator';
+import { Tag, UpdatableTag, combine, createUpdatableTag, updateTag } from '@glimmer/validator';
 import { DynamicScope, VM as PublicVM, VMArguments, Helper } from '@glimmer/interfaces';
 
 class DynamicVarReference implements PathReference<unknown> {
@@ -23,7 +23,7 @@ class DynamicVarReference implements PathReference<unknown> {
     let name = String(this.nameRef.value());
     let ref = this.scope.get(name);
 
-    update(this.varTag, ref.tag);
+    updateTag(this.varTag, ref.tag);
 
     return ref;
   }

--- a/packages/@glimmer/runtime/lib/vm/content/text.ts
+++ b/packages/@glimmer/runtime/lib/vm/content/text.ts
@@ -1,7 +1,7 @@
 import { isEmpty, isString } from '../../dom/normalize';
 import { UpdatingOpcode } from '../../opcodes';
 import { VersionedReference } from '@glimmer/reference';
-import { Tag, value, validate, Revision } from '@glimmer/validator';
+import { Tag, valueForTag, validateTag, Revision } from '@glimmer/validator';
 import { SimpleText } from '@simple-dom/interface';
 
 export default class DynamicTextContent extends UpdatingOpcode {
@@ -17,14 +17,14 @@ export default class DynamicTextContent extends UpdatingOpcode {
   ) {
     super();
     this.tag = reference.tag;
-    this.lastRevision = value(this.tag);
+    this.lastRevision = valueForTag(this.tag);
   }
 
   evaluate() {
     let { reference, tag } = this;
 
-    if (!validate(tag, this.lastRevision)) {
-      this.lastRevision = value(tag);
+    if (!validateTag(tag, this.lastRevision)) {
+      this.lastRevision = valueForTag(tag);
       this.update(reference.value());
     }
   }

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -15,9 +15,9 @@ import {
 } from '@glimmer/interfaces';
 import {
   combine,
-  value,
-  update,
-  validate,
+  valueForTag,
+  updateTag,
+  validateTag,
   createUpdatableTag,
   Tag,
   UpdatableTag,
@@ -171,7 +171,7 @@ export class TryOpcode extends BlockOpcode implements ExceptionHandler {
   }
 
   didInitializeChildren() {
-    update(this._tag, combineSlice(this.children));
+    updateTag(this._tag, combineSlice(this.children));
   }
 
   evaluate(vm: UpdatingVM) {
@@ -313,17 +313,17 @@ export class ListBlockOpcode extends BlockOpcode {
   }
 
   didInitializeChildren(listDidChange = true) {
-    this.lastIterated = value(this.artifacts.tag);
+    this.lastIterated = valueForTag(this.artifacts.tag);
 
     if (listDidChange) {
-      update(this._tag, combineSlice(this.children));
+      updateTag(this._tag, combineSlice(this.children));
     }
   }
 
   evaluate(vm: UpdatingVM) {
     let { artifacts, lastIterated } = this;
 
-    if (!validate(artifacts.tag, lastIterated)) {
+    if (!validateTag(artifacts.tag, lastIterated)) {
       let { bounds } = this;
       let { dom } = vm;
 

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -12,7 +12,7 @@ export {
   createUpdatableTag,
   CurrentTag,
   CURRENT_TAG,
-  dirty,
+  dirtyTag,
   DirtyableTag,
   EntityTag,
   EntityTagged,
@@ -23,9 +23,9 @@ export {
   Tag,
   Tagged,
   UpdatableTag,
-  update,
-  validate,
-  value,
+  updateTag,
+  validateTag,
+  valueForTag,
   VolatileTag,
   VOLATILE_TAG,
   VOLATILE,
@@ -33,7 +33,18 @@ export {
 
 export { dirtyTagFor, tagFor, setPropertyDidChange } from './lib/meta';
 
-export { consume, EPOCH, isTracking, track, trackedData, untrack } from './lib/tracking';
+export {
+  beginTrackFrame,
+  endTrackFrame,
+  consumeTag,
+  EPOCH,
+  isTracking,
+  track,
+  trackedData,
+  memoizeTracked,
+  untrack,
+  isConstMemo,
+} from './lib/tracking';
 
 export {
   setAutotrackingTransactionEnv,

--- a/packages/@glimmer/validator/lib/meta.ts
+++ b/packages/@glimmer/validator/lib/meta.ts
@@ -1,5 +1,11 @@
 import { DEBUG } from '@glimmer/env';
-import { dirty, createUpdatableTag, UpdatableTag, CONSTANT_TAG, ConstantTag } from './validators';
+import {
+  dirtyTag,
+  createUpdatableTag,
+  UpdatableTag,
+  CONSTANT_TAG,
+  ConstantTag,
+} from './validators';
 import { assertTagNotConsumed } from './debug';
 
 export let propertyDidChange = function() {};
@@ -33,7 +39,7 @@ export function dirtyTagFor<T>(obj: T, key: keyof T | string | symbol): void {
         assertTagNotConsumed!(propertyTag, obj, key);
       }
 
-      dirty(propertyTag);
+      dirtyTag(propertyTag);
       propertyDidChange();
     }
   } else {

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -50,7 +50,7 @@ export interface Tagged {
  *
  * @param tag
  */
-export function value(_tag: Tag): Revision {
+export function valueForTag(_tag: Tag): Revision {
   return $REVISION;
 }
 
@@ -64,7 +64,7 @@ export function value(_tag: Tag): Revision {
  * @param tag
  * @param snapshot
  */
-export function validate(tag: Tag, snapshot: Revision) {
+export function validateTag(tag: Tag, snapshot: Revision) {
   return snapshot >= tag[COMPUTE]();
 }
 
@@ -171,7 +171,7 @@ class MonomorphicTagImpl implements MonomorphicTag {
     return this.lastValue;
   }
 
-  static update(_tag: UpdatableTag, _subtag: Tag) {
+  static updateTag(_tag: UpdatableTag, _subtag: Tag) {
     if (DEBUG && _tag[TYPE] !== MonomorphicTagTypes.Updatable) {
       throw new Error('Attempted to update a tag that was not updatable');
     }
@@ -206,7 +206,7 @@ class MonomorphicTagImpl implements MonomorphicTag {
     }
   }
 
-  static dirty(tag: DirtyableTag | UpdatableTag) {
+  static dirtyTag(tag: DirtyableTag | UpdatableTag) {
     if (
       DEBUG &&
       !(tag[TYPE] === MonomorphicTagTypes.Updatable || tag[TYPE] === MonomorphicTagTypes.Dirtyable)
@@ -224,8 +224,8 @@ class MonomorphicTagImpl implements MonomorphicTag {
   }
 }
 
-export const dirty = MonomorphicTagImpl.dirty;
-export const update = MonomorphicTagImpl.update;
+export const dirtyTag = MonomorphicTagImpl.dirtyTag;
+export const updateTag = MonomorphicTagImpl.updateTag;
 
 //////////
 

--- a/packages/@glimmer/validator/test/meta-test.ts
+++ b/packages/@glimmer/validator/test/meta-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from './-utils';
 
-import { dirtyTagFor, tagFor, validate, value } from '..';
+import { dirtyTagFor, tagFor, validateTag, valueForTag } from '..';
 
 module('@glimmer/validator: meta', () => {
   test('it creates a unique tag for a property on a given object', assert => {
@@ -13,9 +13,9 @@ module('@glimmer/validator: meta', () => {
     let obj = {};
     let tag = tagFor(obj, 'foo');
 
-    let snapshot = value(tag);
+    let snapshot = valueForTag(tag);
     dirtyTagFor(obj, 'foo');
 
-    assert.notOk(validate(tag, snapshot));
+    assert.notOk(validateTag(tag, snapshot));
   });
 });

--- a/packages/@glimmer/validator/test/validators-test.ts
+++ b/packages/@glimmer/validator/test/validators-test.ts
@@ -10,25 +10,25 @@ import {
   combine,
   createTag,
   createUpdatableTag,
-  dirty,
-  update,
-  validate,
-  value,
+  dirtyTag,
+  updateTag,
+  validateTag,
+  valueForTag,
 } from '..';
 
 module('@glimmer/validator: validators', () => {
   module('DirtyableTag', () => {
     test('it can be dirtied', assert => {
       let tag = createTag();
-      let snapshot = value(tag);
+      let snapshot = valueForTag(tag);
 
-      assert.ok(validate(tag, snapshot));
+      assert.ok(validateTag(tag, snapshot));
 
-      dirty(tag);
-      assert.notOk(validate(tag, snapshot));
+      dirtyTag(tag);
+      assert.notOk(validateTag(tag, snapshot));
 
-      snapshot = value(tag);
-      assert.ok(validate(tag, snapshot));
+      snapshot = valueForTag(tag);
+      assert.ok(validateTag(tag, snapshot));
     });
 
     if (DEBUG) {
@@ -37,7 +37,7 @@ module('@glimmer/validator: validators', () => {
         let subtag = createTag();
 
         assert.throws(
-          () => update(tag as any, subtag),
+          () => updateTag(tag as any, subtag),
           /Error: Attempted to update a tag that was not updatable/
         );
       });
@@ -47,31 +47,31 @@ module('@glimmer/validator: validators', () => {
   module('UpdatableTag', () => {
     test('it can be dirtied', assert => {
       let tag = createUpdatableTag();
-      let snapshot = value(tag);
+      let snapshot = valueForTag(tag);
 
-      assert.ok(validate(tag, snapshot));
+      assert.ok(validateTag(tag, snapshot));
 
-      dirty(tag);
-      assert.notOk(validate(tag, snapshot));
+      dirtyTag(tag);
+      assert.notOk(validateTag(tag, snapshot));
 
-      snapshot = value(tag);
-      assert.ok(validate(tag, snapshot));
+      snapshot = valueForTag(tag);
+      assert.ok(validateTag(tag, snapshot));
     });
 
     test('it can be updated', assert => {
       let tag = createUpdatableTag();
       let subtag = createUpdatableTag();
 
-      update(tag, subtag);
+      updateTag(tag, subtag);
 
-      let snapshot = value(tag);
-      assert.ok(validate(tag, snapshot));
+      let snapshot = valueForTag(tag);
+      assert.ok(validateTag(tag, snapshot));
 
-      dirty(subtag);
-      assert.notOk(validate(tag, snapshot));
+      dirtyTag(subtag);
+      assert.notOk(validateTag(tag, snapshot));
 
-      snapshot = value(tag);
-      assert.ok(validate(tag, snapshot));
+      snapshot = valueForTag(tag);
+      assert.ok(validateTag(tag, snapshot));
     });
 
     test('it correctly buffers updates when subtag has a less recent value', assert => {
@@ -79,20 +79,20 @@ module('@glimmer/validator: validators', () => {
       let subtag = createUpdatableTag();
 
       // First, we dirty the parent tag so it is more recent than the subtag
-      dirty(tag);
+      dirtyTag(tag);
 
       // Then, we get a snapshot of the parent
-      let snapshot = value(tag);
+      let snapshot = valueForTag(tag);
 
       // Now, we update the parent tag with the subtag, and revalidate it
-      update(tag as any, subtag);
+      updateTag(tag as any, subtag);
 
-      assert.ok(validate(tag, snapshot), 'tag is still valid after being updated');
+      assert.ok(validateTag(tag, snapshot), 'tag is still valid after being updated');
 
       // Finally, dirty the subtag one final time to bust the buffer cache
-      dirty(subtag);
+      dirtyTag(subtag);
 
-      assert.notOk(validate(tag, snapshot), 'tag is invalid after subtag is dirtied again');
+      assert.notOk(validateTag(tag, snapshot), 'tag is invalid after subtag is dirtied again');
     });
 
     test('it correctly buffers updates when subtag has a more recent value', assert => {
@@ -100,20 +100,20 @@ module('@glimmer/validator: validators', () => {
       let subtag = createUpdatableTag();
 
       // First, we get a snapshot of the parent
-      let snapshot = value(tag);
+      let snapshot = valueForTag(tag);
 
       // Then we dirty the currently unrelated subtag
-      dirty(subtag);
+      dirtyTag(subtag);
 
       // Now, we update the parent tag with the subtag, and revalidate it
-      update(tag as any, subtag);
+      updateTag(tag as any, subtag);
 
-      assert.ok(validate(tag, snapshot), 'tag is still valid after being updated');
+      assert.ok(validateTag(tag, snapshot), 'tag is still valid after being updated');
 
       // Finally, dirty the subtag one final time to bust the buffer cache
-      dirty(subtag);
+      dirtyTag(subtag);
 
-      assert.notOk(validate(tag, snapshot), 'tag is invalid after subtag is dirtied again');
+      assert.notOk(validateTag(tag, snapshot), 'tag is invalid after subtag is dirtied again');
     });
 
     if (DEBUG) {
@@ -121,31 +121,31 @@ module('@glimmer/validator: validators', () => {
         let tag = createUpdatableTag();
         let subtag = createUpdatableTag();
 
-        let snapshot = value(tag);
+        let snapshot = valueForTag(tag);
 
-        update(tag, subtag);
-        update(subtag, tag);
+        updateTag(tag, subtag);
+        updateTag(subtag, tag);
 
-        dirty(tag);
+        dirtyTag(tag);
 
-        assert.throws(() => validate(tag, snapshot));
+        assert.throws(() => validateTag(tag, snapshot));
       });
 
       test('does allow cycles on tags that have been marked with ALLOW_CYCLES', assert => {
         let tag = createUpdatableTag();
         let subtag = createUpdatableTag();
 
-        let snapshot = value(tag);
+        let snapshot = valueForTag(tag);
 
         ALLOW_CYCLES!.set(tag, true);
         ALLOW_CYCLES!.set(subtag, true);
 
-        update(tag, subtag);
-        update(subtag, tag);
+        updateTag(tag, subtag);
+        updateTag(subtag, tag);
 
-        dirty(tag);
+        dirtyTag(tag);
 
-        assert.notOk(validate(tag, snapshot));
+        assert.notOk(validateTag(tag, snapshot));
       });
     }
   });
@@ -157,13 +157,13 @@ module('@glimmer/validator: validators', () => {
 
       let combined = combine([tag1, tag2]);
 
-      let snapshot = value(combined);
-      dirty(tag1);
-      assert.notOk(validate(combined, snapshot));
+      let snapshot = valueForTag(combined);
+      dirtyTag(tag1);
+      assert.notOk(validateTag(combined, snapshot));
 
-      snapshot = value(combined);
-      dirty(tag2);
-      assert.notOk(validate(combined, snapshot));
+      snapshot = valueForTag(combined);
+      dirtyTag(tag2);
+      assert.notOk(validateTag(combined, snapshot));
     });
 
     if (DEBUG) {
@@ -174,7 +174,7 @@ module('@glimmer/validator: validators', () => {
         let combined = combine([tag1, tag2]);
 
         assert.throws(
-          () => dirty(combined as any),
+          () => dirtyTag(combined as any),
           /Error: Attempted to dirty a tag that was not dirtyable/
         );
       });
@@ -186,7 +186,7 @@ module('@glimmer/validator: validators', () => {
         let combined = combine([tag1, tag2]);
 
         assert.throws(
-          () => update(combined as any, tag1),
+          () => updateTag(combined as any, tag1),
           /Error: Attempted to update a tag that was not updatable/
         );
       });
@@ -197,7 +197,7 @@ module('@glimmer/validator: validators', () => {
     if (DEBUG) {
       test('it cannot be dirtied', assert => {
         assert.throws(
-          () => dirty(CONSTANT_TAG as any),
+          () => dirtyTag(CONSTANT_TAG as any),
           /Error: Attempted to dirty a tag that was not dirtyable/
         );
       });
@@ -206,7 +206,7 @@ module('@glimmer/validator: validators', () => {
         let subtag = createTag();
 
         assert.throws(
-          () => update(CONSTANT_TAG as any, subtag),
+          () => updateTag(CONSTANT_TAG as any, subtag),
           /Error: Attempted to update a tag that was not updatable/
         );
       });
@@ -215,8 +215,8 @@ module('@glimmer/validator: validators', () => {
 
   module('VolatileTag', () => {
     test('it is always invalid', assert => {
-      let snapshot = value(VOLATILE_TAG);
-      assert.notOk(validate(VOLATILE_TAG, snapshot));
+      let snapshot = valueForTag(VOLATILE_TAG);
+      assert.notOk(validateTag(VOLATILE_TAG, snapshot));
     });
 
     test('it ensures that any tags which it is combined with are also always invalid', assert => {
@@ -226,14 +226,14 @@ module('@glimmer/validator: validators', () => {
 
       bump();
 
-      let snapshot = value(combined);
-      assert.notOk(validate(combined, snapshot));
+      let snapshot = valueForTag(combined);
+      assert.notOk(validateTag(combined, snapshot));
     });
 
     if (DEBUG) {
       test('it cannot be dirtied', assert => {
         assert.throws(
-          () => dirty(VOLATILE_TAG as any),
+          () => dirtyTag(VOLATILE_TAG as any),
           /Error: Attempted to dirty a tag that was not dirtyable/
         );
       });
@@ -242,7 +242,7 @@ module('@glimmer/validator: validators', () => {
         let subtag = createTag();
 
         assert.throws(
-          () => update(VOLATILE_TAG as any, subtag),
+          () => updateTag(VOLATILE_TAG as any, subtag),
           /Error: Attempted to update a tag that was not updatable/
         );
       });
@@ -251,32 +251,32 @@ module('@glimmer/validator: validators', () => {
 
   module('CurrentTag', () => {
     test('it is always the current revision', assert => {
-      let snapshot = value(CURRENT_TAG);
-      assert.ok(validate(CURRENT_TAG, snapshot));
+      let snapshot = valueForTag(CURRENT_TAG);
+      assert.ok(validateTag(CURRENT_TAG, snapshot));
 
       let tag = createTag();
-      dirty(tag);
+      dirtyTag(tag);
 
-      assert.notOk(validate(CURRENT_TAG, snapshot));
+      assert.notOk(validateTag(CURRENT_TAG, snapshot));
     });
 
     test('it ensures that any tags which it is combined with are also always the current revision', assert => {
       let tag2 = createTag();
       let combined = combine([CURRENT_TAG, tag2]);
 
-      let snapshot = value(combined);
-      assert.ok(validate(combined, snapshot));
+      let snapshot = valueForTag(combined);
+      assert.ok(validateTag(combined, snapshot));
 
       let otherTag = createTag();
-      dirty(otherTag);
+      dirtyTag(otherTag);
 
-      assert.notOk(validate(combined, snapshot));
+      assert.notOk(validateTag(combined, snapshot));
     });
 
     if (DEBUG) {
       test('it cannot be dirtied', assert => {
         assert.throws(
-          () => dirty(CURRENT_TAG as any),
+          () => dirtyTag(CURRENT_TAG as any),
           /Error: Attempted to dirty a tag that was not dirtyable/
         );
       });
@@ -285,7 +285,7 @@ module('@glimmer/validator: validators', () => {
         let subtag = createTag();
 
         assert.throws(
-          () => update(CURRENT_TAG as any, subtag),
+          () => updateTag(CURRENT_TAG as any, subtag),
           /Error: Attempted to update a tag that was not updatable/
         );
       });


### PR DESCRIPTION
Adds `memoizeTracked`, which is meant to clean up autotracking patterns
in general by simplifying them. Also introduces beginTrackFrame and
endTrackFrame for usage within the VM.

`memoizeTracked` has the following signature:

```ts
function memoizeTracked<T, Args>((...args: Args) => T): (...args: Args) => T;
```

It essentially receives a function, and returns the same function but memoized based on tracking. If you consume a tag within that function, it will memoize based on that tag, and will only update if that tag is dirtied. Otherwise, it returns the previous result.

```ts
let count = 0;

let tag = createTag();

let counter = memoizeTracked(() => {
  count++;
  consumeTag(tag);
});

counter(); // count is 1
counter(); // count still 1
dirtyTag(tag);
counter(); // count is 2
```

Depends on #1063