### PR TITLE
[BUGFIX] Fix untrack logic

### DIFF
--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -61,12 +61,10 @@ class Tracker {
  */
 let CURRENT_TRACKER: Option<Tracker> = null;
 
-const OPEN_TRACK_FRAMES: Tracker[] = [];
+const OPEN_TRACK_FRAMES: Option<Tracker>[] = [];
 
 export function beginTrackFrame(): void {
-  if (CURRENT_TRACKER !== null) {
-    OPEN_TRACK_FRAMES.push(CURRENT_TRACKER);
-  }
+  OPEN_TRACK_FRAMES.push(CURRENT_TRACKER);
 
   CURRENT_TRACKER = new Tracker();
 }
@@ -74,11 +72,11 @@ export function beginTrackFrame(): void {
 export function endTrackFrame(): Tag {
   let current = CURRENT_TRACKER;
 
-  if (DEBUG && !CURRENT_TRACKER) {
+  if (DEBUG && OPEN_TRACK_FRAMES.length === 0) {
     throw new Error('attempted to close a tracking frame, but one was not open');
   }
 
-  CURRENT_TRACKER = OPEN_TRACK_FRAMES.length > 0 ? OPEN_TRACK_FRAMES.pop()! : null;
+  CURRENT_TRACKER = OPEN_TRACK_FRAMES.pop()!;
 
   return current!.combine();
 }
@@ -197,13 +195,13 @@ export function isTracking() {
 }
 
 export function untrack(callback: () => void) {
-  let parent = CURRENT_TRACKER;
+  OPEN_TRACK_FRAMES.push(CURRENT_TRACKER);
   CURRENT_TRACKER = null;
 
   try {
     callback();
   } finally {
-    CURRENT_TRACKER = parent;
+    CURRENT_TRACKER = OPEN_TRACK_FRAMES.pop()!;
   }
 }
 

--- a/packages/@glimmer/validator/test/tracking-test.ts
+++ b/packages/@glimmer/validator/test/tracking-test.ts
@@ -119,6 +119,30 @@ module('@glimmer/validator: tracking', () => {
         });
       });
     });
+
+    test('nested tracks work', assert => {
+      assert.notOk(isTracking());
+
+      track(() => {
+        assert.ok(isTracking());
+
+        untrack(() => {
+          assert.notOk(isTracking());
+        });
+      });
+    });
+
+    test('nested tracks and untracks work', assert => {
+      track(() => {
+        track(() => {
+          untrack(() => {
+            track(() => {
+              assert.ok(isTracking(), 'tracking');
+            });
+          });
+        });
+      });
+    });
   });
 
   module('manual track frames', () => {


### PR DESCRIPTION
The current logic for `untrack` can cause the tracking frames to become
lopsided. This updates it to ensure that we count untracks and empty
track frames on the autotracking frame stack.