### PR TITLE
Ensure overriding with an empty Hash does not add extra whitespace.

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/printer.ts
+++ b/packages/@glimmer/syntax/lib/generation/printer.ts
@@ -72,7 +72,7 @@ export default class Printer {
     if (this.options.override !== undefined) {
       let result = this.options.override(node, this.options);
       if (typeof result === 'string') {
-        if (ensureLeadingWhitespace && NON_WHITESPACE.test(result[0])) {
+        if (ensureLeadingWhitespace && result !== '' && NON_WHITESPACE.test(result[0])) {
           result = ` ${result}`;
         }
 

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -149,4 +149,22 @@ QUnit.module('[glimmer-syntax] Code generation - override', function() {
 
     assert.equal(actual, `{{foo-bar baz="ZOMG!!!!"}}`);
   });
+
+  test('maintains proper spacing when overriding empty hash', function(assert) {
+    let ast = parse(`{{foo-bar derp blah=baz}}`);
+
+    let actual = print(ast, {
+      entityEncoding: 'transformed',
+
+      override(ast) {
+        if (ast.type === 'Hash') {
+          return '';
+        }
+
+        return;
+      },
+    });
+
+    assert.equal(actual, `{{foo-bar derp}}`);
+  });
 });


### PR DESCRIPTION
When an override is used (e.g. `ember-template-recast`) and a `Hash` result is overriden to be an empty string, we were previously **always** appending a whitespace character.

For example, the following is a failing test in ember-template-recast:

```js
let ast = parse('{{some-helper (foo "hi")}}');

let [sexpr] = ast.body[0].params;
ast.body.push(builders.mustache(sexpr.path, sexpr.params, sexpr.hash));

expect(print(ast)).toEqual(`{{some-helper (foo "hi")}}{{foo "hi"}}`);
```

Prior to these changes that emits:

```hbs
{{some-helper (foo "hi")}}{{foo "hi" }}
```

(Note the extra space in the last `MustacheStatement`)

See failure in https://github.com/ember-template-lint/ember-template-recast/pull/279