### PR TITLE
Update main key in package json to reference es2017 bundles

### DIFF
--- a/build/broccoli/write-package-json.js
+++ b/build/broccoli/write-package-json.js
@@ -6,7 +6,7 @@ const funnel = require('broccoli-funnel');
 const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 
 const PACKAGE_JSON_FIELDS = {
-  main: 'dist/commonjs/es5/index.js',
+  main: 'dist/commonjs/es2017/index.js',
   'jsnext:main': 'dist/modules/es5/index.js',
   module: 'dist/modules/es2017/index.js',
   typings: 'dist/types/index.d.ts',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -56,7 +56,7 @@ module.exports = function() {
       ['types'],
     ];
   } else {
-    matrix = [['amd', 'es5'], ['commonjs', 'es5'], ['modules', 'es2017'], ['types']];
+    matrix = [['amd', 'es5'], ['commonjs', 'es2017'], ['modules', 'es2017'], ['types']];
   }
 
   // Third, build our module/ES combinations for each package.


### PR DESCRIPTION
**Why**
Currently when we try to use glimmer-vm in a node env it pulls in the es5 bundles instead of the es2017 bundle. [node > 10 has 100% support for es2017](https://node.green/#ES2017) so we should be able to just pull that in and don't have to run any of the polyfilled features which could have runtime overahead.

**How**
- Update path in write-package-json build script

