### PR TITLE
feat: better DEBUG memoization

### DIFF
--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -192,6 +192,16 @@ export class HelperRootReference<T = unknown> extends RootReference<T> {
   }
 }
 
+/*
+  DEBUG only fields. Keeping this in a separate interface which Typescript then
+  merges with the class definition allow us to have a DEBUG only property without
+  paying the cost of that field being present and initialized (usually to void 0)
+  in production.
+*/
+export interface PropertyReference {
+  ref?: PropertyReference;
+}
+
 /**
  * PropertyReferences represent a property that has been accessed on a root, or
  * another property (or iterable, see below). `some` and `prop` in
@@ -200,10 +210,6 @@ export class HelperRootReference<T = unknown> extends RootReference<T> {
  * recursively calling `get` on the previous reference as a template chain is
  * followed.
  */
-export interface PropertyReference {
-  ref?: PropertyReference;
-}
-
 export class PropertyReference implements TemplatePathReference {
   public tag: Tag;
   private valueTag: UpdatableTag;

--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -103,17 +103,17 @@ export abstract class RootReference<T = unknown> implements TemplatePathReferenc
         this.didSetupDebugContext = true;
         this.env.setTemplatePathDebugContext(this, this.debugLogName || 'this', null);
       }
-
-      return new PropertyReference(this, key, this.env);
-    } else {
-      let ref = this.children[key];
-
-      if (ref === undefined) {
-        ref = this.children[key] = new PropertyReference(this, key, this.env);
-      }
-
-      return ref;
     }
+
+    let ref = this.children[key];
+
+    if (ref === undefined) {
+      ref = this.children[key] = new PropertyReference(this, key, this.env);
+    } else if (DEBUG) {
+      return new PropertyReference(this, key, this.env, ref);
+    }
+
+    return ref;
   }
 }
 
@@ -200,6 +200,10 @@ export class HelperRootReference<T = unknown> extends RootReference<T> {
  * recursively calling `get` on the previous reference as a template chain is
  * followed.
  */
+export interface PropertyReference {
+  ref?: PropertyReference;
+}
+
 export class PropertyReference implements TemplatePathReference {
   public tag: Tag;
   private valueTag: UpdatableTag;
@@ -210,10 +214,12 @@ export class PropertyReference implements TemplatePathReference {
   constructor(
     protected parentReference: TemplatePathReference,
     protected propertyKey: string,
-    protected env: TemplateReferenceEnvironment
+    protected env: TemplateReferenceEnvironment,
+    ref?: PropertyReference
   ) {
     if (DEBUG) {
       env.setTemplatePathDebugContext(this, propertyKey, parentReference);
+      this.ref = ref;
     }
 
     let valueTag = (this.valueTag = createUpdatableTag());
@@ -230,7 +236,11 @@ export class PropertyReference implements TemplatePathReference {
 
       if (isDict(parentValue)) {
         let combined = track(() => {
-          lastValue = this.env.getPath(parentValue, propertyKey);
+          if (DEBUG && this.ref) {
+            lastValue = this.ref.value();
+          } else {
+            lastValue = this.env.getPath(parentValue, propertyKey);
+          }
         }, DEBUG && this.env.getTemplatePathDebugContext(this));
 
         updateTag(valueTag, combined);
@@ -246,20 +256,18 @@ export class PropertyReference implements TemplatePathReference {
   }
 
   get(key: string): TemplatePathReference {
-    // References should in general be identical to one another, so we can usually
-    // deduplicate them in production. However, in DEBUG we need unique references
-    // so we can properly key off them for the logging context.
-    if (DEBUG) {
-      return new PropertyReference(this, key, this.env);
-    } else {
-      let ref = this.children[key];
+    let ref = this.children[key];
 
-      if (ref === undefined) {
-        ref = this.children[key] = new PropertyReference(this, key, this.env);
-      }
-
-      return ref;
+    if (ref === undefined) {
+      ref = this.children[key] = new PropertyReference(this, key, this.env);
+    } else if (DEBUG) {
+      // References should in general be identical to one another, so we can usually
+      // deduplicate them in production. However, in DEBUG we need unique references
+      // so we can properly key off them for the logging context.
+      return new PropertyReference(this, key, this.env, ref);
     }
+
+    return ref;
   }
 
   [UPDATE_REFERENCED_VALUE](value: unknown) {
@@ -317,19 +325,17 @@ export class IterationItemReference<T = unknown> implements TemplatePathReferenc
   }
 
   get(key: string): TemplatePathReference {
-    // References should in general be identical to one another, so we can usually
-    // deduplicate them in production. However, in DEBUG we need unique references
-    // so we can properly key off them for the logging context.
-    if (DEBUG) {
-      return new PropertyReference(this, key, this.env);
-    } else {
-      let ref = this.children[key];
+    let ref = this.children[key];
 
-      if (ref === undefined) {
-        ref = this.children[key] = new PropertyReference(this, key, this.env);
-      }
-
-      return ref;
+    if (ref === undefined) {
+      ref = this.children[key] = new PropertyReference(this, key, this.env);
+    } else if (DEBUG) {
+      // References should in general be identical to one another, so we can usually
+      // deduplicate them in production. However, in DEBUG we need unique references
+      // so we can properly key off them for the logging context.
+      return new PropertyReference(this, key, this.env, ref);
     }
+
+    return ref;
   }
 }

--- a/packages/@glimmer/reference/test/template-test.ts
+++ b/packages/@glimmer/reference/test/template-test.ts
@@ -7,8 +7,6 @@ import {
   dirtyTag,
   valueForTag,
   validateTag,
-  track,
-  runInAutotrackingTransaction,
 } from '@glimmer/validator';
 
 import {

--- a/packages/@glimmer/reference/test/template-test.ts
+++ b/packages/@glimmer/reference/test/template-test.ts
@@ -7,6 +7,8 @@ import {
   dirtyTag,
   valueForTag,
   validateTag,
+  track,
+  runInAutotrackingTransaction,
 } from '@glimmer/validator';
 
 import {
@@ -70,7 +72,7 @@ module('@glimmer/reference: template', () => {
       let component = {
         get foo() {
           pullCount++;
-          return 'hello';
+          return pullCount;
         },
       };
       let ref = new ComponentRootReference(
@@ -95,9 +97,15 @@ module('@glimmer/reference: template', () => {
         })()
       );
 
-      ref.get('foo').value();
-      ref.get('foo').value();
-      ref.get('foo').value();
+      let ref1 = ref.get('foo');
+      ref1.value();
+      let ref2 = ref.get('foo');
+      ref2.value();
+      let ref3 = ref.get('foo');
+      ref3.value();
+      assert.ok(true, 'we did not error');
+      assert.notStrictEqual(ref1, ref2, 'second access is a new reference');
+      assert.notStrictEqual(ref1, ref3, 'third access is a new reference');
       assert.strictEqual(setCount, 4, 'We setup template debug context appropriately');
       assert.strictEqual(pullCount, 1, 'We only access the value once');
     });


### PR DESCRIPTION
I recently noticed that the effect of our extra `PropertyReference` creations in DEBUG to preserve context for debuggability decreases the level of memoization that occurs. For instance, a component with a property that is a getter will re-run that getter every location that property is used in it's template. For getters that do not return a stable value, this is a footgun.

In DEBUG (without this fix) this change to memoization semantics can lead to errors that would not occur in production, both in application code (should referential integrity matter) and in the form of rendering assertions for an issue that would not exist in production (a value changing during render).