### PR TITLE
Backport: Properly cleanup the element builder in a try/finally

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -470,12 +470,22 @@ export default class VM<T> implements PublicVM {
 
     let result: IteratorResult<RenderResult>;
 
-    while (true) {
-      result = this.next();
-      if (result.done) break;
+    try {
+      while (true) {
+        result = this.next();
+        if (result.done) break;
+      }
+    } finally {
+      // If any existing blocks are open, due to an error or something like
+      // that, we need to close them all and clean things up properly.
+      let elements = this.elements();
+
+      while (elements.hasBlocks) {
+        elements.popBlock();
+      }
     }
 
-    return result.value;
+    return result.value!;
   }
 
   next(): IteratorResult<RenderResult> {

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -131,6 +131,7 @@ export interface ElementBuilder extends Cursor, DOMStack, TreeOperations {
   expectConstructing(method: string): Simple.Element;
 
   block(): Tracker;
+  hasBlocks: boolean;
 
   pushSimpleBlock(): Tracker;
   pushUpdatableBlock(): UpdatableTracker;
@@ -182,6 +183,10 @@ export class NewElementBuilder implements ElementBuilder {
 
   get nextSibling(): Option<Simple.Node> {
     return this.cursorStack.current!.nextSibling as Option<Simple.Node>;
+  }
+
+  get hasBlocks() {
+    return this.blockStack.size > 0;
   }
 
   expectConstructing(method: string): Simple.Element {

--- a/packages/@glimmer/test-helpers/lib/render-test.ts
+++ b/packages/@glimmer/test-helpers/lib/render-test.ts
@@ -468,9 +468,18 @@ export class RenderTest {
 
     let result = expect(this.renderResult, 'the test should call render() before rerender()');
 
-    result.env.begin();
-    result.rerender();
-    result.env.commit();
+    try {
+      result.env.begin();
+      result.rerender();
+    } finally {
+      result.env.commit();
+    }
+  }
+
+  destroy(): void {
+    let result = expect(this.renderResult, 'the test should call render() before destroy()');
+
+    result.destroy();
   }
 
   protected set(key: string, value: Opaque): void {

--- a/packages/@glimmer/test-helpers/lib/suites/components.ts
+++ b/packages/@glimmer/test-helpers/lib/suites/components.ts
@@ -773,4 +773,96 @@ export class BasicComponents extends RenderTest {
     this.assertHTML(`<div color='red'>hello!</div>`);
     this.assertStableNodes();
   }
+
+    @test({ kind: 'fragment' })
+  'throwing an error during component construction does not put result into a bad state'() {
+    this.registerComponent(
+      'Glimmer',
+      'Foo',
+      'Hello',
+      class extends EmberishGlimmerComponent {
+        constructor() {
+          super();
+          throw new Error('something went wrong!');
+        }
+      }
+    );
+
+    this.render('{{#if showing}}<Foo/>{{/if}}', {
+      showing: false,
+    });
+
+    this.assert.throws(() => {
+      this.rerender({ showing: true });
+    }, 'something went wrong!');
+
+    this.assertHTML('<!---->', 'values rendered before the error rendered correctly');
+    this.destroy();
+
+    this.assertHTML('', 'destroys correctly');
+  }
+
+  @test({ kind: 'fragment' })
+  'throwing an error during component construction does not put result into a bad state with multiple prior nodes'() {
+    this.registerComponent(
+      'Glimmer',
+      'Foo',
+      'Hello',
+      class extends EmberishGlimmerComponent {
+        constructor() {
+          super();
+          throw new Error('something went wrong!');
+        }
+      }
+    );
+
+    this.render('{{#if showing}}<div class="first"></div><div class="second"></div><Foo/>{{/if}}', {
+      showing: false,
+    });
+
+    this.assert.throws(() => {
+      this.rerender({ showing: true });
+    }, 'something went wrong!');
+
+    this.assertHTML(
+      '<div class="first"></div><div class="second"></div><!---->',
+      'values rendered before the error rendered correctly'
+    );
+    this.destroy();
+
+    this.assertHTML('', 'destroys correctly');
+  }
+
+  @test({ kind: 'fragment' })
+  'throwing an error during component construction does not put result into a bad state with nested components'() {
+    this.registerComponent(
+      'Glimmer',
+      'Foo',
+      'Hello',
+      class extends EmberishGlimmerComponent {
+        constructor() {
+          super();
+          throw new Error('something went wrong!');
+        }
+      }
+    );
+
+    this.registerComponent('Basic', 'Bar', '<div class="second"></div><Foo/>');
+
+    this.render('{{#if showing}}<div class="first"></div><Bar/>{{/if}}', {
+      showing: false,
+    });
+
+    this.assert.throws(() => {
+      this.rerender({ showing: true });
+    }, 'something went wrong!');
+
+    this.assertHTML(
+      '<div class="first"></div><div class="second"></div><!---->',
+      'values rendered before the error rendered correctly'
+    );
+    this.destroy();
+
+    this.assertHTML('', 'destroys correctly');
+  }
 }


### PR DESCRIPTION
This is a backport of the changes in #1073 to the release-0-38-alpha branch so that we can fix these issues in ember-source@3.16 (which still uses 0.38-alpha).