### PR TITLE
Fix `MonomorphicTag` type error for downstream consumers

### DIFF
--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -1,5 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import { UnionToIntersection, symbol } from './utils';
+import { symbol } from './utils';
 import { assertTagNotConsumed } from './debug';
 
 //////////
@@ -100,17 +100,7 @@ export interface UpdatableTag extends MonomorphicTagBase<MonomorphicTagTypes.Upd
 export interface CombinatorTag extends MonomorphicTagBase<MonomorphicTagTypes.Combinator> {}
 export interface ConstantTag extends MonomorphicTagBase<MonomorphicTagTypes.Constant> {}
 
-interface MonomorphicTagMapping {
-  [MonomorphicTagTypes.Dirtyable]: DirtyableTag;
-  [MonomorphicTagTypes.Updatable]: UpdatableTag;
-  [MonomorphicTagTypes.Combinator]: CombinatorTag;
-  [MonomorphicTagTypes.Constant]: ConstantTag;
-}
-
-type MonomorphicTag = UnionToIntersection<MonomorphicTagMapping[MonomorphicTagTypes]>;
-type MonomorphicTagType = UnionToIntersection<MonomorphicTagTypes>;
-
-class MonomorphicTagImpl implements MonomorphicTag {
+class MonomorphicTagImpl<T extends MonomorphicTagTypes = MonomorphicTagTypes> {
   private revision = INITIAL;
   private lastChecked = INITIAL;
   private lastValue = INITIAL;
@@ -121,10 +111,10 @@ class MonomorphicTagImpl implements MonomorphicTag {
   private subtag: Tag | null = null;
   private subtagBufferCache: Revision | null = null;
 
-  [TYPE]: MonomorphicTagType;
+  [TYPE]: T;
 
-  constructor(type: MonomorphicTagTypes) {
-    this[TYPE] = type as MonomorphicTagType;
+  constructor(type: T) {
+    this[TYPE] = type;
   }
 
   [COMPUTE](): Revision {
@@ -239,7 +229,7 @@ export function createUpdatableTag(): UpdatableTag {
 
 //////////
 
-export const CONSTANT_TAG = new MonomorphicTagImpl(MonomorphicTagTypes.Constant) as ConstantTag;
+export const CONSTANT_TAG: ConstantTag = new MonomorphicTagImpl(MonomorphicTagTypes.Constant);
 
 export function isConstTagged({ tag }: Tagged): boolean {
   return tag === CONSTANT_TAG;
@@ -290,7 +280,7 @@ export function createCombinatorTag(tags: Tag[]): Tag {
     case 1:
       return tags[0];
     default:
-      let tag = new MonomorphicTagImpl(MonomorphicTagTypes.Combinator) as CombinatorTag;
+      let tag: CombinatorTag = new MonomorphicTagImpl(MonomorphicTagTypes.Combinator);
       (tag as any).subtags = tags;
       return tag;
   }


### PR DESCRIPTION
### Context

As of TypeScript 3.9, [intersections of types with a conflicting discriminator value now resolve to `never`](https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/).

Previously, the `MonomorphicTag` type defined here amounted to `Tag & { [TYPE]: never }`, but as of 3.9 that `never` now propagates up and makes the entire `MonomorphicTag` type `never`, which is invalid as the target of an `implements` clause, causing the error described in #1116.

### This Change

This PR makes `MonomorphicTagImpl` parametric over the specific enum value it has as its `[TYPE]`. The runtime behavior is untouched, and I believe this is at least as typesafe as the prior approach. Any properties added to one of the exported `{Dirtyable,Updatable,Combinator,Constant}Tag` types will produce a type error elsewhere in the `validators` module if `MonomorphicTagImpl` doesn't fulfill that contract.

### Other Work

There are several other type errors that crop up on bumping the local version of TypeScript in this repo, but #1116 seems to be the only one that leaks into the public declarations.

Obviously TS stability is [still something the community is working out](https://github.com/typed-ember/ember-cli-typescript/pull/1158) and the core Ember/Glimmer repos haven't made any commitments in that area, but it would be great to at least start flagging breakage in the current stable/beta versions of TypeScript in CI.

From the look of things, that might be as simple as adding a couple extra steps to https://github.com/glimmerjs/glimmer-vm/blob/ac39630bf193fcbecc2ada2d60a75a4f77ab9d08/.github/workflows/ci.yml#L87-L95 to install `typescript@latest` and/or `typescript@next` and then running `yarn test:types` again, but I'm not sure 
how y'all would best like to reason about that.

/cc @pzuraq @chriskrycho since we've discussed this particular error in the past