### PR TITLE
Ensure version numbers are bumped for benchmark and local-linker.

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,10 +128,14 @@
         ],
         "additionalManifests": {
           "dependencyUpdates": [
+            "benchmark/package.json",
+            "lib/local-linker/package.json",
             "packages/*/*/package.json"
           ],
           "versionUpdates": [
             "package.json",
+            "benchmark/package.json",
+            "lib/local-linker/package.json",
             "packages/*/*/package.json"
           ]
         }


### PR DESCRIPTION
Due to this repos somewhat odd setup (we publish from within `dist/@glimmer/<PACKAGE_NAME>` instead of the location actually referenced by the `workspaces` configuration in `package.json`) we have to maintain the list of `package.json`s to update as special `release-it-yarn-workspaces` configuration (normally it would just infer everything from `workspaces` setting).