### PR TITLE
[BUGFIX] Update iterable items only when changed

### DIFF
--- a/packages/@glimmer/integration-tests/lib/suites/in-element.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/in-element.ts
@@ -6,6 +6,7 @@ import { equalsElement } from '../dom/assertions';
 import { stripTight } from '../test-helpers/strings';
 import { replaceHTML } from '../dom/simple-utils';
 import { EmberishCurlyComponent } from '../components/emberish-curly';
+import { tracked } from '../test-helpers/tracked';
 
 export class InElementSuite extends RenderTest {
   static suiteName = '#in-element';
@@ -388,20 +389,28 @@ export class InElementSuite extends RenderTest {
 
   @test
   'Inside a loop'() {
+    let { delegate } = this;
+
+    class Item {
+      element = delegate.createElement('div');
+
+      @tracked value: string;
+
+      constructor(value: string) {
+        this.value = value;
+      }
+    }
+
     this.testType = 'Dynamic';
     this.registerComponent('Basic', 'FooBar', '<p>{{@value}}</p>');
 
     this.registerHelper('log', ([item]) => console.log(item));
 
-    let roots = [
-      { id: 0, element: this.delegate.createElement('div'), value: 'foo' },
-      { id: 1, element: this.delegate.createElement('div'), value: 'bar' },
-      { id: 2, element: this.delegate.createElement('div'), value: 'baz' },
-    ];
+    let roots = [new Item('foo'), new Item('bar'), new Item('baz')];
 
     this.render(
       stripTight`
-        {{~#each this.roots key="id" as |root|~}}
+        {{~#each this.roots as |root|~}}
           {{~log root~}}
           {{~#in-element root.element ~}}
             <FooBar @value={{root.value}} />

--- a/packages/@glimmer/integration-tests/lib/test-helpers/tracked.ts
+++ b/packages/@glimmer/integration-tests/lib/test-helpers/tracked.ts
@@ -1,0 +1,15 @@
+import { trackedData } from '@glimmer/validator';
+
+export function tracked(target: object, key: string) {
+  let { getter, setter } = trackedData<any, any>(key);
+
+  Object.defineProperty(target, key, {
+    get() {
+      return getter(this);
+    },
+
+    set(value: unknown) {
+      setter(this, value);
+    },
+  });
+}

--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -307,8 +307,12 @@ export class IterationItemReference<T = unknown> implements TemplatePathReferenc
   }
 
   update(value: T) {
-    dirtyTag(this.tag);
-    this.itemValue = value;
+    let { itemValue } = this;
+
+    if (value !== itemValue) {
+      dirtyTag(this.tag);
+      this.itemValue = value;
+    }
   }
 
   get(key: string): TemplatePathReference {

--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -309,6 +309,7 @@ export class IterationItemReference<T = unknown> implements TemplatePathReferenc
   update(value: T) {
     let { itemValue } = this;
 
+    // TODO: refactor this https://github.com/glimmerjs/glimmer-vm/issues/1101
     if (value !== itemValue) {
       dirtyTag(this.tag);
       this.itemValue = value;


### PR DESCRIPTION
Currently, iterable item references always update their value and dirty
their tag, even if the value didn't actually change. This is different
from the baseline behavior in Ember, and a regression.

This PR updates this behavior, and also updates affected tests. These
tests were written prior to the recent VM upgrade, and probably assumed
some differences in behaviors in the testing environment. Now that we're
trying to align the testing environment more closely with Ember, these
tests need to be updated. I added a `@tracked` decorator to the test
helpers, which should allow us to more closely match Ember's behavior.

Fix for https://github.com/emberjs/ember.js/issues/18968