### PR TITLE
[REFACTOR] Simplify CapturedArguments

### DIFF
--- a/packages/@glimmer/debug/lib/stack-check.ts
+++ b/packages/@glimmer/debug/lib/stack-check.ts
@@ -191,6 +191,33 @@ class ArrayChecker<T> implements Checker<T[]> {
   }
 }
 
+class DictChecker<T> implements Checker<Dict<T>> {
+  type!: Dict<T>;
+
+  constructor(private checker: Checker<T>) {}
+
+  validate(value: unknown): value is Dict<T> {
+    let isDict =
+      typeof value === 'object' && value !== null && Object.getPrototypeOf(value) === null;
+
+    if (!isDict) return false;
+
+    let { checker } = this;
+
+    for (let key in value as Dict) {
+      if (!checker.validate((value as Dict)[key])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  expected(): string {
+    return `a primitive`;
+  }
+}
+
 class OpaqueChecker implements Checker<unknown> {
   type: unknown;
 
@@ -242,6 +269,10 @@ export function CheckInterface<
 
 export function CheckArray<T>(obj: Checker<T>): Checker<T[]> {
   return new ArrayChecker(obj);
+}
+
+export function CheckDict<T>(obj: Checker<T>): Checker<Dict<T>> {
+  return new DictChecker(obj);
 }
 
 export function check<T>(value: unknown, checker: Checker<T>): T {

--- a/packages/@glimmer/integration-tests/lib/components/emberish-glimmer.ts
+++ b/packages/@glimmer/integration-tests/lib/components/emberish-glimmer.ts
@@ -24,7 +24,7 @@ import { TestComponentDefinitionState } from './test-component';
 import { TestComponentConstructor } from './types';
 import { EmberishCurlyComponentFactory } from './emberish-curly';
 import { UpdatableRootReference } from '../reference';
-import { registerDestructor } from '@glimmer/runtime';
+import { registerDestructor, reifyNamed } from '@glimmer/runtime';
 
 export type Attrs = Dict;
 export type AttrsDiff = { oldAttrs: Option<Attrs>; newAttrs: Attrs };
@@ -133,7 +133,7 @@ export class EmberishGlimmerComponentManager
   ): EmberishGlimmerComponentState {
     let args = _args.named.capture();
     let klass = definition.ComponentClass || EmberishGlimmerComponent;
-    let attrs = args.value();
+    let attrs = reifyNamed(args);
     let component = klass.create({ attrs });
 
     component.didInitAttrs({ attrs });
@@ -183,7 +183,7 @@ export class EmberishGlimmerComponentManager
 
   update({ args, component }: EmberishGlimmerComponentState): void {
     let oldAttrs = component.attrs;
-    let newAttrs = args.value();
+    let newAttrs = reifyNamed(args);
 
     component.attrs = newAttrs;
     component.didUpdateAttrs({ oldAttrs, newAttrs });

--- a/packages/@glimmer/integration-tests/lib/helpers.ts
+++ b/packages/@glimmer/integration-tests/lib/helpers.ts
@@ -1,5 +1,6 @@
 import { Dict, CapturedArguments, VMArguments } from '@glimmer/interfaces';
 import { PathReference, Reference } from '@glimmer/reference';
+import { reifyNamed, reifyPositional } from '@glimmer/runtime';
 
 export type UserHelper = (args: ReadonlyArray<unknown>, named: Dict<unknown>) => unknown;
 
@@ -19,7 +20,7 @@ export class HelperReference implements PathReference {
   value() {
     let { helper, args } = this;
 
-    return helper(args.positional.value(), args.named.value());
+    return helper(reifyPositional(args.positional), reifyNamed(args.named));
   }
 
   get(prop: string): SimplePathReference {

--- a/packages/@glimmer/integration-tests/lib/modifiers.ts
+++ b/packages/@glimmer/integration-tests/lib/modifiers.ts
@@ -10,7 +10,7 @@ import {
   CapturedArguments,
 } from '@glimmer/interfaces';
 import { UpdatableTag, createUpdatableTag } from '@glimmer/validator';
-import { registerDestructor } from '@glimmer/runtime';
+import { registerDestructor, reifyPositional, reifyNamed } from '@glimmer/runtime';
 
 export interface TestModifierConstructor {
   new (): TestModifierInstance;
@@ -50,8 +50,8 @@ export class TestModifierManager
 
   install({ element, args, instance }: TestModifier) {
     // Do this eagerly to ensure they are tracked
-    let positional = args.positional.value();
-    let named = args.named.value();
+    let positional = reifyPositional(args.positional);
+    let named = reifyNamed(args.named);
 
     if (instance && instance.didInsertElement) {
       instance.element = element;
@@ -65,8 +65,8 @@ export class TestModifierManager
 
   update({ args, instance }: TestModifier) {
     // Do this eagerly to ensure they are tracked
-    let positional = args.positional.value();
-    let named = args.named.value();
+    let positional = reifyPositional(args.positional);
+    let named = reifyNamed(args.named);
 
     if (instance && instance.didUpdate) {
       instance.didUpdate(positional, named);

--- a/packages/@glimmer/interfaces/lib/runtime/arguments.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/arguments.d.ts
@@ -3,6 +3,8 @@ import { Tag } from '@glimmer/validator';
 import { Dict, Option } from '../core';
 import { ScopeBlock, JitOrAotBlock } from './scope';
 
+declare const CAPTURED_ARGS: unique symbol;
+
 export interface VMArguments {
   length: number;
   positional: PositionalArguments;
@@ -13,15 +15,9 @@ export interface VMArguments {
 }
 
 export interface CapturedArguments {
-  length: number;
   positional: CapturedPositionalArguments;
   named: CapturedNamedArguments;
-  value(): CapturedArgumentsValue;
-}
-
-export interface CapturedArgumentsValue {
-  named: Dict;
-  positional: unknown[];
+  [CAPTURED_ARGS]: true;
 }
 
 export interface PositionalArguments {
@@ -30,11 +26,8 @@ export interface PositionalArguments {
   capture(): CapturedPositionalArguments;
 }
 
-export interface CapturedPositionalArguments extends PathReference<unknown[]> {
-  length: number;
-  references: PathReference<unknown>[];
-  at<T extends unknown>(position: number): PathReference<T>;
-  value(): unknown[];
+export interface CapturedPositionalArguments extends Array<PathReference> {
+  [CAPTURED_ARGS]: true;
 }
 
 export interface NamedArguments {
@@ -60,12 +53,12 @@ export interface CapturedBlockArguments {
   get(name: string): Option<ScopeBlock>;
 }
 
-export interface CapturedNamedArguments extends PathReference<Dict<unknown>> {
-  map: Dict<PathReference<unknown>>;
-  names: string[];
-  length: number;
-  references: PathReference<unknown>[];
-  has(name: string): boolean;
-  get<T extends PathReference<unknown>>(name: string): T;
-  value(): Dict<unknown>;
+export interface CapturedNamedArguments {
+  [key: string]: PathReference;
+  [CAPTURED_ARGS]: true;
+}
+
+export interface Arguments {
+  positional: unknown[];
+  named: Record<string, unknown>;
 }

--- a/packages/@glimmer/reference/test/template-test.ts
+++ b/packages/@glimmer/reference/test/template-test.ts
@@ -10,12 +10,7 @@ import {
   UNDEFINED_REFERENCE,
 } from '..';
 import { TestEnv } from './utils/template';
-import {
-  EMPTY_ARGS,
-  CapturedNamedArgumentsImpl,
-  CapturedPositionalArgumentsImpl,
-  CapturedArgumentsImpl,
-} from '@glimmer/runtime';
+import { EMPTY_ARGS, EMPTY_NAMED, createCapturedArgs } from '@glimmer/runtime';
 
 module('@glimmer/reference: template', () => {
   module('ComponentRootReference', () => {
@@ -47,7 +42,7 @@ module('@glimmer/reference: template', () => {
     test('non-constant helper values are non-constant if arguments are not constant', assert => {
       let tag = createTag();
 
-      const EMPTY_POSITIONAL = new CapturedPositionalArgumentsImpl([
+      const MUTABLE_ARGS = createCapturedArgs(EMPTY_NAMED, [
         {
           value() {
             consumeTag(tag);
@@ -61,11 +56,9 @@ module('@glimmer/reference: template', () => {
           },
         },
       ]);
-      const EMPTY_NAMED = new CapturedNamedArgumentsImpl([], []);
-      const MUTABLE_ARGS = new CapturedArgumentsImpl(EMPTY_POSITIONAL, EMPTY_NAMED, 0);
 
       let ref = new HelperRootReference(
-        args => args.positional.at(0).value(),
+        args => args.positional[0].value(),
         MUTABLE_ARGS,
         new TestEnv()
       );

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -57,9 +57,14 @@ export { SafeString } from './lib/upsert';
 export { InternalVM, UpdatingVM, VM as LowLevelVM } from './lib/vm';
 export {
   EMPTY_ARGS,
-  CapturedArgumentsImpl,
-  CapturedNamedArgumentsImpl,
-  CapturedPositionalArgumentsImpl,
+  EMPTY_NAMED,
+  EMPTY_POSITIONAL,
+  createCapturedArgs,
+  reifyArgs,
+  reifyNamed,
+  reifyPositional,
+  ReifyNamedReference,
+  ReifyPositionalReference,
 } from './lib/vm/arguments';
 export {
   DynamicAttribute,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
@@ -11,9 +11,10 @@ import {
   wrap,
   CheckOption,
   CheckOr,
+  CheckArray,
+  CheckDict,
 } from '@glimmer/debug';
 import {
-  CapturedArguments,
   CompilableBlock,
   ComponentDefinition,
   ComponentManager,
@@ -22,7 +23,7 @@ import {
   JitOrAotBlock,
   Scope,
   Helper,
-  CapturedArgumentsValue,
+  CapturedArguments,
   Option,
   JitScopeBlock,
 } from '@glimmer/interfaces';
@@ -30,11 +31,7 @@ import { PathReference, Reference } from '@glimmer/reference';
 import { Tag, COMPUTE } from '@glimmer/validator';
 import { ScopeImpl } from '../../environment';
 import CurryComponentReference from '../../references/curry-component';
-import {
-  CapturedNamedArgumentsImpl,
-  CapturedPositionalArgumentsImpl,
-  VMArgumentsImpl,
-} from '../../vm/arguments';
+import { VMArgumentsImpl } from '../../vm/arguments';
 import { ComponentInstance, ComponentElementOperations } from './component';
 import { UNDEFINED_REFERENCE } from '../../references';
 
@@ -61,18 +58,6 @@ export const CheckArguments: Checker<VMArgumentsImpl> = wrap(() =>
 
 export const CheckHelper: Checker<Helper> = CheckFunction as Checker<Helper>;
 
-class CheckCapturedArgumentsValue implements Checker<() => CapturedArgumentsValue> {
-  type!: () => CapturedArgumentsValue;
-
-  validate(value: unknown): value is () => CapturedArgumentsValue {
-    return typeof value === 'function';
-  }
-
-  expected(): string {
-    return `SafeString`;
-  }
-}
-
 export class UndefinedReferenceChecker implements Checker<Reference> {
   type!: Reference;
 
@@ -88,10 +73,8 @@ export class UndefinedReferenceChecker implements Checker<Reference> {
 export const CheckUndefinedReference = new UndefinedReferenceChecker();
 
 export const CheckCapturedArguments: Checker<CapturedArguments> = CheckInterface({
-  length: CheckNumber,
-  positional: wrap(() => CheckInstanceof(CapturedPositionalArgumentsImpl)),
-  named: wrap(() => CheckInstanceof(CapturedNamedArgumentsImpl)),
-  value: new CheckCapturedArgumentsValue(),
+  positional: wrap(() => CheckArray(CheckPathReference)),
+  named: wrap(() => CheckDict(CheckPathReference)),
 });
 
 export const CheckCurryComponent = wrap(() => CheckInstanceof(CurryComponentReference));


### PR DESCRIPTION
Now that the VM uses tracking internally, some of the previous structure
of things doesn't make much sense anymore. For CapturedArguments in
particular, they previously had to b their own class structure because
they needed to combine and forward all of the tags of the argument
references. Now, the references will be consumed naturally whenever they
are accessed, so that's not necessary as much anymore.

This PR makes CapturedPositionalArguments a `Reference[]`, and
CapturedNamedArguments a `Record<string, Reference>`, keeping the data
structures as simple as possible and inline with their general usage.
It also exposes `reifyNamed` and `reifyPositional` as convenience
methods for getting all of the values of the references, and it exposes
a `capturedArgs` function for generating captured arguments manually,
which is done several times in Ember.

The interfaces for CapturedArguments use a declared symbol to also make
it so that users cannot generate them themselves. This allows us to
ensure that `CapturedArguments` is always created with the same shape.