### PR TITLE
[BUGFIX] Adds an assertion to prevent duplicate validator packages

### DIFF
--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -1,3 +1,17 @@
+import { symbolFor, getGlobal } from './lib/utils';
+
+const globalObj = getGlobal();
+
+const GLIMMER_VALIDATOR_REGISTRATION = symbolFor('GLIMMER_VALIDATOR_REGISTRATION');
+
+if (globalObj[GLIMMER_VALIDATOR_REGISTRATION] === true) {
+  throw new Error(
+    'The `@glimmer/validator` library has been included twice in this application. It could be different versions of the package, or the same version included twice by mistake. `@glimmer/validator` depends on having a single copy of the package in use at any time in an application, even if they are the same version. You must dedupe your build to remove the duplicate packages in order to prevent this error.'
+  );
+}
+
+globalObj[GLIMMER_VALIDATOR_REGISTRATION] = true;
+
 export {
   ALLOW_CYCLES,
   bump,

--- a/packages/@glimmer/validator/lib/utils.ts
+++ b/packages/@glimmer/validator/lib/utils.ts
@@ -11,3 +11,18 @@ export const symbol =
   typeof Symbol !== 'undefined'
     ? Symbol
     : (key: string) => `__${key}${Math.floor(Math.random() * Date.now())}__` as any;
+
+export const symbolFor =
+  typeof Symbol !== 'undefined'
+    ? Symbol.for
+    : (key: string) => (`__GLIMMER_VALIDATOR_SYMBOL_FOR_${key}` as unknown) as symbol;
+
+export function getGlobal(): any {
+  // eslint-disable-next-line node/no-unsupported-features/es-builtins
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+
+  throw new Error('unable to locate global object');
+}


### PR DESCRIPTION
Adds an assertion that will throw if duplicate validator packages are detected.
This is because validator depends on a few global values for things to work properly
at the moment. We may be able to relax this restriction in the future, mainly adding
it now to prevent confusion when things aren't working properly.