### PR TITLE
Update PerformanceCheck CI run to fetch full git history.

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - uses: volta-cli/action@v1
       - name: Build Control
         run: |


### PR DESCRIPTION
Currently (with a `fetch-depth` of 2) a PR that has multiple commits will not retrieve the commit referenced by `${{ github.event.pull_request.base.sha }}`.

This changes the checkout action configuration to fetch the full history, and avoids the issue.