### PR TITLE
[FEATURE] Adds `cache` api

### DIFF
--- a/packages/@glimmer/integration-tests/lib/render-test.ts
+++ b/packages/@glimmer/integration-tests/lib/render-test.ts
@@ -1,6 +1,6 @@
 import { Dict, Maybe, Option, RenderResult, Helper } from '@glimmer/interfaces';
 import { ASTPluginBuilder } from '@glimmer/syntax';
-import { bump, isConst } from '@glimmer/validator';
+import { bump, isConstTagged } from '@glimmer/validator';
 import { clearElement, dict, expect, assign } from '@glimmer/util';
 import { SimpleElement, SimpleNode } from '@simple-dom/interface';
 import {
@@ -393,7 +393,7 @@ export class RenderTest implements IRenderTest {
 
     let self = this.delegate.getSelf(this.context);
 
-    if (!isConst(self)) {
+    if (!isConstTagged(self)) {
       (self as UpdatableRootReference).forceUpdate(this.context);
     }
 

--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -10,7 +10,7 @@ import {
   updateTag,
   track,
   Revision,
-  isConst,
+  isConstTagged,
   isConstTag,
   valueForTag,
   validateTag,
@@ -150,7 +150,7 @@ export class HelperRootReference<T = unknown> extends RootReference<T> {
       this.didSetupDebugContext = true;
     }
 
-    if (isConst(args)) {
+    if (isConstTagged(args)) {
       this.compute();
     }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -38,7 +38,7 @@ import {
   ModifierManager,
 } from '@glimmer/interfaces';
 import { VersionedPathReference, VersionedReference } from '@glimmer/reference';
-import { CONSTANT_TAG, isConst, isConstTag, Tag } from '@glimmer/validator';
+import { CONSTANT_TAG, isConstTagged, isConstTag, Tag } from '@glimmer/validator';
 import {
   assert,
   dict,
@@ -538,7 +538,7 @@ function setDeferredAttr(
     vm.elements().setStaticAttribute(name, value, namespace);
   } else {
     let attribute = vm.elements().setDynamicAttribute(name, value.value(), trusting, namespace);
-    if (!isConst(value)) {
+    if (!isConstTagged(value)) {
       vm.updateWith(new UpdateDynamicAttributeOpcode(value, attribute));
     }
   }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -1,5 +1,5 @@
 import { Reference } from '@glimmer/reference';
-import { Tag, isConst } from '@glimmer/validator';
+import { Tag, isConstTagged } from '@glimmer/validator';
 import {
   check,
   CheckString,
@@ -77,7 +77,7 @@ APPEND_OPCODES.add(Op.AppendText, vm => {
 
   let node = vm.elements().appendDynamicText(value);
 
-  if (!isConst(reference)) {
+  if (!isConstTagged(reference)) {
     vm.updateWith(new DynamicTextContent(node, reference, value));
   }
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -1,5 +1,12 @@
 import { Reference, ReferenceCache, VersionedReference } from '@glimmer/reference';
-import { Revision, Tag, isConst, isConstTag, valueForTag, validateTag } from '@glimmer/validator';
+import {
+  Revision,
+  Tag,
+  isConstTagged,
+  isConstTag,
+  valueForTag,
+  validateTag,
+} from '@glimmer/validator';
 import { check, CheckString, CheckElement, CheckOption, CheckNode } from '@glimmer/debug';
 import { Op, Option, ModifierManager } from '@glimmer/interfaces';
 import { $t0 } from '@glimmer/vm';
@@ -43,7 +50,7 @@ APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
   let insertBefore: Maybe<SimpleNode>;
   let guid = guidRef.value() as string;
 
-  if (isConst(elementRef)) {
+  if (isConstTagged(elementRef)) {
     element = check(elementRef.value(), CheckElement);
   } else {
     let cache = new ReferenceCache(elementRef as Reference<SimpleElement>);
@@ -52,7 +59,7 @@ APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
   }
 
   if (insertBeforeRef.value() !== undefined) {
-    if (isConst(insertBeforeRef)) {
+    if (isConstTagged(insertBeforeRef)) {
       insertBefore = check(insertBeforeRef.value(), CheckOption(CheckNode));
     } else {
       let cache = new ReferenceCache(insertBeforeRef as Reference<Option<SimpleNode>>);
@@ -163,7 +170,7 @@ APPEND_OPCODES.add(Op.DynamicAttr, (vm, { op1: _name, op2: trusting, op3: _names
 
   let attribute = vm.elements().setDynamicAttribute(name, value, !!trusting, namespace);
 
-  if (!isConst(reference)) {
+  if (!isConstTagged(reference)) {
     vm.updateWith(new UpdateDynamicAttributeOpcode(reference, attribute));
   }
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -1,6 +1,13 @@
 import { CompilableTemplate, Option, Op } from '@glimmer/interfaces';
 import { isModified, ReferenceCache } from '@glimmer/reference';
-import { CONSTANT_TAG, isConst, Revision, Tag, valueForTag, validateTag } from '@glimmer/validator';
+import {
+  CONSTANT_TAG,
+  isConstTagged,
+  Revision,
+  Tag,
+  valueForTag,
+  validateTag,
+} from '@glimmer/validator';
 import { initializeGuid, assert, isHandle, HandleConstants, decodeHandle } from '@glimmer/util';
 import {
   CheckNumber,
@@ -160,7 +167,7 @@ APPEND_OPCODES.add(Op.InvokeYield, vm => {
 APPEND_OPCODES.add(Op.JumpIf, (vm, { op1: target }) => {
   let reference = check(vm.stack.pop(), CheckReference);
 
-  if (isConst(reference)) {
+  if (isConstTagged(reference)) {
     if (reference.value()) {
       vm.goto(target);
     }
@@ -178,7 +185,7 @@ APPEND_OPCODES.add(Op.JumpIf, (vm, { op1: target }) => {
 APPEND_OPCODES.add(Op.JumpUnless, (vm, { op1: target }) => {
   let reference = check(vm.stack.pop(), CheckReference);
 
-  if (isConst(reference)) {
+  if (isConstTagged(reference)) {
     if (!reference.value()) {
       vm.goto(target);
     }
@@ -204,7 +211,7 @@ APPEND_OPCODES.add(Op.JumpEq, (vm, { op1: target, op2: comparison }) => {
 APPEND_OPCODES.add(Op.AssertSame, vm => {
   let reference = check(vm.stack.peek(), CheckReference);
 
-  if (!isConst(reference)) {
+  if (!isConstTagged(reference)) {
     vm.updateWith(Assert.initialize(new ReferenceCache(reference)));
   }
 });

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -17,7 +17,7 @@ export {
   EntityTag,
   EntityTagged,
   INITIAL,
-  isConst,
+  isConstTagged,
   isConstTag,
   Revision,
   Tag,
@@ -39,11 +39,16 @@ export {
   consumeTag,
   isTracking,
   track,
-  trackedData,
   memo,
   untrack,
   isConstMemo,
+  Cache,
+  createCache,
+  isConst,
+  getValue,
 } from './lib/tracking';
+
+export { trackedData } from './lib/tracked-data';
 
 export {
   setAutotrackingTransactionEnv,

--- a/packages/@glimmer/validator/lib/tracked-data.ts
+++ b/packages/@glimmer/validator/lib/tracked-data.ts
@@ -1,0 +1,42 @@
+import { DEBUG } from '@glimmer/env';
+import { tagFor, dirtyTagFor } from './meta';
+import { assertTagNotConsumed } from './debug';
+import { consumeTag } from './tracking';
+
+export type Getter<T, K extends keyof T> = (self: T) => T[K] | undefined;
+export type Setter<T, K extends keyof T> = (self: T, value: T[K]) => void;
+
+export function trackedData<T extends object, K extends keyof T>(
+  key: K,
+  initializer?: (this: T) => T[K]
+): { getter: Getter<T, K>; setter: Setter<T, K> } {
+  let values = new WeakMap<T, T[K]>();
+  let hasInitializer = typeof initializer === 'function';
+
+  function getter(self: T) {
+    consumeTag(tagFor(self, key));
+
+    let value;
+
+    // If the field has never been initialized, we should initialize it
+    if (hasInitializer && !values.has(self)) {
+      value = initializer!.call(self);
+      values.set(self, value);
+    } else {
+      value = values.get(self);
+    }
+
+    return value;
+  }
+
+  function setter(self: T, value: T[K]): void {
+    if (DEBUG) {
+      assertTagNotConsumed!(tagFor(self, key), self, key, true);
+    }
+
+    dirtyTagFor(self, key);
+    values.set(self, value);
+  }
+
+  return { getter, setter };
+}

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -241,7 +241,7 @@ export function createUpdatableTag(): UpdatableTag {
 
 export const CONSTANT_TAG = new MonomorphicTagImpl(MonomorphicTagTypes.Constant) as ConstantTag;
 
-export function isConst({ tag }: Tagged): boolean {
+export function isConstTagged({ tag }: Tagged): boolean {
   return tag === CONSTANT_TAG;
 }
 

--- a/packages/@glimmer/validator/test/tracking-test.ts
+++ b/packages/@glimmer/validator/test/tracking-test.ts
@@ -21,6 +21,9 @@ import {
   untrack,
   validateTag,
   valueForTag,
+  createCache,
+  isConst,
+  getValue,
 } from '..';
 
 module('@glimmer/validator: tracking', () => {
@@ -386,7 +389,165 @@ module('@glimmer/validator: tracking', () => {
 
         assert.throws(
           () => isConstMemo(fn),
-          /Error: Attempted to call `isConstMemo` on a memoized function/
+          /Error: isConst\(\) can only be used on a cache once getValue\(\) has been called at least once/
+        );
+      });
+    }
+  });
+
+  module('tracking cache', () => {
+    test('it memoizes based on tags that are consumed within a track frame', assert => {
+      let tag1 = createTag();
+      let tag2 = createTag();
+      let count = 0;
+
+      let cache = createCache(() => {
+        consumeTag(tag1);
+        consumeTag(tag2);
+
+        return ++count;
+      });
+
+      assert.equal(getValue(cache), 1, 'called correctly the first time');
+      assert.equal(getValue(cache), 1, 'memoized result returned second time');
+
+      dirtyTag(tag1);
+      assert.equal(getValue(cache), 2, 'cache busted when tag1 dirtied');
+      assert.equal(getValue(cache), 2, 'memoized result returned when nothing dirtied');
+
+      dirtyTag(tag2);
+      assert.equal(getValue(cache), 3, 'cache busted when tag2 dirtied');
+      assert.equal(getValue(cache), 3, 'memoized result returned when nothing dirtied');
+    });
+
+    test('it ignores tags consumed within an untrack frame', assert => {
+      let tag1 = createTag();
+      let tag2 = createTag();
+      let count = 0;
+
+      let cache = createCache(() => {
+        consumeTag(tag1);
+
+        untrack(() => consumeTag(tag2));
+
+        return ++count;
+      });
+
+      assert.equal(getValue(cache), 1, 'called correctly the first time');
+      assert.equal(getValue(cache), 1, 'memoized result returned second time');
+
+      dirtyTag(tag1);
+      assert.equal(getValue(cache), 2, 'cache busted when tag1 dirtied');
+      assert.equal(getValue(cache), 2, 'memoized result returned when nothing dirtied');
+
+      dirtyTag(tag2);
+      assert.equal(getValue(cache), 2, 'cache not busted when tag2 dirtied');
+    });
+
+    test('nested memoizations work, and automatically propogate', assert => {
+      let innerTag = createTag();
+      let outerTag = createTag();
+
+      let innerCount = 0;
+      let outerCount = 0;
+
+      let innerCache = createCache(() => {
+        consumeTag(innerTag);
+
+        return ++innerCount;
+      });
+
+      let outerCache = createCache(() => {
+        consumeTag(outerTag);
+
+        return [++outerCount, getValue(innerCache)];
+      });
+
+      assert.deepEqual(
+        getValue(outerCache),
+        [1, 1],
+        'both functions called correctly the first time'
+      );
+      assert.deepEqual(getValue(outerCache), [1, 1], 'memoized result returned correctly');
+
+      dirtyTag(outerTag);
+
+      assert.deepEqual(
+        getValue(outerCache),
+        [2, 1],
+        'outer result updated, inner result still memoized'
+      );
+      assert.deepEqual(getValue(outerCache), [2, 1], 'memoized result returned correctly');
+
+      dirtyTag(innerTag);
+
+      assert.deepEqual(getValue(outerCache), [3, 2], 'both inner and outer result updated');
+      assert.deepEqual(getValue(outerCache), [3, 2], 'memoized result returned correctly');
+    });
+
+    test('isTracking works within a memoized function and untrack frame', assert => {
+      assert.expect(3);
+      assert.notOk(isTracking());
+
+      let cache = createCache(() => {
+        assert.ok(isTracking());
+
+        untrack(() => {
+          assert.notOk(isTracking());
+        });
+      });
+
+      getValue(cache);
+    });
+
+    test('isConst allows users to check if a memoized function is constant', assert => {
+      let tag = createTag();
+
+      let constCache = createCache(() => {
+        // do nothing;
+      });
+
+      let nonConstCache = createCache(() => {
+        consumeTag(tag);
+      });
+
+      getValue(constCache);
+      getValue(nonConstCache);
+
+      assert.ok(isConst(constCache), 'constant cache returns true');
+      assert.notOk(isConst(nonConstCache), 'non-constant cache returns false');
+    });
+
+    if (DEBUG) {
+      test('createCache throws an error in DEBUG mode if users to use with a non-function', assert => {
+        assert.throws(
+          () => createCache(123 as any),
+          /Error: createCache\(\) must be passed a function as its first parameter. Called with: 123/
+        );
+      });
+
+      test('getValue throws an error in DEBUG mode if users to use with a non-cache', assert => {
+        assert.throws(
+          () => getValue(123 as any),
+          /Error: getValue\(\) can only be used on an instance of a cache created with createCache\(\). Called with: 123/
+        );
+      });
+
+      test('isConst throws an error in DEBUG mode if users attempt to check a function before it has been called', assert => {
+        let cache = createCache(() => {
+          // do nothing;
+        });
+
+        assert.throws(
+          () => isConst(cache),
+          /Error: isConst\(\) can only be used on a cache once getValue\(\) has been called at least once/
+        );
+      });
+
+      test('isConst throws an error in DEBUG mode if users attempt to use with a non-cache', assert => {
+        assert.throws(
+          () => isConst(123 as any),
+          /Error: isConst\(\) can only be used on an instance of a cache created with createCache\(\). Called with: 123/
         );
       });
     }


### PR DESCRIPTION
Adds the cache API specified in [RFC 615](https://github.com/emberjs/rfcs/blob/master/text/0615-autotracking-memoization.md).

There were a few minor refactors in addition to this:

- Moved `trackedData` into a separate module, since the `tracking`
  module was getting pretty big.

- Renamed `isConst` to `isConstTagged`, since there is a naming conflict
  with the new `isConst` function. Given `isConstTagged` will be removed
  soon and is not generally much used outside of the VM, I thought it
  was better to prioritize the new API getting this name.

- Rewrote the `memoizeTracked` implementation on top of the cache APIs.
  One thing worth noting is that in order to support the API
  `memoizeTracked` had before, `getValue` also needed to be able to
  accept and pass on args. This is something we'll wrap to hide when we
  expose this publicly in Ember/Glimmer for the time being, since that
  was a capability that was not added in the RFC.