### PR TITLE
[REFACTOR] Expose tagMeta and simplify property lookups

### DIFF
--- a/packages/@glimmer/integration-tests/lib/reference.ts
+++ b/packages/@glimmer/integration-tests/lib/reference.ts
@@ -45,6 +45,10 @@ const DEFAULT_TEMPLATE_REF_ENV = {
     return null;
   },
 
+  getProp(obj: unknown, key: string) {
+    return (obj as Dict)[key];
+  },
+
   getPath(obj: unknown, key: string) {
     return (obj as Dict)[key];
   },

--- a/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
@@ -49,6 +49,7 @@ export interface Environment<Extra = unknown> {
   toBool(value: unknown): boolean;
   toIterator(value: unknown): Option<IteratorDelegate>;
 
+  getProp(item: unknown, prop: string): unknown;
   getPath(item: unknown, path: string): unknown;
   setPath(item: unknown, path: string, value: unknown): unknown;
 

--- a/packages/@glimmer/reference/lib/template.ts
+++ b/packages/@glimmer/reference/lib/template.ts
@@ -48,6 +48,7 @@ export interface TemplatePathReference<T = unknown> extends VersionedPathReferen
  * renderer, and gets `env` passed to it.
  */
 export interface TemplateReferenceEnvironment {
+  getProp(obj: unknown, prop: string): unknown;
   getPath(obj: unknown, path: string): unknown;
   setPath(obj: unknown, path: string, value: unknown): unknown;
 

--- a/packages/@glimmer/reference/test/utils/template.ts
+++ b/packages/@glimmer/reference/test/utils/template.ts
@@ -60,6 +60,10 @@ class ObjectIterator extends BoundedIterator {
 }
 
 export class TestEnv implements TemplateReferenceEnvironment {
+  getProp(obj: unknown, path: string) {
+    return (obj as any)[path];
+  }
+
   getPath(obj: unknown, path: string) {
     return (obj as any)[path];
   }

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -253,7 +253,8 @@ export class EnvironmentImpl<Extra> implements Environment<Extra> {
   public protocolForURL = defaultDelegateFn(this.delegate.protocolForURL, defaultGetProtocolForURL);
   public attributeFor = defaultDelegateFn(this.delegate.attributeFor, defaultAttributeFor);
 
-  public getPath = defaultDelegateFn(this.delegate.getPath, defaultGetPath);
+  public getProp = defaultDelegateFn(this.delegate.getProp, defaultGetProp);
+  public getPath = defaultDelegateFn(this.delegate.getPath, defaultGetProp);
   public setPath = defaultDelegateFn(this.delegate.setPath, defaultSetPath);
 
   public toBool = defaultDelegateFn(this.delegate.toBool, defaultToBool);
@@ -370,6 +371,15 @@ export interface EnvironmentDelegate<Extra = undefined> {
   toBool?(value: unknown): boolean;
 
   /**
+   * Hook for specifying how Glimmer should access properties in cases where it
+   * needs to. For instance, accessing an object's values in templates.
+   *
+   * @param obj The object provided to get a value from
+   * @param path The path to get the value from
+   */
+  getProp?(obj: unknown, path: string): unknown;
+
+  /**
    * Hook for specifying how Glimmer should access paths in cases where it needs
    * to. For instance, the `key` value of `{{each}}` loops.
    *
@@ -470,7 +480,7 @@ function defaultAttributeFor(
   return dynamicAttribute(element, attr, namespace);
 }
 
-function defaultGetPath(obj: unknown, key: string): unknown {
+function defaultGetProp(obj: unknown, key: string): unknown {
   return (obj as Dict)[key];
 }
 

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -45,7 +45,7 @@ export {
   VOLATILE,
 } from './lib/validators';
 
-export { dirtyTagFor, tagFor, setPropertyDidChange } from './lib/meta';
+export { dirtyTagFor, tagFor, tagMetaFor, setPropertyDidChange, TagMeta } from './lib/meta';
 
 export {
   beginTrackFrame,

--- a/packages/@glimmer/validator/lib/meta.ts
+++ b/packages/@glimmer/validator/lib/meta.ts
@@ -1,11 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import {
-  dirtyTag,
-  createUpdatableTag,
-  UpdatableTag,
-  CONSTANT_TAG,
-  ConstantTag,
-} from './validators';
+import { dirtyTag, createUpdatableTag, UpdatableTag, ConstantTag } from './validators';
 import { assertTagNotConsumed } from './debug';
 
 export let propertyDidChange = function() {};
@@ -14,56 +8,63 @@ export function setPropertyDidChange(cb: () => void) {
   propertyDidChange = cb;
 }
 
-function isObject<T>(u: T): u is object & T {
+function isObjectLike<T>(u: T): u is object & T {
   return (typeof u === 'object' && u !== null) || typeof u === 'function';
 }
 
 ///////////
 
-type Tags = Map<PropertyKey, UpdatableTag>;
+export type TagMeta = Map<PropertyKey, UpdatableTag>;
 
-const TRACKED_TAGS = new WeakMap<object, Tags>();
+const TRACKED_TAGS = new WeakMap<object, TagMeta>();
 
-export function dirtyTagFor<T>(obj: T, key: keyof T | string | symbol): void {
-  if (isObject(obj)) {
-    let tags = TRACKED_TAGS.get(obj);
-
-    // No tags have been setup for this object yet, return
-    if (tags === undefined) return;
-
-    // Dirty the tag for the specific property if it exists
-    let propertyTag = tags.get(key);
-
-    if (propertyTag !== undefined) {
-      if (DEBUG) {
-        assertTagNotConsumed!(propertyTag, obj, key);
-      }
-
-      dirtyTag(propertyTag);
-      propertyDidChange();
-    }
-  } else {
+export function dirtyTagFor<T extends object>(obj: T, key: keyof T | string | symbol): void {
+  if (DEBUG && !isObjectLike(obj)) {
     throw new Error(`BUG: Can't update a tag for a primitive`);
+  }
+
+  let tags = TRACKED_TAGS.get(obj);
+
+  // No tags have been setup for this object yet, return
+  if (tags === undefined) return;
+
+  // Dirty the tag for the specific property if it exists
+  let propertyTag = tags.get(key);
+
+  if (propertyTag !== undefined) {
+    if (DEBUG) {
+      assertTagNotConsumed!(propertyTag, obj, key);
+    }
+
+    dirtyTag(propertyTag);
+    propertyDidChange();
   }
 }
 
-export function tagFor<T>(obj: T, key: keyof T | string | symbol): UpdatableTag | ConstantTag {
-  if (isObject(obj)) {
-    let tags = TRACKED_TAGS.get(obj);
+export function tagMetaFor(obj: object) {
+  let tags = TRACKED_TAGS.get(obj);
 
-    if (tags === undefined) {
-      tags = new Map();
+  if (tags === undefined) {
+    tags = new Map();
 
-      TRACKED_TAGS.set(obj, tags);
-    } else if (tags.has(key)) {
-      return tags.get(key)!;
-    }
-
-    let tag = createUpdatableTag();
-    tags.set(key, tag);
-
-    return tag;
-  } else {
-    return CONSTANT_TAG;
+    TRACKED_TAGS.set(obj, tags);
   }
+
+  return tags;
+}
+
+export function tagFor<T extends object>(
+  obj: T,
+  key: keyof T | string | symbol,
+  meta?: TagMeta
+): UpdatableTag | ConstantTag {
+  let tags = meta === undefined ? tagMetaFor(obj) : meta;
+  let tag = tags.get(key);
+
+  if (tag === undefined) {
+    tag = createUpdatableTag();
+    tags.set(key, tag);
+  }
+
+  return tag;
 }


### PR DESCRIPTION
This refactor exposes tag metas directly in order to allow Ember to perform fewer lookups in general. It also adds `getProp` to allow use to do fewer operations when looking up a property that is known to not be a path, and refactors `ConditionalReference` so that it autotracks, and Ember can avoid doing a brand check in `get` for proxies.

---

Breakage:

* requires the host environment to pass in a `getProp` method