### PR TITLE
attempt to add failing test to nested p tags rehydration

### DIFF
--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -799,6 +799,26 @@ class Rehydration extends AbstractRehydrationTests {
   }
 
   @test
+  'nested p tags'() {
+    let template = '<p class="outer">{{{content}}}</p>';
+    let innerContent = '<p>This is <strong>HTML safe</strong> content.</p>';
+    let mark = '<!--%glmr%-->';
+    this.renderServerSide(template, { selector: 'div', content: innerContent });
+    let b = blockStack();
+    this.assertHTML(strip`
+      ${b(0)}
+      <p class="outer">${b(1)}${mark}${innerContent}${mark}${b(1)}</p>
+      ${b(0)}
+    `);
+    this.renderClientSide(template, { selector: 'div' });
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertHTML(strip`
+    <p class="outer">${innerContent}</p>
+    `);
+    this.assertStableRerender();
+  }
+
+  @test
   'clearing bounds'() {
     let template = strip`
       {{#if isTrue}}


### PR DESCRIPTION
related issue: https://github.com/emberjs/ember.js/issues/19114

![image](https://user-images.githubusercontent.com/1360552/92399744-76fade80-f133-11ea-85ac-e189feaa5a0f.png)

may be related: https://stackoverflow.com/questions/8460993/p-end-tag-p-is-not-needed-in-html

assert bubbling from 

![image](https://user-images.githubusercontent.com/1360552/92400168-21730180-f134-11ea-89d2-71f3322f83ca.png)

According to current parser implementation, unclosed `<p>` throw error: https://astexplorer.net/#/gist/0e4452d39e7a5d86ac852414ec56fa99/054dedaf474d1710d2fabcc7e0e93a3e63692c4f