### PR TITLE
[PERF] Removes the Errors created for autotracking transactions

### DIFF
--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -31,7 +31,7 @@ class Tracker {
     this.tags.add(tag);
 
     if (DEBUG) {
-      markTagAsConsumed!(tag, new Error());
+      markTagAsConsumed!(tag);
     }
 
     this.last = tag;


### PR DESCRIPTION
These errors are expensive to generate, and have become problematic for
development mode in general. The plan is to remove them for now, and try
to bring them back some time in the future in a opt-in way that is more
conventional and comprehensive (e.g. show all possible consumption
locations, not just the first one).

Related: https://github.com/emberjs/ember.js/issues/18834
Related: https://github.com/emberjs/ember.js/issues/18798