### PR TITLE
[BUGFIX] Ensure {{each}} updates register destructors

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -232,7 +232,7 @@ class ListRevalidationDelegate implements IteratorSynchronizerDelegate<Environme
     let vm = opcode.vmForInsertion(nextSibling);
     let tryOpcode: Option<TryOpcode> = null;
 
-    vm.execute(vm => {
+    let result = vm.execute(vm => {
       tryOpcode = vm.iterate(memo, item);
       map.set(key, tryOpcode);
       vm.pushUpdating(new LinkedList<UpdatingOpcode>());
@@ -241,6 +241,8 @@ class ListRevalidationDelegate implements IteratorSynchronizerDelegate<Environme
     });
 
     updating.insertBefore(tryOpcode!, reference);
+
+    associate(opcode, result.drop);
 
     this.didInsert = true;
   }


### PR DESCRIPTION
Destructors were not being registered for items added to each loops in
updates. This PR fixes this and adds a test.