### PR TITLE
[REFACTOR] Rename memoizeTracked to memo

### DIFF
--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -41,7 +41,7 @@ export {
   isTracking,
   track,
   trackedData,
-  memoizeTracked,
+  memo,
   untrack,
   isConstMemo,
 } from './lib/tracking';

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -85,29 +85,26 @@ export function endTrackFrame(): Tag {
 
 const IS_CONST_MAP: WeakMap<object, boolean | undefined> = new WeakMap();
 
-export function memoizeTracked<T>(cb: () => T, context?: string | false): () => T;
-export function memoizeTracked<T, U>(cb: (a1: U) => T, context?: string | false): (a1: U) => T;
-export function memoizeTracked<T, U, V, W>(
+export function memo<T>(cb: () => T, context?: string | false): () => T;
+export function memo<T, U>(cb: (a1: U) => T, context?: string | false): (a1: U) => T;
+export function memo<T, U, V, W>(
   cb: (a1: U, a2: V, a3: W) => T,
   context?: string | false
 ): (a1: U, a2: V, a3: W) => T;
-export function memoizeTracked<T, U, V, W, X>(
+export function memo<T, U, V, W, X>(
   cb: (a1: U, a2: V, a3: W, a4: X) => T,
   context?: string | false
 ): (a1: U, a2: V, a3: W, a4: X) => T;
-export function memoizeTracked<T, U, V, W, X, Y>(
+export function memo<T, U, V, W, X, Y>(
   cb: (a1: U, a2: V, a3: W, a4: X, a5: Y) => T,
   context?: string | false
 ): (a1: U, a2: V, a3: W, a4: X, a5: Y) => T;
-export function memoizeTracked<T, U, V, W, X, Y, Z>(
+export function memo<T, U, V, W, X, Y, Z>(
   cb: (a1: U, a2: V, a3: W, a4: X, a5: Y, a6: Z) => T,
   context?: string | false
 ): (a1: U, a2: V, a3: W, a4: X, a5: Y, a6: Z) => T;
 
-export function memoizeTracked<T>(
-  callback: (...args: unknown[]) => T,
-  debuggingContext?: string | false
-) {
+export function memo<T>(callback: (...args: unknown[]) => T, debuggingContext?: string | false) {
   let lastValue: T | undefined;
   let tag: Tag;
   let snapshot: Revision;

--- a/packages/@glimmer/validator/test/tracking-test.ts
+++ b/packages/@glimmer/validator/test/tracking-test.ts
@@ -16,7 +16,7 @@ import {
   setPropertyDidChange,
   tagFor,
   track,
-  memoizeTracked,
+  memo,
   trackedData,
   untrack,
   validateTag,
@@ -263,13 +263,13 @@ module('@glimmer/validator: tracking', () => {
     });
   });
 
-  module('memoizeTracked', () => {
+  module('memo', () => {
     test('it memoizes based on tags that are consumed within a track frame', assert => {
       let tag1 = createTag();
       let tag2 = createTag();
       let count = 0;
 
-      let fn = memoizeTracked(() => {
+      let fn = memo(() => {
         consumeTag(tag1);
         consumeTag(tag2);
 
@@ -293,7 +293,7 @@ module('@glimmer/validator: tracking', () => {
       let tag2 = createTag();
       let count = 0;
 
-      let fn = memoizeTracked(() => {
+      let fn = memo(() => {
         consumeTag(tag1);
 
         untrack(() => consumeTag(tag2));
@@ -319,13 +319,13 @@ module('@glimmer/validator: tracking', () => {
       let innerCount = 0;
       let outerCount = 0;
 
-      let innerFn = memoizeTracked(() => {
+      let innerFn = memo(() => {
         consumeTag(innerTag);
 
         return ++innerCount;
       });
 
-      let outerFn = memoizeTracked(() => {
+      let outerFn = memo(() => {
         consumeTag(outerTag);
 
         return [++outerCount, innerFn()];
@@ -349,7 +349,7 @@ module('@glimmer/validator: tracking', () => {
       assert.expect(3);
       assert.notOk(isTracking());
 
-      let fn = memoizeTracked(() => {
+      let fn = memo(() => {
         assert.ok(isTracking());
 
         untrack(() => {
@@ -363,11 +363,11 @@ module('@glimmer/validator: tracking', () => {
     test('isConstMemo allows users to check if a memoized function is constant', assert => {
       let tag = createTag();
 
-      let constFn = memoizeTracked(() => {
+      let constFn = memo(() => {
         // do nothing;
       });
 
-      let nonConstFn = memoizeTracked(() => {
+      let nonConstFn = memo(() => {
         consumeTag(tag);
       });
 
@@ -380,7 +380,7 @@ module('@glimmer/validator: tracking', () => {
 
     if (DEBUG) {
       test('isConstMemo throws an error in DEBUG mode if users attempt to check a function before it has been called', assert => {
-        let fn = memoizeTracked(() => {
+        let fn = memo(() => {
           // do nothing;
         });
 


### PR DESCRIPTION
Since this is no longer going to be the public API, rename it to be
an internal API with a shorter name (less bytes, easier to remember