### PR TITLE
[MEGA HAX] useful stack during template evaluation

### DIFF
--- a/packages/@glimmer/debug/index.ts
+++ b/packages/@glimmer/debug/index.ts
@@ -1,4 +1,4 @@
 export * from './lib/stack-check';
 export * from './lib/metadata';
 export { opcodeMetadata } from './lib/opcode-metadata';
-export { debug, debugSlice, logOpcode } from './lib/debug';
+export { debug, debugFunction, debugSlice, logOpcode } from './lib/debug';

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -17,7 +17,7 @@ import { EMPTY_ARRAY } from '@glimmer/util';
 import { templateCompilationContext } from './opcode-builder/context';
 import { concatStatements } from './syntax/concat';
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
-import { debugCompiler } from './compiler';
+import { debugCompiler, compileDebugFunction } from './compiler';
 import { patchStdlibs } from '@glimmer/program';
 import { STATEMENTS } from './syntax/statements';
 
@@ -79,6 +79,7 @@ export function compileStatements(
   let handle = context.encoder.commit(syntaxContext.program.heap, meta.size);
 
   if (LOCAL_SHOULD_LOG) {
+    compileDebugFunction(context, handle);
     debugCompiler(context, handle);
   }
 

--- a/packages/@glimmer/opcode-compiler/lib/compiler.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compiler.ts
@@ -1,4 +1,4 @@
-import { debugSlice } from '@glimmer/debug';
+import { debugFunction, debugSlice } from '@glimmer/debug';
 import {
   CompilerBuffer,
   CompileTimeHeap,
@@ -67,4 +67,16 @@ if (LOCAL_SHOULD_LOG) {
 
     debugSlice(context, start, end);
   };
+}
+
+export function compileDebugFunction(
+  context: TemplateCompilationContext,
+  result: HandleResult
+): void {
+  let handle = extractHandle(result);
+  let { heap } = context.syntax.program;
+  let start = heap.getaddr(handle);
+  let end = start + heap.sizeof(handle);
+
+  window.DEBUG_FUNCTIONS[start] = debugFunction(context, start, end);
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/stdlib.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/stdlib.ts
@@ -1,5 +1,6 @@
 import { $s0 } from '@glimmer/vm';
-
+import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
+import { compileDebugFunction } from '../../compiler';
 import { invokePreparedComponent, InvokeBareComponent } from './components';
 import { StdLib } from '../stdlib';
 import { EncoderImpl, op } from '../encoder';
@@ -90,6 +91,10 @@ function build(program: WholeProgramCompilationContext, callback: () => CompileA
     // This shouldn't be possible
     throw new Error(`Unexpected errors compiling std`);
   } else {
+    if (LOCAL_SHOULD_LOG) {
+      compileDebugFunction(stdContext, result);
+    }
+
     return result;
   }
 }

--- a/packages/@glimmer/opcode-compiler/lib/program-context.ts
+++ b/packages/@glimmer/opcode-compiler/lib/program-context.ts
@@ -31,6 +31,7 @@ export class JitProgramCompilationContext implements JitProgramCompilationContex
   readonly mode: CompileMode = CompileMode.jit;
 
   constructor(delegate: CompileTimeResolverDelegate) {
+    window.DEBUG_FUNCTIONS = Object.create(null);
     this.resolverDelegate = delegate;
     this.stdlib = compileStd(this);
   }

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -11,7 +11,7 @@ import { templateCompilationContext } from './opcode-builder/context';
 import { meta } from './opcode-builder/helpers/shared';
 import { ATTRS_BLOCK, WrappedComponent } from './opcode-builder/helpers/components';
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
-import { debugCompiler } from './compiler';
+import { debugCompiler, compileDebugFunction } from './compiler';
 import { concatStatements } from './syntax/concat';
 import { patchStdlibs } from '@glimmer/program';
 
@@ -58,6 +58,7 @@ export class WrappedBuilder implements CompilableProgram {
     this.compiled = handle;
 
     if (LOCAL_SHOULD_LOG) {
+      compileDebugFunction(context, handle);
       debugCompiler(context, handle);
     }
 


### PR DESCRIPTION
![useful-stack](https://user-images.githubusercontent.com/55829/81020304-5c2efb00-8e1d-11ea-8e62-96a897fb95b9.gif)

Instead of pulling the normal generator loop, this compiles each template block into a [threaded](https://en.wikipedia.org/wiki/Threaded_code) function that drives the VM instead.

This essentially unrolls the core VM loop into normal imperative JavaScript code and function calls. This means we can use all the debugger functionalities (stepping, jumping between stack frames, watch expressions, etc) normally.

This uses indirect eval (`new Function`) and is intended for debug mode only.

Currently it passes all JIT tests for me locally but it breaks just about everything else. It also has lots of MEGA HAX, so it's really just a proof-of-concept at this point.

To try it, clone the branch, find a JIT test, introduce an error somewhere, run the test with LOCAL_SHOULD_LOG, without try/catch, and with the debugger open.

I recommend the "correct scope - complex yield" test for this purpose as it has a good amount of nesting that show cases the usefulness of this feature well.

If you are lucky, maybe this URL will bring you there: http://localhost:4200/tests/index.html?enable_local_should_log&filter=jit&testId=2780f765

The easiest way to introduce an error is to invoke a component that doesn't exists. Once you have done it and refresh, you should be paused in the debugger (assuming you have pause on uncaught exceptions enabled) where the error is thrown.

You can go up the stack and see exactly the opcode execution sequence that got you here, with the nesting information. You can set a breakpoint anywhere in the opcodes before the error, refresh the page and be paused in the right location. You can even use conditional breakpoints, adding watch expressions for `vm.pc`, `vm.stack.peek()`, etc and have them update live as you step through the code.