### PR TITLE
validate if in-element has already been transformed

### DIFF
--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -450,7 +450,7 @@ export default class TemplateCompiler implements Processor<InputOps> {
       let { key, value } = pairs[i];
 
       if (isInElement) {
-        if (key === 'guid' && !value.value.startsWith('%cursor:')) {
+        if (key === 'guid' && value.type === 'StringLiteral' && !value.value.startsWith('%cursor:')) {
           throw new SyntaxError(
             `Cannot pass \`guid\` to \`{{#in-element}}\` on line ${value.loc.start.line}.`,
             value.loc

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -450,7 +450,7 @@ export default class TemplateCompiler implements Processor<InputOps> {
       let { key, value } = pairs[i];
 
       if (isInElement) {
-        if (key === 'guid') {
+        if (key === 'guid' && !value.value.startsWith('%cursor:')) {
           throw new SyntaxError(
             `Cannot pass \`guid\` to \`{{#in-element}}\` on line ${value.loc.start.line}.`,
             value.loc

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -453,8 +453,8 @@ export default class TemplateCompiler implements Processor<InputOps> {
         if (
           key === 'guid' &&
           value.type === 'StringLiteral' &&
-          !value.value.startsWith('%cursor:'))
-        {
+          !value.value.startsWith('%cursor:')
+        ) {
           throw new SyntaxError(
             `Cannot pass \`guid\` to \`{{#in-element}}\` on line ${value.loc.start.line}.`,
             value.loc

--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -450,7 +450,11 @@ export default class TemplateCompiler implements Processor<InputOps> {
       let { key, value } = pairs[i];
 
       if (isInElement) {
-        if (key === 'guid' && value.type === 'StringLiteral' && !value.value.startsWith('%cursor:')) {
+        if (
+          key === 'guid' &&
+          value.type === 'StringLiteral' &&
+          !value.value.startsWith('%cursor:'))
+        {
           throw new SyntaxError(
             `Cannot pass \`guid\` to \`{{#in-element}}\` on line ${value.loc.start.line}.`,
             value.loc


### PR DESCRIPTION
I was using it for some preprocessing, and then it broke at the end when glimmer was parsing the final template (only if it had in-element)