### PR TITLE
[REFACTOR] Simplifies immediate and handle encoding

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -1,46 +1,24 @@
 import { WriteOnlyConstants } from '@glimmer/program';
-import { assert } from '@glimmer/util';
 import { RuntimeConstants } from '@glimmer/interfaces';
 
 export default class DebugConstants extends WriteOnlyConstants implements RuntimeConstants {
-  getNumber(value: number): number {
-    return this.values[value] as number;
+  getValue<T>(handle: number) {
+    return this.values[handle] as T;
   }
 
-  getString(value: number): string {
-    return this.values[value] as string;
-  }
+  getArray<T>(value: number): T[] {
+    let handles = this.getValue(value) as number[];
+    let reified: T[] = new Array(handles.length);
 
-  getStringArray(value: number): string[] {
-    let names = this.getArray(value);
-    let _names: string[] = new Array(names.length);
-
-    for (let i = 0; i < names.length; i++) {
-      let n = names[i];
-      _names[i] = this.getString(n);
+    for (let i = 0; i < handles.length; i++) {
+      let n = handles[i];
+      reified[i] = this.getValue(n);
     }
 
-    return _names;
+    return reified;
   }
 
-  getArray(value: number): number[] {
-    return this.values[value] as number[];
-  }
-
-  resolveHandle<T>(s: number): T {
-    assert(typeof s === 'number', 'Cannot resolve undefined as a handle');
-    return ({ handle: s } as any) as T;
-  }
-
-  getSerializable(s: number): unknown {
-    return JSON.parse(this.values[s] as string);
-  }
-
-  getTemplateMeta(m: number): unknown {
-    return this.getSerializable(m);
-  }
-
-  getOther(s: number): unknown {
-    return this.values[s];
+  getSerializable<T>(s: number): T {
+    return JSON.parse(this.values[s] as string) as T;
   }
 }

--- a/packages/@glimmer/debug/lib/debug.ts
+++ b/packages/@glimmer/debug/lib/debug.ts
@@ -10,17 +10,14 @@ import {
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { RuntimeOpImpl } from '@glimmer/program';
 import { Register, $s0, $s1, $t0, $t1, $v0, $fp, $sp, $pc, $ra } from '@glimmer/vm';
-import { decodeImmediate, isHandle, HandleConstants, decodeHandle } from '@glimmer/util';
+import { decodeImmediate, isHandle, decodeHandle } from '@glimmer/util';
 import { opcodeMetadata } from './opcode-metadata';
 import { Primitive } from './stack-check';
 
 export interface DebugConstants {
-  getNumber(value: number): number;
-  getString(value: number): string;
-  getStringArray(value: number): string[];
-  getArray(value: number): number[];
+  getValue<T>(handle: number): T;
+  getArray<T>(value: number): T[];
   getSerializable(s: number): unknown;
-  getTemplateMeta(m: number): unknown;
 }
 
 interface LazyDebugConstants {
@@ -119,15 +116,11 @@ export function debug(
           out[operand.name] = resolver.resolve(actualOperand);
           break;
         case 'str':
-          out[operand.name] = c.getString(actualOperand);
-          break;
         case 'option-str':
-          out[operand.name] = actualOperand ? c.getString(actualOperand) : null;
+        case 'array':
+          out[operand.name] = c.getValue(actualOperand);
           break;
         case 'str-array':
-          out[operand.name] = c.getStringArray(actualOperand);
-          break;
-        case 'array':
           out[operand.name] = c.getArray(actualOperand);
           break;
         case 'bool':
@@ -197,10 +190,7 @@ function decodeRegister(register: Register): string {
 
 function decodePrimitive(primitive: number, constants: DebugConstants): Primitive {
   if (isHandle(primitive)) {
-    if (primitive > HandleConstants.NUMBER_MAX_HANDLE) {
-      return constants.getString(decodeHandle(primitive, HandleConstants.STRING_MAX_HANDLE));
-    }
-    return constants.getNumber(decodeHandle(primitive, HandleConstants.NUMBER_MAX_HANDLE));
+    return constants.getValue(decodeHandle(primitive));
   }
   return decodeImmediate(primitive);
 }

--- a/packages/@glimmer/integration-tests/lib/suites/bundle-compiler.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/bundle-compiler.ts
@@ -45,21 +45,4 @@ export class BundleCompilerEmberTests extends EmberishComponentTests {
     this.assertHTML('B 1 B 1');
     this.assertStableRerender();
   }
-
-  @test({ kind: 'glimmer' })
-  'should serialize the locator with dynamic component helpers'() {
-    this.registerComponent('Glimmer', 'A', '{{component @B foo=@bar}}');
-    this.registerComponent('Glimmer', 'B', 'B {{@foo}}');
-    this.render('<A @bar={{1}} @B={{name}} />', { name: 'B' });
-    let ALocator = JSON.stringify({ module: 'ui/components/A', name: 'default' });
-    let MainLocator = JSON.stringify({
-      module: 'ui/components/main',
-      name: 'default',
-    });
-    let values = this.delegate.constants!.toPool();
-    this.assert.ok(values.indexOf(ALocator) > -1, 'Has locator for "A"');
-    this.assert.equal(values.indexOf(MainLocator), -1);
-    this.assertHTML('B 1');
-    this.assertStableRerender();
-  }
 }

--- a/packages/@glimmer/interfaces/lib/compile/operands.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/operands.d.ts
@@ -3,12 +3,6 @@ import * as WireFormat from './wire-format';
 import { HandleResult } from '../template';
 import { HighLevelBuilderOp, CompileActions, ArgsOptions } from './encoder';
 
-export const enum PrimitiveType {
-  IMMEDIATE = 0,
-  STRING = 1,
-  NUMBER = 2,
-}
-
 export interface ArrayOperand {
   type: 'array';
   value: number[];
@@ -72,29 +66,14 @@ export interface InlineBlockOperand {
   value: WireFormat.SerializedInlineBlock;
 }
 
-export interface PrimitiveOperand<TValue extends PrimitiveOperandValue = PrimitiveOperandValue> {
+export interface PrimitiveOperand {
   type: 'primitive';
-  value: TValue;
+  value: string | number;
 }
 
-export type PrimitiveOperandValue =
-  | PrimitiveOperandStringValue
-  | PrimitiveOperandNumberValue
-  | PrimitiveOperandImmediateValue;
-
-export interface PrimitiveOperandStringValue {
-  type: PrimitiveType.STRING;
-  primitive: string;
-}
-
-export interface PrimitiveOperandNumberValue {
-  type: PrimitiveType.NUMBER;
-  primitive: number;
-}
-
-export interface PrimitiveOperandImmediateValue {
-  type: PrimitiveType.IMMEDIATE;
-  primitive: number | boolean | null | undefined;
+export interface ImmediateOperand {
+  type: 'immediate';
+  value: number | boolean | null | undefined;
 }
 
 export type NonlabelBuilderOperand =
@@ -106,6 +85,7 @@ export type NonlabelBuilderOperand =
   | StdlibOperand
   | LookupHandleOperand
   | PrimitiveOperand
+  | ImmediateOperand
   | number
   | string
   | boolean

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -93,13 +93,9 @@ export type ConstantPool = unknown[];
  * together with the program.
  */
 export interface CompileTimeConstants {
-  string(value: string): number;
-  stringArray(strings: string[]): number;
-  array(values: number[]): number;
+  value(value: unknown): number;
+  array(values: unknown[]): number;
   serializable(value: unknown): number;
-  templateMeta(value: unknown): number;
-  number(value: number): number;
-  other(value: unknown): number;
   toPool(): ConstantPool;
 }
 
@@ -112,13 +108,9 @@ export interface CompileTimeLazyConstants extends CompileTimeConstants {
 }
 
 export interface RuntimeConstants {
-  getNumber(value: number): number;
-  getString(handle: number): string;
-  getStringArray(value: number): string[];
-  getArray(value: number): number[];
-  getSerializable(handle: number): unknown;
-  getTemplateMeta(s: number): unknown;
-  getOther(s: number): unknown;
+  getValue<T>(handle: number): T;
+  getArray<T>(handle: number): T[];
+  getSerializable<T>(handle: number): T;
 }
 
 export interface JitProgramCompilationContext extends WholeProgramCompilationContext {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -28,7 +28,6 @@ import {
   EncoderError,
   HandleResult,
   CompileErrorOp,
-  PrimitiveType,
 } from '@glimmer/interfaces';
 import { isMachineOp } from '@glimmer/vm';
 import {
@@ -39,7 +38,6 @@ import {
   exhausted,
   unreachable,
   encodeHandle,
-  HandleConstants,
 } from '@glimmer/util';
 import { commit } from '../compiler';
 
@@ -204,7 +202,7 @@ function constant(
   }
 
   if (typeof operand === 'string') {
-    return constants.string(operand);
+    return constants.value(operand);
   }
 
   if (operand === null) {
@@ -212,39 +210,19 @@ function constant(
   }
 
   switch (operand.type) {
-    case 'array':
-      return constants.array(operand.value);
     case 'string-array':
-      return constants.stringArray(operand.value);
+      return constants.array(operand.value);
     case 'serializable':
       return constants.serializable(operand.value);
-    case 'template-meta':
-      return constants.templateMeta(operand.value);
-    case 'other':
-      // TODO: Bad cast
-      return constants.other(operand.value);
     case 'stdlib':
       return operand;
-    case 'primitive': {
-      switch (operand.value.type) {
-        case PrimitiveType.STRING:
-          return encodeHandle(
-            constants.string(operand.value.primitive),
-            HandleConstants.STRING_MAX_INDEX,
-            HandleConstants.STRING_MAX_HANDLE
-          );
-        case PrimitiveType.NUMBER:
-          return encodeHandle(
-            constants.number(operand.value.primitive),
-            HandleConstants.NUMBER_MAX_INDEX,
-            HandleConstants.NUMBER_MAX_HANDLE
-          );
-        case PrimitiveType.IMMEDIATE:
-          return encodeImmediate(operand.value.primitive);
-        default:
-          return exhausted(operand.value);
-      }
-    }
+    case 'immediate':
+      return encodeImmediate(operand.value);
+    case 'primitive':
+    case 'template-meta':
+    case 'array':
+    case 'other':
+      return encodeHandle(constants.value(operand.value));
     case 'lookup':
       throw unreachable('lookup not reachable');
     default:

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
@@ -1,4 +1,4 @@
-import { prim, strArray } from '../operands';
+import { prim, strArray, immediate } from '../operands';
 import { $v0 } from '@glimmer/vm';
 import {
   Option,
@@ -6,11 +6,11 @@ import {
   MachineOp,
   BuilderOp,
   CompileActions,
-  PrimitiveType,
   StatementCompileActions,
   ExpressionCompileActions,
   WireFormat,
   PrimitiveOperand,
+  ImmediateOperand,
 } from '@glimmer/interfaces';
 import { op } from '../encoder';
 import { isSmallInt } from '@glimmer/util';
@@ -38,26 +38,28 @@ export function PushPrimitiveReference(value: Primitive): CompileActions {
  * @param value A JavaScript primitive (undefined, null, boolean, number or string)
  */
 export function PushPrimitive(primitive: Primitive): BuilderOp {
-  let p: PrimitiveOperand;
+  let p: PrimitiveOperand | ImmediateOperand;
+
   switch (typeof primitive) {
     case 'number':
       if (isSmallInt(primitive)) {
-        p = prim(primitive, PrimitiveType.IMMEDIATE);
+        p = immediate(primitive);
       } else {
-        p = prim(primitive, PrimitiveType.NUMBER);
+        p = prim(primitive);
       }
       break;
     case 'string':
-      p = prim(primitive, PrimitiveType.STRING);
+      p = prim(primitive);
       break;
     case 'boolean':
     case 'object': // assume null
     case 'undefined':
-      p = prim(primitive, PrimitiveType.IMMEDIATE);
+      p = immediate(primitive);
       break;
     default:
       throw new Error('Invalid primitive passed to pushPrimitive');
   }
+
   return op(Op.Primitive, p);
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
@@ -14,11 +14,7 @@ import {
   StringArrayOperand,
   TemplateMetaOperand,
   WireFormat,
-  PrimitiveType,
-  PrimitiveOperandValue,
-  PrimitiveOperandNumberValue,
-  PrimitiveOperandStringValue,
-  PrimitiveOperandImmediateValue,
+  ImmediateOperand,
 } from '@glimmer/interfaces';
 
 export function arr(value: number[]): ArrayOperand {
@@ -67,27 +63,10 @@ export function lookup(kind: 'helper', value: string): LookupHandleOperand {
   return { type: 'lookup', value: { kind, value } };
 }
 
-export function prim(
-  operand: string,
-  type: PrimitiveType.STRING
-): PrimitiveOperand<PrimitiveOperandStringValue>;
-export function prim(
-  operand: number,
-  type: PrimitiveType.NUMBER
-): PrimitiveOperand<PrimitiveOperandNumberValue>;
-export function prim(
-  operand: number | boolean | null | undefined,
-  type: PrimitiveType.IMMEDIATE
-): PrimitiveOperand<PrimitiveOperandImmediateValue>;
-export function prim(
-  operand: string | number | boolean | null | undefined,
-  type: PrimitiveType
-): PrimitiveOperand {
-  return {
-    type: 'primitive',
-    value: {
-      primitive: operand,
-      type,
-    } as PrimitiveOperandValue,
-  };
+export function immediate(value: number | boolean | null | undefined): ImmediateOperand {
+  return { type: 'immediate', value };
+}
+
+export function prim(value: string | number): PrimitiveOperand {
+  return { type: 'primitive', value };
 }

--- a/packages/@glimmer/opcode-compiler/test/jit-context-test.ts
+++ b/packages/@glimmer/opcode-compiler/test/jit-context-test.ts
@@ -8,6 +8,6 @@ QUnit.test('Jit template metas are not not stringified and parsed', assert => {
   let { constants } = context.program;
 
   let meta = {};
-  let handle = constants.templateMeta(meta);
-  assert.equal(constants.getTemplateMeta(handle), meta, 'Meta is not serialized');
+  let handle = constants.value(meta);
+  assert.equal(constants.getValue(handle), meta, 'Meta is not serialized');
 });

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -9,7 +9,7 @@ export class WriteOnlyConstants implements CompileTimeConstants {
   protected values: unknown[] = [WELL_KNOW_EMPTY_ARRAY];
   protected indexMap: Map<unknown, number> = new Map();
 
-  protected value(value: unknown) {
+  value(value: unknown) {
     let indexMap = this.indexMap;
     let index = indexMap.get(value);
 
@@ -21,44 +21,20 @@ export class WriteOnlyConstants implements CompileTimeConstants {
     return index;
   }
 
-  other(other: unknown): number {
-    return this.value(other);
-  }
+  array(values: unknown[]): number {
+    let handles: number[] = new Array(values.length);
 
-  string(value: string): number {
-    return this.value(value);
-  }
-
-  stringArray(strings: string[]): number {
-    let _strings: number[] = new Array(strings.length);
-
-    for (let i = 0; i < strings.length; i++) {
-      _strings[i] = this.string(strings[i]);
+    for (let i = 0; i < values.length; i++) {
+      handles[i] = this.value(values[i]);
     }
 
-    return this.array(_strings);
-  }
-
-  array(values: number[]): number {
-    if (values.length === 0) {
-      return WELL_KNOWN_EMPTY_ARRAY_POSITION;
-    }
-
-    return this.value(values);
+    return this.value(handles);
   }
 
   serializable(value: unknown): number {
     let str = JSON.stringify(value);
 
     return this.value(str);
-  }
-
-  templateMeta(value: unknown): number {
-    return this.serializable(value);
-  }
-
-  number(number: number): number {
-    return this.value(number);
   }
 
   toPool(): ConstantPool {
@@ -73,45 +49,29 @@ export class RuntimeConstantsImpl implements RuntimeConstants {
     this.values = pool;
   }
 
-  getString(value: number): string {
-    return this.values[value] as string;
+  getValue<T>(handle: number) {
+    return this.values[handle] as T;
   }
 
-  getNumber(value: number): number {
-    return this.values[value] as number;
-  }
+  getArray<T>(value: number): T[] {
+    let handles = this.getValue(value) as number[];
+    let reified: T[] = new Array(handles.length);
 
-  getStringArray(value: number): string[] {
-    let names = this.getArray(value);
-    let _names: string[] = new Array(names.length);
-
-    for (let i = 0; i < names.length; i++) {
-      let n = names[i];
-      _names[i] = this.getString(n);
+    for (let i = 0; i < handles.length; i++) {
+      let n = handles[i];
+      reified[i] = this.getValue(n);
     }
 
-    return _names;
-  }
-
-  getArray(value: number): number[] {
-    return this.values[value] as number[];
+    return reified;
   }
 
   getSerializable<T>(s: number): T {
     return JSON.parse(this.values[s] as string) as T;
   }
-
-  getTemplateMeta<T>(m: number): T {
-    return this.getSerializable(m);
-  }
-
-  getOther<T>(value: number): T {
-    return this.values[value] as T;
-  }
 }
 
 export class JitConstants extends WriteOnlyConstants implements RuntimeConstants {
-  protected reifiedStringArrs: string[][] = [WELL_KNOW_EMPTY_ARRAY as any];
+  protected reifiedArrs: unknown[][] = [WELL_KNOW_EMPTY_ARRAY as any];
 
   templateMeta(meta: unknown): number {
     return this.value(meta);
@@ -121,45 +81,25 @@ export class JitConstants extends WriteOnlyConstants implements RuntimeConstants
     return this.values[index] as T;
   }
 
-  getNumber(value: number): number {
-    return this.getValue(value);
-  }
-
-  getString(value: number): string {
-    return this.getValue(value);
-  }
-
-  getStringArray(value: number): string[] {
-    let reifiedStringArrs = this.reifiedStringArrs;
-    let reified = reifiedStringArrs[value];
+  getArray<T>(value: number): T[] {
+    let reifiedArrs = this.reifiedArrs;
+    let reified = reifiedArrs[value] as T[];
 
     if (reified === undefined) {
-      let names = this.getArray(value);
+      let names: number[] = this.getValue(value);
       reified = new Array(names.length);
 
       for (let i = 0; i < names.length; i++) {
         reified[i] = this.getValue(names[i]);
       }
 
-      reifiedStringArrs[value] = reified;
+      reifiedArrs[value] = reified;
     }
 
     return reified;
   }
 
-  getArray(value: number): number[] {
-    return this.getValue(value);
-  }
-
   getSerializable<T>(s: number): T {
     return JSON.parse(this.getValue(s)) as T;
-  }
-
-  getTemplateMeta<T>(m: number): T {
-    return this.getValue(m);
-  }
-
-  getOther<T>(value: number): T {
-    return this.getValue(value);
   }
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -153,7 +153,7 @@ APPEND_OPCODES.add(Op.CurryComponent, (vm, { op1: _meta }) => {
   let definition = check(stack.pop(), CheckReference);
   let capturedArgs = check(stack.pop(), CheckCapturedArguments);
 
-  let meta = vm[CONSTANTS].getTemplateMeta(_meta);
+  let meta = vm[CONSTANTS].getValue(_meta);
   let resolver = vm.runtime.resolver;
 
   vm.loadValue($v0, new CurryComponentReference(definition, resolver, meta, capturedArgs));
@@ -185,7 +185,7 @@ APPEND_OPCODES.add(Op.PushComponentDefinition, (vm, { op1: handle }) => {
 APPEND_OPCODES.add(Op.ResolveDynamicComponent, (vm, { op1: _meta }) => {
   let stack = vm.stack;
   let component = check(stack.pop(), CheckPathReference).value() as Maybe<Dict>;
-  let meta = vm[CONSTANTS].getTemplateMeta(_meta);
+  let meta = vm[CONSTANTS].getValue(_meta);
 
   vm.loadValue($t1, null); // Clear the temp register
 
@@ -237,11 +237,11 @@ APPEND_OPCODES.add(Op.PushCurriedComponent, vm => {
 
 APPEND_OPCODES.add(Op.PushArgs, (vm, { op1: _names, op2: _blockNames, op3: flags }) => {
   let stack = vm.stack;
-  let names = vm[CONSTANTS].getStringArray(_names);
+  let names = vm[CONSTANTS].getArray<string>(_names);
 
   let positionalCount = flags >> 4;
   let atNames = flags & 0b1000;
-  let blockNames = flags & 0b0111 ? vm[CONSTANTS].getStringArray(_blockNames) : EMPTY_ARRAY;
+  let blockNames = flags & 0b0111 ? vm[CONSTANTS].getArray<string>(_blockNames) : EMPTY_ARRAY;
 
   vm[ARGS].setup(stack, names, blockNames, positionalCount, !!atNames);
   stack.push(vm[ARGS]);
@@ -403,9 +403,9 @@ APPEND_OPCODES.add(Op.PutComponentOperations, vm => {
 });
 
 APPEND_OPCODES.add(Op.ComponentAttr, (vm, { op1: _name, op2: trusting, op3: _namespace }) => {
-  let name = vm[CONSTANTS].getString(_name);
+  let name = vm[CONSTANTS].getValue<string>(_name);
   let reference = check(vm.stack.pop(), CheckReference);
-  let namespace = _namespace ? vm[CONSTANTS].getString(_namespace) : null;
+  let namespace = _namespace ? vm[CONSTANTS].getValue<string>(_namespace) : null;
 
   check(vm.fetchValue($t0), CheckInstanceof(ComponentElementOperations)).setAttribute(
     name,
@@ -416,9 +416,9 @@ APPEND_OPCODES.add(Op.ComponentAttr, (vm, { op1: _name, op2: trusting, op3: _nam
 });
 
 APPEND_OPCODES.add(Op.StaticComponentAttr, (vm, { op1: _name, op2: _value, op3: _namespace }) => {
-  let name = vm[CONSTANTS].getString(_name);
-  let value = vm[CONSTANTS].getString(_value);
-  let namespace = _namespace ? vm[CONSTANTS].getString(_namespace) : null;
+  let name = vm[CONSTANTS].getValue<string>(_name);
+  let value = vm[CONSTANTS].getValue<string>(_value);
+  let namespace = _namespace ? vm[CONSTANTS].getValue<string>(_namespace) : null;
 
   check(vm.fetchValue($t0), CheckInstanceof(ComponentElementOperations)).setStaticAttribute(
     name,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -66,8 +66,8 @@ class ScopeInspector<C extends JitOrAotBlock> {
 }
 
 APPEND_OPCODES.add(Op.Debugger, (vm, { op1: _symbols, op2: _evalInfo }) => {
-  let symbols = vm[CONSTANTS].getStringArray(_symbols);
-  let evalInfo = vm[CONSTANTS].getArray(_evalInfo);
+  let symbols = vm[CONSTANTS].getArray<string>(_symbols);
+  let evalInfo = vm[CONSTANTS].getValue<number[]>(_evalInfo);
   let inspector = new ScopeInspector(vm.scope(), symbols, evalInfo);
   callback(vm.getSelf().value(), path => inspector.get(path).value());
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -25,15 +25,15 @@ import { SimpleElement, SimpleNode } from '@simple-dom/interface';
 import { expect, Maybe } from '@glimmer/util';
 
 APPEND_OPCODES.add(Op.Text, (vm, { op1: text }) => {
-  vm.elements().appendText(vm[CONSTANTS].getString(text));
+  vm.elements().appendText(vm[CONSTANTS].getValue(text));
 });
 
 APPEND_OPCODES.add(Op.Comment, (vm, { op1: text }) => {
-  vm.elements().appendComment(vm[CONSTANTS].getString(text));
+  vm.elements().appendComment(vm[CONSTANTS].getValue(text));
 });
 
 APPEND_OPCODES.add(Op.OpenElement, (vm, { op1: tag }) => {
-  vm.elements().openElement(vm[CONSTANTS].getString(tag));
+  vm.elements().openElement(vm[CONSTANTS].getValue(tag));
 });
 
 APPEND_OPCODES.add(Op.OpenDynamicElement, vm => {
@@ -155,18 +155,18 @@ export class UpdateModifierOpcode extends UpdatingOpcode {
 }
 
 APPEND_OPCODES.add(Op.StaticAttr, (vm, { op1: _name, op2: _value, op3: _namespace }) => {
-  let name = vm[CONSTANTS].getString(_name);
-  let value = vm[CONSTANTS].getString(_value);
-  let namespace = _namespace ? vm[CONSTANTS].getString(_namespace) : null;
+  let name = vm[CONSTANTS].getValue<string>(_name);
+  let value = vm[CONSTANTS].getValue<string>(_value);
+  let namespace = _namespace ? vm[CONSTANTS].getValue<string>(_namespace) : null;
 
   vm.elements().setStaticAttribute(name, value, namespace);
 });
 
 APPEND_OPCODES.add(Op.DynamicAttr, (vm, { op1: _name, op2: trusting, op3: _namespace }) => {
-  let name = vm[CONSTANTS].getString(_name);
+  let name = vm[CONSTANTS].getValue<string>(_name);
   let reference = check(vm.stack.pop(), CheckReference);
   let value = reference.value();
-  let namespace = _namespace ? vm[CONSTANTS].getString(_namespace) : null;
+  let namespace = _namespace ? vm[CONSTANTS].getValue<string>(_namespace) : null;
 
   let attribute = vm.elements().setDynamicAttribute(name, value, !!trusting, namespace);
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -70,7 +70,7 @@ APPEND_OPCODES.add(Op.SetAotBlock, (vm, { op1: symbol }) => {
 });
 
 APPEND_OPCODES.add(Op.ResolveMaybeLocal, (vm, { op1: _name }) => {
-  let name = vm[CONSTANTS].getString(_name);
+  let name = vm[CONSTANTS].getValue<string>(_name);
   let locals = vm.scope().getPartialMap()!;
 
   let ref = locals[name];
@@ -86,7 +86,7 @@ APPEND_OPCODES.add(Op.RootScope, (vm, { op1: symbols }) => {
 });
 
 APPEND_OPCODES.add(Op.GetProperty, (vm, { op1: _key }) => {
-  let key = vm[CONSTANTS].getString(_key);
+  let key = vm[CONSTANTS].getValue<string>(_key);
   let expr = check(vm.stack.pop(), CheckPathReference);
   vm.stack.push(expr.get(key));
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
@@ -14,9 +14,9 @@ APPEND_OPCODES.add(
     let name = check(stack.pop(), CheckReference).value();
     assert(typeof name === 'string', `Could not find a partial named "${String(name)}"`);
 
-    let meta = constants.getTemplateMeta(_meta);
-    let outerSymbols = constants.getStringArray(_symbols);
-    let evalInfo = constants.getArray(_evalInfo);
+    let meta = constants.getValue(_meta);
+    let outerSymbols = constants.getArray<string>(_symbols);
+    let evalInfo = constants.getValue<number[]>(_evalInfo);
 
     let handle = vm.runtime.resolver.lookupPartial(name as string, meta);
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -9,7 +9,7 @@ import {
   validateTag,
   INITIAL,
 } from '@glimmer/validator';
-import { assert, isHandle, HandleConstants, decodeHandle, expect } from '@glimmer/util';
+import { assert, isHandle, decodeHandle, expect } from '@glimmer/util';
 import {
   CheckNumber,
   check,
@@ -37,18 +37,13 @@ APPEND_OPCODES.add(Op.PushDynamicScope, vm => vm.pushDynamicScope());
 APPEND_OPCODES.add(Op.PopDynamicScope, vm => vm.popDynamicScope());
 
 APPEND_OPCODES.add(Op.Constant, (vm, { op1: other }) => {
-  vm.stack.push(vm[CONSTANTS].getOther(other));
+  vm.stack.push(vm[CONSTANTS].getValue(other));
 });
 
 APPEND_OPCODES.add(Op.Primitive, (vm, { op1: primitive }) => {
   let stack = vm.stack;
   if (isHandle(primitive)) {
-    let value: string | number;
-    if (primitive > HandleConstants.NUMBER_MAX_HANDLE) {
-      value = vm[CONSTANTS].getString(decodeHandle(primitive, HandleConstants.STRING_MAX_HANDLE));
-    } else {
-      value = vm[CONSTANTS].getNumber(decodeHandle(primitive, HandleConstants.NUMBER_MAX_HANDLE));
-    }
+    let value = vm[CONSTANTS].getValue(decodeHandle(primitive));
     stack.pushJs(value);
   } else {
     // is already an encoded immediate
@@ -84,7 +79,7 @@ APPEND_OPCODES.add(Op.Fetch, (vm, { op1: register }) => {
 });
 
 APPEND_OPCODES.add(Op.BindDynamicScope, (vm, { op1: _names }) => {
-  let names = vm[CONSTANTS].getArray(_names);
+  let names = vm[CONSTANTS].getArray<string>(_names);
   vm.bindDynamicScope(names);
 });
 

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -115,7 +115,7 @@ export interface InternalVM<C extends JitOrAotBlock = JitOrAotBlock> {
   pushScope(scope: Scope<C>): void;
 
   dynamicScope(): DynamicScope;
-  bindDynamicScope(names: number[]): void;
+  bindDynamicScope(names: string[]): void;
   pushDynamicScope(): void;
   popDynamicScope(): void;
 
@@ -561,11 +561,11 @@ export default abstract class VM<C extends JitOrAotBlock> implements PublicVM, I
     return result;
   }
 
-  bindDynamicScope(names: number[]) {
+  bindDynamicScope(names: string[]) {
     let scope = this.dynamicScope();
 
     for (let i = names.length - 1; i >= 0; i--) {
-      let name = this[CONSTANTS].getString(names[i]);
+      let name = names[i];
       scope.set(name, this.stack.pop<VersionedPathReference<unknown>>());
     }
   }

--- a/packages/@glimmer/util/test/immediate-test.ts
+++ b/packages/@glimmer/util/test/immediate-test.ts
@@ -1,0 +1,20 @@
+import { encodeImmediate, decodeImmediate, ImmediateMapping } from '..';
+
+const { module, test } = QUnit;
+
+module('immediate encoding tests', () => {
+  test('it works', assert => {
+    [
+      ImmediateMapping.MIN_INT,
+      -1,
+      0,
+      ImmediateMapping.MAX_INT,
+      undefined,
+      null,
+      true,
+      false,
+    ].forEach(val => {
+      assert.equal(val, decodeImmediate(encodeImmediate(val)), 'correctly encdoded and decoded');
+    });
+  });
+});


### PR DESCRIPTION
Simplifies immediate and constant handle encoding in the following ways:

1. Immediates are stored as negative numbers instead of positive, as
  handles are much more common in general.

2. `true`, `false`, `undefined`, and `null` are the first four negatives.
  The remaining negatives are divided between positive numbers and
  negative, with positives taking up the higher negatives since they're
  expected to be more common.

3. Constants in the constant pool now all exist in a single array of
  values. This makes lookups and storage code simpler overall and
  appears to have a positive impact on performance (per the last PR).

4. Handles are no longer divided between string and number handles,
  since all constants are pulled from the same pool. This allows us to
  avoid encoding/decoding handles in general.

Benchmark results: [artifact-33.pdf](https://github.com/glimmerjs/glimmer-vm/files/5007813/artifact-33.pdf)
