### PR TITLE
[Refactor] Use a map to dedupe constants instead of indexOf

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -4,11 +4,11 @@ import { RuntimeConstants } from '@glimmer/interfaces';
 
 export default class DebugConstants extends WriteOnlyConstants implements RuntimeConstants {
   getNumber(value: number): number {
-    return this.numbers[value];
+    return this.values[value] as number;
   }
 
   getString(value: number): string {
-    return this.strings[value];
+    return this.values[value] as string;
   }
 
   getStringArray(value: number): string[] {
@@ -24,7 +24,7 @@ export default class DebugConstants extends WriteOnlyConstants implements Runtim
   }
 
   getArray(value: number): number[] {
-    return (this.arrays as number[][])[value];
+    return this.values[value] as number[];
   }
 
   resolveHandle<T>(s: number): T {
@@ -33,7 +33,7 @@ export default class DebugConstants extends WriteOnlyConstants implements Runtim
   }
 
   getSerializable(s: number): unknown {
-    return JSON.parse(this.strings[s]);
+    return JSON.parse(this.values[s] as string);
   }
 
   getTemplateMeta(m: number): unknown {
@@ -41,6 +41,6 @@ export default class DebugConstants extends WriteOnlyConstants implements Runtim
   }
 
   getOther(s: number): unknown {
-    return this.others[s];
+    return this.values[s];
   }
 }

--- a/packages/@glimmer/integration-tests/lib/suites/bundle-compiler.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/bundle-compiler.ts
@@ -20,9 +20,9 @@ export class BundleCompilerEmberTests extends EmberishComponentTests {
       module: 'ui/components/main',
       name: 'default',
     });
-    let { strings } = this.delegate.getConstants();
-    this.assert.equal(strings.indexOf(ALocator), -1);
-    this.assert.equal(strings.indexOf(MainLocator), -1);
+    let values = this.delegate.getConstants();
+    this.assert.equal(values.indexOf(ALocator), -1);
+    this.assert.equal(values.indexOf(MainLocator), -1);
     this.assertHTML('B 1 B 2 B 3 B 4');
     this.assertStableRerender();
   }
@@ -39,9 +39,9 @@ export class BundleCompilerEmberTests extends EmberishComponentTests {
     let MainLocator = JSON.stringify({
       locator: { module: 'ui/components/main', name: 'default' },
     });
-    let { strings } = this.delegate.constants!.toPool();
-    this.assert.equal(strings.indexOf(ALocator), -1);
-    this.assert.equal(strings.indexOf(MainLocator), -1);
+    let values = this.delegate.constants!.toPool();
+    this.assert.equal(values.indexOf(ALocator), -1);
+    this.assert.equal(values.indexOf(MainLocator), -1);
     this.assertHTML('B 1 B 1');
     this.assertStableRerender();
   }
@@ -56,9 +56,9 @@ export class BundleCompilerEmberTests extends EmberishComponentTests {
       module: 'ui/components/main',
       name: 'default',
     });
-    let { strings } = this.delegate.constants!.toPool();
-    this.assert.ok(strings.indexOf(ALocator) > -1, 'Has locator for "A"');
-    this.assert.equal(strings.indexOf(MainLocator), -1);
+    let values = this.delegate.constants!.toPool();
+    this.assert.ok(values.indexOf(ALocator) > -1, 'Has locator for "A"');
+    this.assert.equal(values.indexOf(MainLocator), -1);
     this.assertHTML('B 1');
     this.assertStableRerender();
   }

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -85,12 +85,7 @@ export interface TemplateCompilationContext {
 
 export type EMPTY_ARRAY = Array<ReadonlyArray<never>>;
 
-export interface ConstantPool {
-  strings: string[];
-  arrays: number[][] | EMPTY_ARRAY;
-  handles: number[];
-  numbers: number[];
-}
+export type ConstantPool = unknown[];
 
 /**
  * Constants are interned values that are referenced as numbers in the program.

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -360,24 +360,21 @@ export class NamedArgumentsImpl implements NamedArguments {
     if (extras > 0) {
       let { names, length, stack } = this;
       let { names: extraNames } = other;
-
-      if (Object.isFrozen(names) && names.length === 0) {
-        names = [];
-      }
+      let newNames = names.slice();
 
       for (let i = 0; i < extras; i++) {
         let name = extraNames[i];
-        let idx = names.indexOf(name);
+        let idx = newNames.indexOf(name);
 
         if (idx === -1) {
-          length = names.push(name);
+          length = newNames.push(name);
           stack.push(other.references[i]);
         }
       }
 
       this.length = length;
       this._references = null;
-      this._names = names;
+      this._names = newNames;
       this._atNames = null;
     }
   }


### PR DESCRIPTION
This PR updates the constants pool to use a Map for deduping rather than `indexOf`, which can get very expensive in larger applications. It also caches reified string arrays, so we don't re-reify for every component invocation, and refactors arguments so that we don't mutate those arrays when currying.

[artifact-19.pdf](https://github.com/glimmerjs/glimmer-vm/files/5003731/artifact-19.pdf)
