### PR TITLE
[BUGFIX] Fixes a memory leak with {{each}}

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -231,7 +231,7 @@ class ListRevalidationDelegate implements IteratorSynchronizerDelegate<Environme
     let vm = opcode.vmForInsertion(nextSibling);
     let tryOpcode: Option<TryOpcode> = null;
 
-    let result = vm.execute(vm => {
+    vm.execute(vm => {
       vm.pushUpdating();
       tryOpcode = vm.enterItem(memo, item);
       map.set(key, tryOpcode);
@@ -239,7 +239,13 @@ class ListRevalidationDelegate implements IteratorSynchronizerDelegate<Environme
 
     updating.insertBefore(tryOpcode!, reference);
 
-    associateDestroyableChild(opcode, result.drop);
+    // TODO: We ignore the `result` from the updating VM here because it returns
+    // a RenderResultImpl, which doesn't fit into our updating list, and is
+    // difficult to destroy dynamically. This points to the RenderResultImpl
+    // itself being a problematic construct for re-rendering _within_ the VM.
+    // We should refactor this so that we can get a TryOpcode directly instead,
+    // ideally.
+    associateDestroyableChild(opcode, tryOpcode!);
 
     this.didInsert = true;
   }


### PR DESCRIPTION
Currently we associate the VM result when we add a list item to a list's
updating opcode. However, when we destroy the list item, we destroy the
_opcode_ instead of the result's `drop` value itself. The result is
never actually destroyed, and retains references to the values within it
(the TryOpcodes within the new list item) in its `updating` LinkedList.

This PR associates the TryOpcode itself instead of the result. This
appears to fix the leak in testing, and given the render result should
only ever have one child TryOpcode, this seems like a decent way to
fix the issue. The RenderResultImpl itself is only referenced by the
child TryOpcode, so it's cleaned up as soon as the child is destroyed.

Alternatively, we could rethink how we store child destroyables in the
ListBlockOpcode, so it would make sense to associate two different kinds
of destroyable children.