### PR TITLE
[REFACTOR] Simplifies immediate and handle encoding

### DIFF
--- a/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
+++ b/packages/@glimmer/bundle-compiler/lib/debug-constants.ts
@@ -1,46 +1,24 @@
 import { WriteOnlyConstants } from '@glimmer/program';
-import { assert } from '@glimmer/util';
 import { RuntimeConstants } from '@glimmer/interfaces';
 
 export default class DebugConstants extends WriteOnlyConstants implements RuntimeConstants {
-  getNumber(value: number): number {
-    return this.values[value] as number;
+  getValue<T>(handle: number) {
+    return this.values[handle] as T;
   }
 
-  getString(value: number): string {
-    return this.values[value] as string;
-  }
+  getArray<T>(value: number): T[] {
+    let handles = this.getValue(value) as number[];
+    let reified: T[] = new Array(handles.length);
 
-  getStringArray(value: number): string[] {
-    let names = this.getArray(value);
-    let _names: string[] = new Array(names.length);
-
-    for (let i = 0; i < names.length; i++) {
-      let n = names[i];
-      _names[i] = this.getString(n);
+    for (let i = 0; i < handles.length; i++) {
+      let n = handles[i];
+      reified[i] = this.getValue(n);
     }
 
-    return _names;
+    return reified;
   }
 
-  getArray(value: number): number[] {
-    return this.values[value] as number[];
-  }
-
-  resolveHandle<T>(s: number): T {
-    assert(typeof s === 'number', 'Cannot resolve undefined as a handle');
-    return ({ handle: s } as any) as T;
-  }
-
-  getSerializable(s: number): unknown {
-    return JSON.parse(this.values[s] as string);
-  }
-
-  getTemplateMeta(m: number): unknown {
-    return this.getSerializable(m);
-  }
-
-  getOther(s: number): unknown {
-    return this.values[s];
+  getSerializable<T>(s: number): T {
+    return JSON.parse(this.values[s] as string) as T;
   }
 }

--- a/packages/@glimmer/integration-tests/lib/suites/bundle-compiler.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/bundle-compiler.ts
@@ -45,21 +45,4 @@ export class BundleCompilerEmberTests extends EmberishComponentTests {
     this.assertHTML('B 1 B 1');
     this.assertStableRerender();
   }
-
-  @test({ kind: 'glimmer' })
-  'should serialize the locator with dynamic component helpers'() {
-    this.registerComponent('Glimmer', 'A', '{{component @B foo=@bar}}');
-    this.registerComponent('Glimmer', 'B', 'B {{@foo}}');
-    this.render('<A @bar={{1}} @B={{name}} />', { name: 'B' });
-    let ALocator = JSON.stringify({ module: 'ui/components/A', name: 'default' });
-    let MainLocator = JSON.stringify({
-      module: 'ui/components/main',
-      name: 'default',
-    });
-    let values = this.delegate.constants!.toPool();
-    this.assert.ok(values.indexOf(ALocator) > -1, 'Has locator for "A"');
-    this.assert.equal(values.indexOf(MainLocator), -1);
-    this.assertHTML('B 1');
-    this.assertStableRerender();
-  }
 }

--- a/packages/@glimmer/interfaces/lib/compile/operands.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/operands.d.ts
@@ -3,12 +3,6 @@ import * as WireFormat from './wire-format';
 import { HandleResult } from '../template';
 import { HighLevelBuilderOp, CompileActions, ArgsOptions } from './encoder';
 
-export const enum PrimitiveType {
-  IMMEDIATE = 0,
-  STRING = 1,
-  NUMBER = 2,
-}
-
 export interface ArrayOperand {
   type: 'array';
   value: number[];
@@ -72,29 +66,14 @@ export interface InlineBlockOperand {
   value: WireFormat.SerializedInlineBlock;
 }
 
-export interface PrimitiveOperand<TValue extends PrimitiveOperandValue = PrimitiveOperandValue> {
+export interface PrimitiveOperand {
   type: 'primitive';
-  value: TValue;
+  value: string | number | boolean | null | undefined;
 }
 
-export type PrimitiveOperandValue =
-  | PrimitiveOperandStringValue
-  | PrimitiveOperandNumberValue
-  | PrimitiveOperandImmediateValue;
-
-export interface PrimitiveOperandStringValue {
-  type: PrimitiveType.STRING;
-  primitive: string;
-}
-
-export interface PrimitiveOperandNumberValue {
-  type: PrimitiveType.NUMBER;
-  primitive: number;
-}
-
-export interface PrimitiveOperandImmediateValue {
-  type: PrimitiveType.IMMEDIATE;
-  primitive: number | boolean | null | undefined;
+export interface ImmediateOperand {
+  type: 'immediate';
+  value: number;
 }
 
 export type NonlabelBuilderOperand =
@@ -106,6 +85,7 @@ export type NonlabelBuilderOperand =
   | StdlibOperand
   | LookupHandleOperand
   | PrimitiveOperand
+  | ImmediateOperand
   | number
   | string
   | boolean

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -93,13 +93,9 @@ export type ConstantPool = unknown[];
  * together with the program.
  */
 export interface CompileTimeConstants {
-  string(value: string): number;
-  stringArray(strings: string[]): number;
-  array(values: number[]): number;
+  value(value: unknown): number;
+  array(values: unknown[]): number;
   serializable(value: unknown): number;
-  templateMeta(value: unknown): number;
-  number(value: number): number;
-  other(value: unknown): number;
   toPool(): ConstantPool;
 }
 
@@ -112,13 +108,9 @@ export interface CompileTimeLazyConstants extends CompileTimeConstants {
 }
 
 export interface RuntimeConstants {
-  getNumber(value: number): number;
-  getString(handle: number): string;
-  getStringArray(value: number): string[];
-  getArray(value: number): number[];
-  getSerializable(handle: number): unknown;
-  getTemplateMeta(s: number): unknown;
-  getOther(s: number): unknown;
+  getValue<T>(handle: number): T;
+  getArray<T>(handle: number): T[];
+  getSerializable<T>(handle: number): T;
 }
 
 export interface JitProgramCompilationContext extends WholeProgramCompilationContext {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -28,7 +28,6 @@ import {
   EncoderError,
   HandleResult,
   CompileErrorOp,
-  PrimitiveType,
 } from '@glimmer/interfaces';
 import { isMachineOp } from '@glimmer/vm';
 import {
@@ -39,7 +38,6 @@ import {
   exhausted,
   unreachable,
   encodeHandle,
-  HandleConstants,
 } from '@glimmer/util';
 import { commit } from '../compiler';
 
@@ -204,7 +202,7 @@ function constant(
   }
 
   if (typeof operand === 'string') {
-    return constants.string(operand);
+    return constants.value(operand);
   }
 
   if (operand === null) {
@@ -212,39 +210,19 @@ function constant(
   }
 
   switch (operand.type) {
-    case 'array':
-      return constants.array(operand.value);
     case 'string-array':
-      return constants.stringArray(operand.value);
+      return constants.array(operand.value);
     case 'serializable':
       return constants.serializable(operand.value);
-    case 'template-meta':
-      return constants.templateMeta(operand.value);
-    case 'other':
-      // TODO: Bad cast
-      return constants.other(operand.value);
     case 'stdlib':
       return operand;
-    case 'primitive': {
-      switch (operand.value.type) {
-        case PrimitiveType.STRING:
-          return encodeHandle(
-            constants.string(operand.value.primitive),
-            HandleConstants.STRING_MAX_INDEX,
-            HandleConstants.STRING_MAX_HANDLE
-          );
-        case PrimitiveType.NUMBER:
-          return encodeHandle(
-            constants.number(operand.value.primitive),
-            HandleConstants.NUMBER_MAX_INDEX,
-            HandleConstants.NUMBER_MAX_HANDLE
-          );
-        case PrimitiveType.IMMEDIATE:
-          return encodeImmediate(operand.value.primitive);
-        default:
-          return exhausted(operand.value);
-      }
-    }
+    case 'immediate':
+      return encodeImmediate(operand.value);
+    case 'primitive':
+    case 'template-meta':
+    case 'array':
+    case 'other':
+      return encodeHandle(constants.value(operand.value));
     case 'lookup':
       throw unreachable('lookup not reachable');
     default:

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
@@ -1,4 +1,4 @@
-import { prim, strArray } from '../operands';
+import { prim, strArray, immediate } from '../operands';
 import { $v0 } from '@glimmer/vm';
 import {
   Option,
@@ -6,11 +6,9 @@ import {
   MachineOp,
   BuilderOp,
   CompileActions,
-  PrimitiveType,
   StatementCompileActions,
   ExpressionCompileActions,
   WireFormat,
-  PrimitiveOperand,
 } from '@glimmer/interfaces';
 import { op } from '../encoder';
 import { isSmallInt } from '@glimmer/util';
@@ -38,26 +36,9 @@ export function PushPrimitiveReference(value: Primitive): CompileActions {
  * @param value A JavaScript primitive (undefined, null, boolean, number or string)
  */
 export function PushPrimitive(primitive: Primitive): BuilderOp {
-  let p: PrimitiveOperand;
-  switch (typeof primitive) {
-    case 'number':
-      if (isSmallInt(primitive)) {
-        p = prim(primitive, PrimitiveType.IMMEDIATE);
-      } else {
-        p = prim(primitive, PrimitiveType.NUMBER);
-      }
-      break;
-    case 'string':
-      p = prim(primitive, PrimitiveType.STRING);
-      break;
-    case 'boolean':
-    case 'object': // assume null
-    case 'undefined':
-      p = prim(primitive, PrimitiveType.IMMEDIATE);
-      break;
-    default:
-      throw new Error('Invalid primitive passed to pushPrimitive');
-  }
+  let p =
+    typeof primitive === 'number' && isSmallInt(primitive) ? immediate(primitive) : prim(primitive);
+
   return op(Op.Primitive, p);
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
@@ -14,11 +14,7 @@ import {
   StringArrayOperand,
   TemplateMetaOperand,
   WireFormat,
-  PrimitiveType,
-  PrimitiveOperandValue,
-  PrimitiveOperandNumberValue,
-  PrimitiveOperandStringValue,
-  PrimitiveOperandImmediateValue,
+  ImmediateOperand,
 } from '@glimmer/interfaces';
 
 export function arr(value: number[]): ArrayOperand {
@@ -67,27 +63,10 @@ export function lookup(kind: 'helper', value: string): LookupHandleOperand {
   return { type: 'lookup', value: { kind, value } };
 }
 
-export function prim(
-  operand: string,
-  type: PrimitiveType.STRING
-): PrimitiveOperand<PrimitiveOperandStringValue>;
-export function prim(
-  operand: number,
-  type: PrimitiveType.NUMBER
-): PrimitiveOperand<PrimitiveOperandNumberValue>;
-export function prim(
-  operand: number | boolean | null | undefined,
-  type: PrimitiveType.IMMEDIATE
-): PrimitiveOperand<PrimitiveOperandImmediateValue>;
-export function prim(
-  operand: string | number | boolean | null | undefined,
-  type: PrimitiveType
-): PrimitiveOperand {
-  return {
-    type: 'primitive',
-    value: {
-      primitive: operand,
-      type,
-    } as PrimitiveOperandValue,
-  };
+export function immediate(value: number): ImmediateOperand {
+  return { type: 'immediate', value };
+}
+
+export function prim(value: string | number | boolean | null | undefined): PrimitiveOperand {
+  return { type: 'primitive', value };
 }

--- a/packages/@glimmer/opcode-compiler/test/jit-context-test.ts
+++ b/packages/@glimmer/opcode-compiler/test/jit-context-test.ts
@@ -8,6 +8,6 @@ QUnit.test('Jit template metas are not not stringified and parsed', assert => {
   let { constants } = context.program;
 
   let meta = {};
-  let handle = constants.templateMeta(meta);
-  assert.equal(constants.getTemplateMeta(handle), meta, 'Meta is not serialized');
+  let handle = constants.value(meta);
+  assert.equal(constants.getValue(handle), meta, 'Meta is not serialized');
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -52,7 +52,7 @@ export class ContentTypeReference implements Reference<ContentType> {
 }
 
 APPEND_OPCODES.add(Op.AppendHTML, vm => {
-  let reference = check(vm.stack.pop(), CheckPathReference);
+  let reference = check(vm.stack.popJs(), CheckPathReference);
 
   let rawValue = reference.value();
   let value = isEmpty(rawValue) ? '' : String(rawValue);
@@ -61,7 +61,7 @@ APPEND_OPCODES.add(Op.AppendHTML, vm => {
 });
 
 APPEND_OPCODES.add(Op.AppendSafeHTML, vm => {
-  let reference = check(vm.stack.pop(), CheckPathReference);
+  let reference = check(vm.stack.popJs(), CheckPathReference);
 
   let rawValue = check(reference.value(), CheckSafeString).toHTML();
   let value = isEmpty(rawValue) ? '' : check(rawValue, CheckString);
@@ -70,7 +70,7 @@ APPEND_OPCODES.add(Op.AppendSafeHTML, vm => {
 });
 
 APPEND_OPCODES.add(Op.AppendText, vm => {
-  let reference = check(vm.stack.pop(), CheckPathReference);
+  let reference = check(vm.stack.popJs(), CheckPathReference);
 
   let rawValue = reference.value();
   let value = isEmpty(rawValue) ? '' : String(rawValue);
@@ -83,7 +83,7 @@ APPEND_OPCODES.add(Op.AppendText, vm => {
 });
 
 APPEND_OPCODES.add(Op.AppendDocumentFragment, vm => {
-  let reference = check(vm.stack.pop(), CheckPathReference);
+  let reference = check(vm.stack.popJs(), CheckPathReference);
 
   let value = check(reference.value(), CheckDocumentFragment);
 
@@ -91,7 +91,7 @@ APPEND_OPCODES.add(Op.AppendDocumentFragment, vm => {
 });
 
 APPEND_OPCODES.add(Op.AppendNode, vm => {
-  let reference = check(vm.stack.pop(), CheckPathReference);
+  let reference = check(vm.stack.popJs(), CheckPathReference);
 
   let value = check(reference.value(), CheckNode);
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -1,6 +1,6 @@
 import { Op, JitOrAotBlock, Scope } from '@glimmer/interfaces';
 import { VersionedPathReference } from '@glimmer/reference';
-import { dict } from '@glimmer/util';
+import { dict, decodeHandle } from '@glimmer/util';
 import { APPEND_OPCODES } from '../../opcodes';
 import { CONSTANTS } from '../../symbols';
 
@@ -66,8 +66,8 @@ class ScopeInspector<C extends JitOrAotBlock> {
 }
 
 APPEND_OPCODES.add(Op.Debugger, (vm, { op1: _symbols, op2: _evalInfo }) => {
-  let symbols = vm[CONSTANTS].getStringArray(_symbols);
-  let evalInfo = vm[CONSTANTS].getArray(_evalInfo);
+  let symbols = vm[CONSTANTS].getArray<string>(_symbols);
+  let evalInfo = vm[CONSTANTS].getValue<number[]>(decodeHandle(_evalInfo));
   let inspector = new ScopeInspector(vm.scope(), symbols, evalInfo);
   callback(vm.getSelf().value(), path => inspector.get(path).value());
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -25,26 +25,26 @@ import { SimpleElement, SimpleNode } from '@simple-dom/interface';
 import { expect, Maybe } from '@glimmer/util';
 
 APPEND_OPCODES.add(Op.Text, (vm, { op1: text }) => {
-  vm.elements().appendText(vm[CONSTANTS].getString(text));
+  vm.elements().appendText(vm[CONSTANTS].getValue(text));
 });
 
 APPEND_OPCODES.add(Op.Comment, (vm, { op1: text }) => {
-  vm.elements().appendComment(vm[CONSTANTS].getString(text));
+  vm.elements().appendComment(vm[CONSTANTS].getValue(text));
 });
 
 APPEND_OPCODES.add(Op.OpenElement, (vm, { op1: tag }) => {
-  vm.elements().openElement(vm[CONSTANTS].getString(tag));
+  vm.elements().openElement(vm[CONSTANTS].getValue(tag));
 });
 
 APPEND_OPCODES.add(Op.OpenDynamicElement, vm => {
-  let tagName = check(check(vm.stack.pop(), CheckReference).value(), CheckString);
+  let tagName = check(check(vm.stack.popJs(), CheckReference).value(), CheckString);
   vm.elements().openElement(tagName);
 });
 
 APPEND_OPCODES.add(Op.PushRemoteElement, vm => {
-  let elementRef = check(vm.stack.pop(), CheckReference);
-  let insertBeforeRef = check(vm.stack.pop(), CheckReference);
-  let guidRef = check(vm.stack.pop(), CheckReference);
+  let elementRef = check(vm.stack.popJs(), CheckReference);
+  let insertBeforeRef = check(vm.stack.popJs(), CheckReference);
+  let guidRef = check(vm.stack.popJs(), CheckReference);
 
   let element: SimpleElement;
   let insertBefore: Maybe<SimpleNode>;
@@ -106,7 +106,7 @@ APPEND_OPCODES.add(Op.CloseElement, vm => {
 APPEND_OPCODES.add(Op.Modifier, (vm, { op1: handle }) => {
   let { manager, state } = vm.runtime.resolver.resolve<ModifierDefinition>(handle);
   let stack = vm.stack;
-  let args = check(stack.pop(), CheckArguments);
+  let args = check(stack.popJs(), CheckArguments);
   let { constructing, updateOperations } = vm.elements();
   let dynamicScope = vm.dynamicScope();
   let modifier = manager.create(
@@ -155,18 +155,18 @@ export class UpdateModifierOpcode extends UpdatingOpcode {
 }
 
 APPEND_OPCODES.add(Op.StaticAttr, (vm, { op1: _name, op2: _value, op3: _namespace }) => {
-  let name = vm[CONSTANTS].getString(_name);
-  let value = vm[CONSTANTS].getString(_value);
-  let namespace = _namespace ? vm[CONSTANTS].getString(_namespace) : null;
+  let name = vm[CONSTANTS].getValue<string>(_name);
+  let value = vm[CONSTANTS].getValue<string>(_value);
+  let namespace = _namespace ? vm[CONSTANTS].getValue<string>(_namespace) : null;
 
   vm.elements().setStaticAttribute(name, value, namespace);
 });
 
 APPEND_OPCODES.add(Op.DynamicAttr, (vm, { op1: _name, op2: trusting, op3: _namespace }) => {
-  let name = vm[CONSTANTS].getString(_name);
-  let reference = check(vm.stack.pop(), CheckReference);
+  let name = vm[CONSTANTS].getValue<string>(_name);
+  let reference = check(vm.stack.popJs(), CheckReference);
   let value = reference.value();
-  let namespace = _namespace ? vm[CONSTANTS].getString(_namespace) : null;
+  let namespace = _namespace ? vm[CONSTANTS].getValue<string>(_namespace) : null;
 
   let attribute = vm.elements().setDynamicAttribute(name, value, !!trusting, namespace);
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/lists.ts
@@ -6,8 +6,8 @@ import { Op } from '@glimmer/interfaces';
 
 APPEND_OPCODES.add(Op.PutIterator, vm => {
   let stack = vm.stack;
-  let listRef = check(stack.pop(), CheckPathReference);
-  let keyRef = check(stack.pop(), CheckPathReference);
+  let listRef = check(stack.popJs(), CheckPathReference);
+  let keyRef = check(stack.popJs(), CheckPathReference);
 
   let keyValue = keyRef.value();
   let key = keyValue === null ? '@identity' : String(keyValue);
@@ -15,12 +15,12 @@ APPEND_OPCODES.add(Op.PutIterator, vm => {
   let iterableRef = new IterableReference(listRef, key, vm.env);
 
   // Push the first time to push the iterator onto the stack for iteration
-  stack.push(iterableRef);
+  stack.pushJs(iterableRef);
 
   // Push the second time to push it as a reference for presence in general
   // (e.g whether or not it is empty). This reference will be used to skip
   // iteration entirely.
-  stack.push(iterableRef);
+  stack.pushJs(iterableRef);
 });
 
 APPEND_OPCODES.add(Op.EnterList, (vm, { op1: relativeStart }) => {
@@ -33,7 +33,7 @@ APPEND_OPCODES.add(Op.ExitList, vm => {
 
 APPEND_OPCODES.add(Op.Iterate, (vm, { op1: breaks }) => {
   let stack = vm.stack;
-  let iterable = check(stack.peek(), CheckInstanceof(IterableReference));
+  let iterable = check(stack.peekJs(), CheckInstanceof(IterableReference));
   let item = iterable.next();
 
   if (item) {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
@@ -1,6 +1,6 @@
 import { VersionedPathReference } from '@glimmer/reference';
 import { APPEND_OPCODES } from '../../opcodes';
-import { assert, unwrapHandle } from '@glimmer/util';
+import { assert, unwrapHandle, decodeHandle } from '@glimmer/util';
 import { check } from '@glimmer/debug';
 import { Op, Dict, PartialDefinition } from '@glimmer/interfaces';
 import { CheckReference } from './-debug-strip';
@@ -11,12 +11,12 @@ APPEND_OPCODES.add(
   (vm, { op1: _meta, op2: _symbols, op3: _evalInfo }) => {
     let { [CONSTANTS]: constants, stack } = vm;
 
-    let name = check(stack.pop(), CheckReference).value();
+    let name = check(stack.popJs(), CheckReference).value();
     assert(typeof name === 'string', `Could not find a partial named "${String(name)}"`);
 
-    let meta = constants.getTemplateMeta(_meta);
-    let outerSymbols = constants.getStringArray(_symbols);
-    let evalInfo = constants.getArray(_evalInfo);
+    let meta = constants.getValue(decodeHandle(_meta));
+    let outerSymbols = constants.getArray<string>(_symbols);
+    let evalInfo = constants.getValue<number[]>(decodeHandle(_evalInfo));
 
     let handle = vm.runtime.resolver.lookupPartial(name as string, meta);
 

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -109,14 +109,14 @@ function renderInvocation<C extends JitOrAotBlock>(
 
   // Push blocks on to the stack, three stack values per block
   for (let i = 0; i < 3 * blockNames.length; i++) {
-    vm.stack.push(null);
+    vm.stack.pushNull();
   }
 
-  vm.stack.push(null);
+  vm.stack.pushNull();
 
   // For each argument, push its backing reference on to the stack
   argList.forEach(([, reference]) => {
-    vm.stack.push(reference);
+    vm.stack.pushJs(reference);
   });
 
   // Configure VM based on blocks and args just pushed on to the stack.
@@ -124,9 +124,9 @@ function renderInvocation<C extends JitOrAotBlock>(
 
   // Needed for the Op.Main opcode: arguments, component invocation object, and
   // component definition.
-  vm.stack.push(vm[ARGS]);
-  vm.stack.push(invocation);
-  vm.stack.push(definition);
+  vm.stack.pushJs(vm[ARGS]);
+  vm.stack.pushJs(invocation);
+  vm.stack.pushJs(definition);
 
   return new TemplateIteratorImpl(vm);
 }

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -215,7 +215,7 @@ export class PositionalArgumentsImpl implements PositionalArguments {
 
     if (!references) {
       let { stack, base, length } = this;
-      references = this._references = stack.sliceArray<VersionedPathReference<unknown>>(
+      references = this._references = stack.slice<VersionedPathReference<unknown>>(
         base,
         base + length
       );
@@ -368,7 +368,7 @@ export class NamedArgumentsImpl implements NamedArguments {
 
         if (idx === -1) {
           length = newNames.push(name);
-          stack.push(other.references[i]);
+          stack.pushJs(other.references[i]);
         }
       }
 
@@ -384,7 +384,7 @@ export class NamedArgumentsImpl implements NamedArguments {
 
     if (!references) {
       let { base, length, stack } = this;
-      references = this._references = stack.sliceArray<VersionedPathReference<unknown>>(
+      references = this._references = stack.slice<VersionedPathReference<unknown>>(
         base,
         base + length
       );
@@ -506,7 +506,7 @@ export class BlockArgumentsImpl<C extends JitOrAotBlock> implements BlockArgumen
 
     if (!values) {
       let { base, length, stack } = this;
-      values = this.internalValues = stack.sliceArray<number>(base, base + length * 3);
+      values = this.internalValues = stack.slice<number>(base, base + length * 3);
     }
 
     return values;
@@ -553,7 +553,7 @@ export class BlockArgumentsImpl<C extends JitOrAotBlock> implements BlockArgumen
 class CapturedBlockArgumentsImpl implements CapturedBlockArguments {
   public length: number;
 
-  constructor(public names: string[], public values: BlockValue[]) {
+  constructor(public names: string[], public values: Option<BlockValue>[]) {
     this.length = names.length;
   }
 

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -32,9 +32,14 @@ export function initializeRegistersWithPC(pc: number): LowLevelRegisters {
 }
 
 export interface Stack {
-  push(value: number): void;
+  pushJs(value: unknown): void;
+  pushSmallInt(value: number): void;
+  pushTrue(): void;
+  pushFalse(): void;
+  pushNull(): void;
+  pushUndefined(): void;
   get(position: number): number;
-  pop(): number;
+  popSmallInt(): number;
 }
 
 export interface Externs {
@@ -68,8 +73,8 @@ export default class LowLevelVM {
 
   // Start a new frame and save $ra and $fp on the stack
   pushFrame() {
-    this.stack.push(this.registers[$ra]);
-    this.stack.push(this.registers[$fp]);
+    this.stack.pushSmallInt(this.registers[$ra]);
+    this.stack.pushSmallInt(this.registers[$fp]);
     this.registers[$fp] = this.registers[$sp] - 1;
   }
 
@@ -81,11 +86,11 @@ export default class LowLevelVM {
   }
 
   pushSmallFrame() {
-    this.stack.push(this.registers[$ra]);
+    this.stack.pushSmallInt(this.registers[$ra]);
   }
 
   popSmallFrame() {
-    this.registers[$ra] = this.stack.pop();
+    this.registers[$ra] = this.stack.popSmallInt();
   }
 
   // Jump to an address in `program`
@@ -168,7 +173,7 @@ export default class LowLevelVM {
       case MachineOp.InvokeStatic:
         return this.call(opcode.op1);
       case MachineOp.InvokeVirtual:
-        return this.call(this.stack.pop());
+        return this.call(this.stack.popSmallInt());
       case MachineOp.Jump:
         return this.goto(opcode.op1);
       case MachineOp.Return:

--- a/packages/@glimmer/util/lib/immediate.ts
+++ b/packages/@glimmer/util/lib/immediate.ts
@@ -1,267 +1,154 @@
-import { exhausted } from './platform-utils';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
-
-let checkInt: undefined | ((num: number, min?: number, max?: number) => void);
-
-if (LOCAL_DEBUG) {
-  // eslint-disable-next-line no-var,vars-on-top
-  checkInt = (num: number, min = -2147483648, max = 2147483647) => {
-    if (!isInt(num, min, max)) {
-      throw new Error(`expected ${num} to be an integer between ${min} to ${max}`);
-    }
-  };
-}
+import { debugAssert as assert } from './assert';
 
 /*
-Encoding notes
+  Encoding notes
 
-first
-2 bits    start        end
-0 1       1073741824   2147483647   direct negative or boolean or null or undefined
-0 0       0            1073741823   direct positive
-1 1       -1           -1073741824  string index
-1 0       -1073741825  -2147483648  number index
+  We use 30 bit integers for encoding, so that we don't ever encode a non-SMI
+  integer to push on the stack.
 
-Since first bit is the sign bit then
+  Handles are >= 0
+  Immediates are < 0
 
-encoded >= 0  is all directly encoded values
-encoded < 0  is all indirect encoded values (encoded indexes)
+  True, False, Undefined and Null are pushed as handles into the symbol table,
+  with well known handles (0, 1, 2, 3)
 
-For directly encoded values
-encoded      decoded
-0            0
-...          ...
-1073741823   1073741823
-1073741824   false
-1073741825   true
-1073741826   null
-1073741827   undefined
-1073741828   -1
-...          ...
-2147483647   -1073741820
+  The negative space is divided into positives and negatives. Positives are
+  higher numbers (-1, -2, -3, etc), negatives are lower.
 
-for stack handles
-we map js index 0 to 2147483647 onto -1 to -2147483648
+  We only encode immediates for two reasons:
 
-for constant handles
-we map string index 0 to 1073741823 onto -1 to -1073741824
-we map number index 0 to 1073741823 onto -1073741825 to -2147483648
+  1. To transfer over the wire, so they're smaller in general
+  2. When pushing values onto the stack from the low level/inner VM, which may
+     be converted into WASM one day.
+
+  This allows the low-level VM to always use SMIs, and to minimize using JS
+  values via handles for things like the stack pointer and frame pointer.
+  Externally, most code pushes values as JS values, except when being pulled
+  from the append byte code where it was already encoded.
+
+  Logically, this is because the low level VM doesn't really care about these
+  higher level values. For instance, the result of a userland helper may be a
+  number, or a boolean, or undefined/null, but it's extra work to figure that
+  out and push it correctly, vs. just pushing the value as a JS value with a
+  handle.
+
+  Note: The details could change here in the future, this is just the current
+  strategy.
 */
 
-/**
- * Immediates use the positive half of 32 bits 0 through 2147483647 (0x7fffffff)
- * leaving the negative half for handles -1 through -2147483648.
- */
 export const enum ImmediateConstants {
-  /**
-   * 31 bits can encode 2^31 values
-   */
-  IMMEDIATE_LENGTH = 2 ** 31,
+  MAX_SMI = 2 ** 30 - 1,
+  MIN_SMI = ~MAX_SMI,
+  SIGN_BIT = ~(2 ** 29),
+  MAX_INT = ~SIGN_BIT - 1,
+  MIN_INT = ~MAX_INT,
 
-  /**
-   * Min encoded immediate is min positive
-   */
-  MIN_IMMEDIATE = 0,
+  FALSE_HANDLE = 0,
+  TRUE_HANDLE = 1,
+  NULL_HANDLE = 2,
+  UNDEFINED_HANDLE = 3,
 
-  /**
-   * Max encoded immediate is the max positive 32 bit signed int
-   */
-  MAX_IMMEDIATE = IMMEDIATE_LENGTH - 1,
-
-  /**
-   * The encoding of false.
-   * False is the start of the second half of 31 bits
-   */
-  FALSE = IMMEDIATE_LENGTH / 2,
-
-  /**
-   * The maximum int that can be directly encoded vs a handle.
-   *
-   * The last positive int is just before FALSE.
-   */
-  MAX_INT = FALSE - 1,
-
-  /**
-   * The encoding of true
-   */
-  TRUE = FALSE + 1,
-
-  /**
-   * The encoding of null
-   */
-  NULL = TRUE + 1,
-
-  /**
-   * The encoding of undefined
-   */
-  UNDEFINED = NULL + 1,
-
-  /**
-   * Encoded -1
-   *
-   * Encoded just after UNDEFINED
-   */
-  NEGATIVE_ONE = UNDEFINED + 1,
-
-  /**
-   * The base to substract a negative from to decode or encode it.
-   *
-   * NEGATIVE_ONE      == NEGATIVE_BASE - -1             == encodeImmediate(-1)
-   * MAX_IMMEDIATE     == NEGATIVE_BASE - MIN_INT        == encodeImmediate(MIN_INT)
-   * -1                == NEGATIVE_BASE - NEGATIVE_ONE   == decodeImmediate(NEGATIVE_ONE)
-   * MIN_INT           == NEGATIVE_BASE - MAX_IMMEDIATE  == decodeImmediate(MAX_IMMEDIATE)
-   */
-  NEGATIVE_BASE = NEGATIVE_ONE - 1,
-
-  /**
-   * The minimum int that can be directly encoded vs a handle.
-   */
-  MIN_INT = NEGATIVE_BASE - MAX_IMMEDIATE,
+  ENCODED_FALSE_HANDLE = FALSE_HANDLE,
+  ENCODED_TRUE_HANDLE = TRUE_HANDLE,
+  ENCODED_NULL_HANDLE = NULL_HANDLE,
+  ENCODED_UNDEFINED_HANDLE = UNDEFINED_HANDLE,
 }
 
-/**
- * The compiler constants divide the handles into two halves strings and numbers
- * while on the stack, there is only one array of js values.
- */
-export const enum HandleConstants {
-  HANDLE_LENGTH = 2 ** 31,
-  MAX_INDEX = HANDLE_LENGTH - 1,
-  MAX_HANDLE = -1,
-  MIN_HANDLE = -1 - MAX_INDEX,
-  STRING_HANDLE_LENGTH = HANDLE_LENGTH / 2,
-  NUMBER_HANDLE_LENGTH = HANDLE_LENGTH - STRING_HANDLE_LENGTH,
-  STRING_MAX_INDEX = STRING_HANDLE_LENGTH - 1,
-  NUMBER_MAX_INDEX = NUMBER_HANDLE_LENGTH - 1,
-  STRING_MAX_HANDLE = MAX_HANDLE,
-  STRING_MIN_HANDLE = STRING_MAX_HANDLE - STRING_MAX_INDEX,
-  NUMBER_MAX_HANDLE = STRING_MIN_HANDLE - 1,
-  NUMBER_MIN_HANDLE = NUMBER_MAX_HANDLE - NUMBER_MAX_INDEX,
+export function isHandle(value: number) {
+  return value >= 0;
 }
 
-/**
- * Encodes a value that can be stored directly instead of being a handle.
- *
- * Immediates use the positive half of 32bits
- *
- * @param value - the value to be encoded.
- */
-export function encodeImmediate(value: null | undefined | boolean | number) {
-  if (typeof value === 'number') {
-    if (LOCAL_DEBUG) {
-      checkInt!(value, ImmediateConstants.MIN_INT, ImmediateConstants.MAX_INT);
-    }
-    // map -1 to -1073741820 onto 1073741828 to 2147483647
-    // 1073741827 - (-1) == 1073741828
-    // 1073741827 - (-1073741820) == 2147483647
-    // positive it stays as is
-    // 0 - 1073741823
-    return value < 0 ? ImmediateConstants.NEGATIVE_BASE - value : value;
-  }
-  if (value === false) {
-    return ImmediateConstants.FALSE;
-  }
-  if (value === true) {
-    return ImmediateConstants.TRUE;
-  }
-  if (value === null) {
-    return ImmediateConstants.NULL;
-  }
-  if (value === undefined) {
-    return ImmediateConstants.UNDEFINED;
-  }
-  return exhausted(value);
+export function isNonPrimitiveHandle(value: number) {
+  return value > ImmediateConstants.ENCODED_UNDEFINED_HANDLE;
 }
 
-/**
- * Decodes an immediate into its value.
- *
- * @param value - the encoded immediate value
- */
-export function decodeImmediate(value: number): null | undefined | boolean | number {
+export function constants(...values: unknown[]): unknown[] {
+  return [false, true, null, undefined, ...values];
+}
+
+export function isSmallInt(value: number) {
+  return (
+    value % 1 === 0 && value <= ImmediateConstants.MAX_INT && value >= ImmediateConstants.MIN_INT
+  );
+}
+
+export function encodeNegative(num: number) {
   if (LOCAL_DEBUG) {
-    // expected value to be checked before this
-    checkInt!(value, ImmediateConstants.MIN_IMMEDIATE, ImmediateConstants.MAX_IMMEDIATE);
+    assert(
+      num % 1 === 0 && num >= ImmediateConstants.MIN_INT && num < 0,
+      `Could not encode negative: ${num}`
+    );
   }
-  if (value > ImmediateConstants.MAX_INT) {
-    switch (value) {
-      case ImmediateConstants.FALSE:
-        return false;
-      case ImmediateConstants.TRUE:
-        return true;
-      case ImmediateConstants.NULL:
-        return null;
-      case ImmediateConstants.UNDEFINED:
-        return undefined;
-      default:
-        // map 1073741828 to 2147483647 to -1 to -1073741820
-        // 1073741827 - 1073741828 == -1
-        // 1073741827 - 2147483647 == -1073741820
-        return ImmediateConstants.NEGATIVE_BASE - value;
-    }
-  }
-  return value;
+
+  return num & ImmediateConstants.SIGN_BIT;
 }
 
-/**
- * True if the number can be stored directly or false if it needs a handle.
- *
- * This is used on any number type to see if it can be directly encoded.
- */
-export function isSmallInt(num: number) {
-  return isInt(num, ImmediateConstants.MIN_INT, ImmediateConstants.MAX_INT);
-}
-
-/**
- * True if the encoded int32 operand or encoded stack int32 is a handle.
- */
-export function isHandle(encoded: number) {
+export function decodeNegative(num: number) {
   if (LOCAL_DEBUG) {
-    // we expect to only use this method when we already know it is an int32
-    // because it was encoded or read from the Int32Array buffer
-    checkInt!(encoded);
+    assert(
+      num % 1 === 0 && num < ~ImmediateConstants.MAX_INT && num >= ImmediateConstants.MIN_SMI,
+      `Could not decode negative: ${num}`
+    );
   }
-  return encoded < 0;
+
+  return num | ~ImmediateConstants.SIGN_BIT;
 }
 
-/**
- * Encodes an index to an operand or stack handle.
- */
-export function encodeHandle(
-  index: number,
-  maxIndex: number = HandleConstants.MAX_INDEX,
-  maxHandle: number = HandleConstants.MAX_HANDLE
-) {
+export function encodePositive(num: number) {
   if (LOCAL_DEBUG) {
-    // expected the index to already be a positive int index from pushing the value
-    checkInt!(index, 0);
+    assert(
+      num % 1 === 0 && num >= 0 && num <= ImmediateConstants.MAX_INT,
+      `Could not encode positive: ${num}`
+    );
   }
-  if (index > maxIndex) {
-    throw new Error(`index ${index} overflowed range 0 to ${maxIndex}`);
-  }
-  // -1 - 0 == -1
-  // -1 - 1073741823 == -1073741824
-  // -1073741825 - 0 == -1073741825
-  // -1073741825 - 1073741823 == -2147483648
-  return maxHandle - index;
+
+  return ~num;
 }
 
-/**
- * Decodes the index from the specified operand or stack handle.
- */
-export function decodeHandle(handle: number, maxHandle: number = HandleConstants.MAX_HANDLE) {
+export function decodePositive(num: number) {
   if (LOCAL_DEBUG) {
-    // we expect to be decoding a encoded int32 operand or encoded int32 on the stack
-    checkInt!(handle, HandleConstants.MIN_HANDLE, maxHandle);
+    assert(
+      num % 1 === 0 && num <= 0 && num >= ~ImmediateConstants.MAX_INT,
+      `Could not decode positive: ${num}`
+    );
   }
-  // -1 - -1 == 0
-  // -1 - -1073741824 == 1073741823
-  // -1073741825 - -1073741825 == 0
-  // -1073741825 - -2147483648 == 1073741823
-  return maxHandle - handle;
+
+  return ~num;
 }
 
-function isInt(num: number, min: number, max: number): boolean {
-  // this is the same as Math.floor(num) === num
-  // also NaN % 1 is NaN and Infinity % 1 is NaN so both should fail
-  return num % 1 === 0 && num >= min && num <= max;
+export function encodeHandle(num: number) {
+  if (LOCAL_DEBUG) {
+    assert(
+      num % 1 === 0 && num >= 0 && num <= ImmediateConstants.MAX_SMI,
+      `Could not encode handle: ${num}`
+    );
+  }
+
+  return num;
 }
+
+export function decodeHandle(num: number) {
+  if (LOCAL_DEBUG) {
+    assert(
+      num % 1 === 0 && num <= ImmediateConstants.MAX_SMI && num >= 0,
+      `Could not decode handle: ${num}`
+    );
+  }
+
+  return num;
+}
+
+export function encodeImmediate(num: number) {
+  num |= 0;
+  return num < 0 ? encodeNegative(num) : encodePositive(num);
+}
+
+export function decodeImmediate(num: number) {
+  num |= 0;
+  return num > ImmediateConstants.SIGN_BIT ? decodePositive(num) : decodeNegative(num);
+}
+
+// Warm
+[1, 2, 3].forEach(x => decodeHandle(encodeHandle(x)));
+[1, -1].forEach(x => decodeImmediate(encodeImmediate(x)));

--- a/packages/@glimmer/util/test/immediate-test.ts
+++ b/packages/@glimmer/util/test/immediate-test.ts
@@ -1,0 +1,17 @@
+import { encodeImmediate, decodeImmediate, ImmediateConstants } from '..';
+
+const { module, test } = QUnit;
+
+module('immediate encoding tests', () => {
+  test('it works', assert => {
+    [ImmediateConstants.MIN_INT, -1, 0, ImmediateConstants.MAX_INT].forEach(val => {
+      let encoded = encodeImmediate(val);
+
+      assert.equal(val, decodeImmediate(encoded), 'correctly encoded and decoded');
+      assert.ok(
+        encoded >= ImmediateConstants.MIN_SMI && encoded <= ImmediateConstants.MAX_SMI,
+        'encoded as an SMI'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Simplifies immediate and constant handle encoding in the following ways:

1. Immediates are stored as negative numbers instead of positive, as
  handles are much more common in general.

2. `true`, `false`, `undefined`, and `null` are stored as handles
  instead of immediates. These handles are predefined/prepopulated, and
  well known ahead of time.

3. Constants in the constant pool now all exist in a single array of
  values. This makes lookups and storage code simpler overall and
  appears to have a positive impact on performance (per the last PR).

4. Handles are no longer divided between string and number handles,
  since all constants are pulled from the same pool. This allows us to
  avoid encoding/decoding handles in general.

5. We now use different methods for pushing and popping handles and immediates on the stack, namely `pushJs`, `pushSmallInt`, `pushNull`, etc. and `popJs`, `peekJs`, `popSmallInt`, etc. 

Benchmark results: 
[artifact-65.pdf](https://github.com/glimmerjs/glimmer-vm/files/5053922/artifact-65.pdf)
