### PR TITLE
Remove unused EPOCH tag

### DIFF
--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -37,7 +37,6 @@ export {
   beginTrackFrame,
   endTrackFrame,
   consumeTag,
-  EPOCH,
   isTracking,
   track,
   trackedData,

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -1,14 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import {
-  Tag,
-  combine,
-  createTag,
-  dirtyTag,
-  CONSTANT_TAG,
-  validateTag,
-  Revision,
-  valueForTag,
-} from './validators';
+import { Tag, combine, CONSTANT_TAG, validateTag, Revision, valueForTag } from './validators';
 import { tagFor, dirtyTagFor } from './meta';
 import { markTagAsConsumed, runInAutotrackingTransaction, assertTagNotConsumed } from './debug';
 

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -207,8 +207,6 @@ export function untrack(callback: () => void) {
 
 //////////
 
-export const EPOCH = createTag();
-
 export type Getter<T, K extends keyof T> = (self: T) => T[K] | undefined;
 export type Setter<T, K extends keyof T> = (self: T, value: T[K]) => void;
 
@@ -240,7 +238,6 @@ export function trackedData<T extends object, K extends keyof T>(
       assertTagNotConsumed!(tagFor(self, key), self, key, true);
     }
 
-    dirtyTag(EPOCH);
     dirtyTagFor(self, key);
     values.set(self, value);
   }


### PR DESCRIPTION
This tag doesn't appear to be used anymore, removing for now to clean
things up and do less work on each dirty.