### PR TITLE
[BUGFIX] Avoid String.prototype.repeat

### DIFF
--- a/packages/@glimmer/validator/lib/debug.ts
+++ b/packages/@glimmer/validator/lib/debug.ts
@@ -186,7 +186,8 @@ if (DEBUG) {
       current = current.parent;
     }
 
-    return trackingStack.map((label, index) => ' '.repeat(2 * index) + label).join('\n');
+    // TODO: Use String.prototype.repeat here once we can drop support for IE11
+    return trackingStack.map((label, index) => Array(2 * index).join(' ') + label).join('\n');
   };
 
   markTagAsConsumed = (_tag: Tag) => {


### PR DESCRIPTION
We need to avoid this API because it is not supported in IE11, and Ember uses
these APIs in its tests. They are DEBUG APIs so it shouldn't affect end users,
but it's important to fix to land in Ember.