### PR TITLE
[BUGFIX] Process in-element in compiler not parser

### DIFF
--- a/packages/@glimmer/integration-tests/lib/compile.ts
+++ b/packages/@glimmer/integration-tests/lib/compile.ts
@@ -21,9 +21,10 @@ export const DEFAULT_TEST_META: AnnotatedModuleLocator = Object.freeze({
 // out of the test environment.
 export function preprocess(
   template: string,
-  meta?: AnnotatedModuleLocator
+  meta?: AnnotatedModuleLocator,
+  options?: PrecompileOptions
 ): Template<AnnotatedModuleLocator> {
-  let wrapper = JSON.parse(rawPrecompile(template));
+  let wrapper = JSON.parse(rawPrecompile(template, options));
   let factory = templateFactory<AnnotatedModuleLocator>(wrapper);
   return factory.create(meta || DEFAULT_TEST_META);
 }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/render.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/render.ts
@@ -1,4 +1,5 @@
 import { JitTestDelegateContext } from './delegate';
+import { PrecompileOptions } from '@glimmer/compiler';
 import { VersionedPathReference } from '@glimmer/reference';
 import { ElementBuilder, RenderResult } from '@glimmer/interfaces';
 import { preprocess } from '../../compile';
@@ -9,9 +10,10 @@ export function renderTemplate(
   src: string,
   { runtime, syntax }: JitTestDelegateContext,
   self: VersionedPathReference,
-  builder: ElementBuilder
+  builder: ElementBuilder,
+  options?: PrecompileOptions
 ): RenderResult {
-  let template = preprocess(src);
+  let template = preprocess(src, undefined, options);
   let handle = unwrapTemplate(template)
     .asLayout()
     .compile(syntax);

--- a/packages/@glimmer/integration-tests/lib/render-delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/render-delegate.ts
@@ -6,6 +6,7 @@ import {
   SimpleDocumentFragment,
   SimpleDocument,
 } from '@simple-dom/interface';
+import { ASTPluginBuilder } from '@glimmer/syntax';
 import { ComponentKind, ComponentTypes } from './components';
 import { UserHelper } from './helpers';
 import {
@@ -39,6 +40,7 @@ export default interface RenderDelegate {
     layout: string,
     Class?: ComponentTypes[K]
   ): void;
+  registerPlugin(plugin: ASTPluginBuilder): void;
   registerHelper(name: string, helper: UserHelper): void;
   registerInternalHelper(name: string, helper: Helper): void;
   registerPartial(name: string, content: string): void;

--- a/packages/@glimmer/integration-tests/lib/render-test.ts
+++ b/packages/@glimmer/integration-tests/lib/render-test.ts
@@ -1,4 +1,5 @@
 import { Dict, Maybe, Option, RenderResult, Helper } from '@glimmer/interfaces';
+import { ASTPluginBuilder } from '@glimmer/syntax';
 import { bump, isConst } from '@glimmer/validator';
 import { clearElement, dict, expect, assign } from '@glimmer/util';
 import { SimpleElement, SimpleNode } from '@simple-dom/interface';
@@ -54,19 +55,23 @@ export class RenderTest implements IRenderTest {
     this.element = delegate.getInitialElement();
   }
 
-  registerHelper(name: string, helper: UserHelper) {
+  registerPlugin(plugin: ASTPluginBuilder): void {
+    this.delegate.registerPlugin(plugin);
+  }
+
+  registerHelper(name: string, helper: UserHelper): void {
     this.delegate.registerHelper(name, helper);
   }
 
-  registerInternalHelper(name: string, helper: Helper) {
+  registerInternalHelper(name: string, helper: Helper): void {
     this.delegate.registerInternalHelper(name, helper);
   }
 
-  registerModifier(name: string, ModifierClass: TestModifierConstructor) {
+  registerModifier(name: string, ModifierClass: TestModifierConstructor): void {
     this.delegate.registerModifier(name, ModifierClass);
   }
 
-  registerPartial(name: string, content: string) {
+  registerPartial(name: string, content: string): void {
     this.delegate.registerPartial(name, content);
   }
 
@@ -75,7 +80,7 @@ export class RenderTest implements IRenderTest {
     name: string,
     layout: string,
     Class?: ComponentTypes[K]
-  ) {
+  ): void {
     this.delegate.registerComponent(type, this.testType, name, layout, Class);
   }
 

--- a/packages/@glimmer/integration-tests/package.json
+++ b/packages/@glimmer/integration-tests/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@glimmer/reference": "^0.52.0",
     "@glimmer/runtime": "^0.52.0",
+    "@glimmer/syntax": "^0.52.0",
     "@glimmer/validator": "^0.52.0",
     "@glimmer/compiler": "^0.52.0",
     "@glimmer/util": "^0.52.0",

--- a/packages/@glimmer/opcode-compiler/lib/syntax/builtins.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/builtins.ts
@@ -167,6 +167,8 @@ export function populateBuiltins(
 
     return ReplayableIf({
       args() {
+        assert(hash !== null, '[BUG] `{{#in-element}}` should have non-empty hash');
+
         let [keys, values] = hash!;
 
         let actions: StatementCompileActions = [];


### PR DESCRIPTION
This fixes the issue described in https://github.com/DockYard/ember-maybe-in-element/pull/25#issuecomment-622506443

tl;dr If an AST transform introduces the element, it doesn't go through the parser, so it's missing the required `guid` and `insertBefore` normalization. This commit moves the processing to a later stage to avoid this issue.