### PR TITLE
Ensure errors during component creation do not cause secondary errors during DOM cleanup

### DIFF
--- a/packages/@glimmer/integration-tests/lib/render-test.ts
+++ b/packages/@glimmer/integration-tests/lib/render-test.ts
@@ -394,9 +394,12 @@ export class RenderTest implements IRenderTest {
 
     let result = expect(this.renderResult, 'the test should call render() before rerender()');
 
-    result.env.begin();
-    result.rerender();
-    result.env.commit();
+    try {
+      result.env.begin();
+      result.rerender();
+    } finally {
+      result.env.commit();
+    }
   }
 
   destroy(): void {

--- a/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
@@ -90,7 +90,7 @@ export interface ElementBuilder extends Cursor, DOMStack, TreeOperations {
   constructing: Option<SimpleElement>;
   element: SimpleElement;
 
-  block(): LiveBlock;
+  hasBlocks: boolean;
   debugBlocks(): LiveBlock[];
 
   pushSimpleBlock(): LiveBlock;

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -131,7 +131,11 @@ export class NewElementBuilder implements ElementBuilder {
     return this[CURSOR_STACK].current!.nextSibling;
   }
 
-  block(): LiveBlock {
+  get hasBlocks() {
+    return this.blockStack.size > 0;
+  }
+
+  protected block(): LiveBlock {
     return expect(this.blockStack.current, 'Expected a current live block');
   }
 


### PR DESCRIPTION
Currently we don't do any cleanup in the event of an error occuring
during the actual execution of the VM. This can leave the VM in a bad
state, in particular the element builder, since it doesn't actually
finalize block nodes until _after_ the entire block has executed. This
means that if an error occurs during the execution of a block, the
VM will never properly initialize those blocks, and their first and last
nodes will be `null`.

While we don't currently support recovering from this type of an error,
we do need to be able to cleanup the application after one, specifically
for tests. Previously, this worked no matter what because of the
Application Wrapper optional feature - there was always a root `div`
element that we could clear, so there was always a first and last node
for us to track. With the feature disabled, we started seeing failures
such as [this issue within user tests](https://github.com/emberjs/ember-test-helpers/issues/768#issuecomment-583752979).

This PR refactors VM updates, specifically, to allow them to properly
clean up the element builder on failures. It now closes all remaining
open blocks, finalizing them to ensure they have nodes.

This only works for VM updates because the initial append is an
_iterator_, which the user controls execution of. We'll need to have a
different strategy for this API, but it shouldn't be a regression at the
moment because any failures during the iteration will result in a
completely broken app from the get-go. There is no result, and no
accompanying `destroy` function, so existing tests and apps cannot be
affected by failures during append.