### PR TITLE
Fix key uniqueness implementation

### DIFF
--- a/packages/@glimmer/reference/lib/iterable-impl.ts
+++ b/packages/@glimmer/reference/lib/iterable-impl.ts
@@ -124,7 +124,7 @@ function uniqueKeyFor(keyFor: KeyFor) {
 
   return (value: unknown, memo: unknown) => {
     let key = keyFor(value, memo);
-    let count = seen.get(value) || 0;
+    let count = seen.get(key) || 0;
 
     seen.set(key, count + 1);
 

--- a/packages/@glimmer/reference/test/iterable-impl-test.ts
+++ b/packages/@glimmer/reference/test/iterable-impl-test.ts
@@ -163,6 +163,22 @@ module('@glimmer/reference: IterableImpl', () => {
       assert.equal(keys1[0], keys2[1]);
     });
 
+    test('@identity works with multiple null values', assert => {
+      let arr: any[] = [null];
+      let { target, artifacts } = initialize(arr);
+
+      let keys1 = target.toKeys();
+
+      arr.push(null);
+      sync(target, artifacts);
+
+      let keys2 = target.toKeys();
+
+      assert.equal(keys2.length, 2);
+      assert.equal(keys1[0], keys2[0]);
+      assert.notEqual(keys1[0], keys2[1]);
+    });
+
     test('@key works', assert => {
       let arr = [
         { key: 'a', name: 'Yehuda' },


### PR DESCRIPTION
Bugfix for the iteration's key uniqueness function, was passing the
value in instead of the key derived from the value. Added a test that
fails if keys are not correctly unique, originally we weren't testing
this because IDENTITY returns the value it was passed in all cases
except `null`.