### PR TITLE
Ensure `isDestroying`/`isDestroyed` without children or destructors does not fail `assertDestroyablesDestroyed`

### DIFF
--- a/packages/@glimmer/runtime/lib/destroyables.ts
+++ b/packages/@glimmer/runtime/lib/destroyables.ts
@@ -212,11 +212,15 @@ export function setScheduleDestroyed(fn: (fn: () => void) => void) {
 }
 
 export function isDestroying(destroyable: Destroyable) {
-  return getDestroyableMeta(destroyable).state >= DestroyingState.Destroying;
+  let meta = DESTROYABLE_META.get(destroyable);
+
+  return meta === undefined ? false : meta.state >= DestroyingState.Destroying;
 }
 
 export function isDestroyed(destroyable: Destroyable) {
-  return getDestroyableMeta(destroyable).state === DestroyingState.Destroyed;
+  let meta = DESTROYABLE_META.get(destroyable);
+
+  return meta === undefined ? false : meta.state >= DestroyingState.Destroyed;
 }
 
 ////////////

--- a/packages/@glimmer/runtime/test/destroyables-test.ts
+++ b/packages/@glimmer/runtime/test/destroyables-test.ts
@@ -438,6 +438,28 @@ module('Destroyables', hooks => {
       assertDestroyablesDestroyed!();
     });
 
+    test('checking isDestroying does not trigger assertion', assert => {
+      assert.expect(1);
+      enableDestroyableTracking!();
+
+      let obj = {};
+
+      isDestroying(obj);
+
+      assertDestroyablesDestroyed!();
+    });
+
+    test('checking isDestroyed does not trigger assertion', assert => {
+      assert.expect(1);
+      enableDestroyableTracking!();
+
+      let obj = {};
+
+      isDestroyed(obj);
+
+      assertDestroyablesDestroyed!();
+    });
+
     test('attempting to call assertDestroyablesDestroyed() before calling enableDestroyableTracking() throws', assert => {
       assert.throws(() => {
         assertDestroyablesDestroyed!();


### PR DESCRIPTION
Checking `isDestroying`/`isDestroyed` should **not** force a given object to be considered an undestroyed destroyable. Only associating children or registering a destructor should cause the `assertDestroyablesDestroyed` method to throw an error.

Reproduction in an Ember context (which is why I noticed it):

```js
enableDestroyableTracking();
let Thing = EmberObject.extend({
  whatever() {}
});
assertDestroyablesDestroyed();
```

This is happening because `Meta.prototype.addMixin` checks if `this.source` is destroying in an assertion:

https://github.com/emberjs/ember.js/blob/a429dc327ee6ef97d948a83e727886c75c6fe043/packages/%40ember/-internals/meta/lib/meta.ts#L262-L273

That is called on the class (`Thing` above) itself so that `this.source` is a class not an instance.