### PR TITLE
Failing test for `<this.someString />` performing component invocation.

### DIFF
--- a/packages/@glimmer/integration-tests/lib/suites/components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/components.ts
@@ -559,6 +559,21 @@ export class BasicComponents extends RenderTest {
   @test({
     kind: 'glimmer',
   })
+  'invoking dynamic component (path) via angle brackets does not work for string'() {
+    class TestHarness extends EmberishGlimmerComponent {
+      public Foo: any;
+    }
+    this.registerComponent('Glimmer', 'TestHarness', '<this.Foo />', TestHarness);
+    this.registerComponent('Glimmer', 'Foo', 'hello world!');
+
+    this.assert.throws(() => {
+      this.render('<TestHarness @Foo="Foo" />');
+    }, /some error message here/);
+  }
+
+  @test({
+    kind: 'glimmer',
+  })
   'invoking dynamic component (path) via angle brackets with named block'() {
     class TestHarness extends EmberishGlimmerComponent {
       public Foo: any;


### PR DESCRIPTION
Creates a failing test for https://github.com/emberjs/ember.js/issues/17744.

This was likely introduced by https://github.com/glimmerjs/glimmer-vm/pull/822 (the original PR adding support for dynamic component invocation in angle brackets).