### PR TITLE
Simplify `SimpleDOM` casting (allow for proper production mode stripping)

### DIFF
--- a/build/broccoli/strip-glimmer-utilities.js
+++ b/build/broccoli/strip-glimmer-utilities.js
@@ -25,7 +25,13 @@ module.exports = function (jsTree) {
     getModuleId: nameResolver,
     plugins: [
       ...glimmerUtils,
-      [stripGlimmerUtils, { bindings: ['cast', 'expect', 'unwrap'], source: '@glimmer/util' }],
+      [
+        stripGlimmerUtils,
+        {
+          bindings: ['expect', 'unwrap', 'castToSimple', 'castToBrowser'],
+          source: '@glimmer/util',
+        },
+      ],
     ],
   });
 };

--- a/packages/@glimmer/benchmark-env/src/benchmark/on-modifier.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/on-modifier.ts
@@ -1,6 +1,6 @@
 import { ModifierManager, VMArguments } from '@glimmer/interfaces';
 import { Reference, valueForRef } from '@glimmer/reference';
-import { cast } from '@glimmer/util';
+import { castToBrowser } from '@glimmer/util';
 import { createUpdatableTag } from '@glimmer/validator';
 import { SimpleElement } from '@simple-dom/interface';
 
@@ -30,13 +30,13 @@ class OnModifierManager implements ModifierManager<OnModifierState, null> {
   install(state: OnModifierState) {
     const name = valueForRef(state.nameRef);
     const listener = valueForRef(state.listenerRef);
-    cast(state.element, 'ELEMENT').addEventListener(name, listener);
+    castToBrowser(state.element, 'ELEMENT').addEventListener(name, listener);
     state.listener = listener;
     state.name = name;
   }
 
   update(state: OnModifierState) {
-    const element = cast(state.element, 'ELEMENT');
+    const element = castToBrowser(state.element, 'ELEMENT');
     const name = valueForRef(state.nameRef);
     const listener = valueForRef(state.listenerRef);
     if (name !== state.name || listener !== state.listener) {

--- a/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
@@ -26,7 +26,7 @@ import {
   runtimeContext,
 } from '@glimmer/runtime';
 import { ASTPluginBuilder } from '@glimmer/syntax';
-import { assign, cast, unwrapTemplate } from '@glimmer/util';
+import { assign, castToBrowser, castToSimple, unwrapTemplate } from '@glimmer/util';
 import {
   ElementNamespace,
   SimpleDocument,
@@ -95,7 +95,7 @@ export class JitRenderDelegate implements RenderDelegate {
   private env: EnvironmentDelegate;
 
   constructor(options?: RenderDelegateOptions) {
-    this.doc = options?.doc ?? cast(document).simple;
+    this.doc = options?.doc ?? castToSimple(document);
     this.env = assign(options?.env ?? {}, BaseEnv);
     this.context = this.getContext();
   }
@@ -106,7 +106,7 @@ export class JitRenderDelegate implements RenderDelegate {
 
   getInitialElement(): SimpleElement {
     if (isBrowserTestDocument(this.doc)) {
-      return cast(this.doc).getElementById('qunit-fixture');
+      return castToSimple(castToBrowser(this.doc).getElementById('qunit-fixture')!);
     } else {
       return this.createElement('div');
     }

--- a/packages/@glimmer/integration-tests/lib/modes/rehydration/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/rehydration/delegate.ts
@@ -38,7 +38,7 @@ import { renderTemplate } from '../jit/render';
 import TestJitRuntimeResolver from '../jit/resolver';
 import { debugRehydration, DebugRehydrationBuilder } from './builder';
 import { BaseEnv } from '../env';
-import { assign, cast } from '@glimmer/util';
+import { assign, castToSimple } from '@glimmer/util';
 
 export interface RehydrationStats {
   clearedNodes: SimpleNode[];
@@ -69,7 +69,7 @@ export class RehydrationDelegate implements RenderDelegate {
   constructor(options?: RenderDelegateOptions) {
     let delegate = assign(options?.env ?? {}, BaseEnv);
 
-    this.clientDoc = cast(document).simple;
+    this.clientDoc = castToSimple(document);
     this.clientResolver = new TestJitRuntimeResolver();
     this.clientRegistry = this.clientResolver.registry;
     this.clientEnv = JitDelegateContext(
@@ -227,5 +227,5 @@ export class RehydrationDelegate implements RenderDelegate {
 }
 
 export function qunitFixture(): SimpleElement {
-  return cast(document).getElementById('qunit-fixture');
+  return castToSimple(document.getElementById('qunit-fixture')!);
 }

--- a/packages/@glimmer/integration-tests/lib/snapshot.ts
+++ b/packages/@glimmer/integration-tests/lib/snapshot.ts
@@ -2,7 +2,7 @@ import { SimpleNode, NodeType, SimpleElement } from '@simple-dom/interface';
 import { Option } from '@glimmer/interfaces';
 import { replaceHTML, toInnerHTML } from './dom/simple-utils';
 import { tokenize, EndTag, Token } from 'simple-html-tokenizer';
-import { cast } from '@glimmer/util';
+import { castToSimple } from '@glimmer/util';
 
 export type IndividualSnapshot = 'up' | 'down' | SimpleNode;
 export type NodesSnapshot = IndividualSnapshot[];
@@ -87,7 +87,7 @@ export function generateSnapshot(element: SimpleElement): SimpleNode[] {
 function generateTokens(divOrHTML: SimpleElement | string): { tokens: Token[]; html: string } {
   let div: SimpleElement;
   if (typeof divOrHTML === 'string') {
-    div = cast(document).createElement('div');
+    div = castToSimple(document.createElement('div'));
     replaceHTML(div, divOrHTML);
   } else {
     div = divOrHTML;

--- a/packages/@glimmer/integration-tests/lib/suites/entry-point.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/entry-point.ts
@@ -1,6 +1,6 @@
 import { DynamicScopeImpl } from '@glimmer/runtime';
 import { createPrimitiveRef } from '@glimmer/reference';
-import { cast } from '@glimmer/util';
+import { castToBrowser } from '@glimmer/util';
 import { RenderTest, Count } from '../render-test';
 import { ComponentKind } from '../components/types';
 import { test } from '../test-decorator';
@@ -22,7 +22,7 @@ export class EntryPointTest extends RenderTest {
     let title = createPrimitiveRef('renderComponent');
     delegate.renderComponent('Title', { title }, element);
 
-    QUnit.assert.equal(cast(element, 'HTML').innerHTML, '<h1>hello renderComponent</h1>');
+    QUnit.assert.equal(castToBrowser(element, 'HTML').innerHTML, '<h1>hello renderComponent</h1>');
   }
 
   @test
@@ -33,12 +33,12 @@ export class EntryPointTest extends RenderTest {
     let element = delegate.getInitialElement();
     let title = createPrimitiveRef('renderComponent');
     delegate.renderComponent('Title', { title }, element);
-    QUnit.assert.equal(cast(element, 'HTML').innerHTML, '<h1>hello renderComponent</h1>');
+    QUnit.assert.equal(castToBrowser(element, 'HTML').innerHTML, '<h1>hello renderComponent</h1>');
 
     element = delegate.getInitialElement();
     let newTitle = createPrimitiveRef('new title');
     delegate.renderComponent('Title', { title: newTitle }, element);
-    QUnit.assert.equal(cast(element, 'HTML').innerHTML, '<h1>hello new title</h1>');
+    QUnit.assert.equal(castToBrowser(element, 'HTML').innerHTML, '<h1>hello new title</h1>');
   }
 
   @test
@@ -50,12 +50,12 @@ export class EntryPointTest extends RenderTest {
     let element = delegate.getInitialElement();
     let title = createPrimitiveRef('renderComponent');
     delegate.renderComponent('Title', { title }, element);
-    QUnit.assert.equal(cast(element, 'HTML').innerHTML, '<h1>hello renderComponent</h1>');
+    QUnit.assert.equal(castToBrowser(element, 'HTML').innerHTML, '<h1>hello renderComponent</h1>');
 
     element = delegate.getInitialElement();
     let body = createPrimitiveRef('text');
     delegate.renderComponent('Body', { body }, element);
-    QUnit.assert.equal(cast(element, 'HTML').innerHTML, '<p>body text</p>');
+    QUnit.assert.equal(castToBrowser(element, 'HTML').innerHTML, '<p>body text</p>');
   }
 
   @test
@@ -69,6 +69,6 @@ export class EntryPointTest extends RenderTest {
     });
     delegate.renderComponent('Locale', {}, element, dynamicScope);
 
-    QUnit.assert.equal(cast(element, 'HTML').innerHTML, 'en_US');
+    QUnit.assert.equal(castToBrowser(element, 'HTML').innerHTML, 'en_US');
   }
 }

--- a/packages/@glimmer/integration-tests/lib/suites/initial-render.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/initial-render.ts
@@ -1,7 +1,7 @@
 import { Namespace, SimpleElement } from '@simple-dom/interface';
 import { RenderTest } from '../render-test';
 import { test } from '../test-decorator';
-import { cast, strip, unwrap } from '@glimmer/util';
+import { castToBrowser, checkNode, strip, unwrap } from '@glimmer/util';
 import { firstElementChild, getElementsByTagName } from '../dom/simple-utils';
 import { assertNodeTagName } from '../dom/assertions';
 
@@ -414,7 +414,7 @@ export class InitialRenderSuite extends RenderTest {
       </select>
     `);
 
-    let selectNode = cast(this.element, 'HTML').checkFirstElementChild('select');
+    let selectNode = checkNode(castToBrowser(this.element, 'HTML').firstElementChild, 'select');
     this.assert.equal(selectNode.selectedIndex, 1);
     this.assertStableRerender();
 
@@ -427,7 +427,7 @@ export class InitialRenderSuite extends RenderTest {
       </select>
     `);
 
-    selectNode = cast(this.element, 'HTML').checkFirstElementChild('select');
+    selectNode = checkNode(castToBrowser(this.element, 'HTML').firstElementChild, 'select');
 
     this.assert.equal(selectNode.selectedIndex, 0);
 
@@ -443,7 +443,7 @@ export class InitialRenderSuite extends RenderTest {
       </select>
     `);
 
-    selectNode = cast(this.element, 'HTML').checkFirstElementChild('select');
+    selectNode = checkNode(castToBrowser(this.element, 'HTML').firstElementChild, 'select');
 
     this.assert.equal(selectNode.selectedIndex, 0);
 
@@ -458,7 +458,7 @@ export class InitialRenderSuite extends RenderTest {
       </select>
     `);
 
-    selectNode = cast(this.element, 'HTML').checkFirstElementChild('select');
+    selectNode = checkNode(castToBrowser(this.element, 'HTML').firstElementChild, 'select');
     this.assert.equal(selectNode.selectedIndex, 1);
     this.assertStableNodes();
   }
@@ -510,8 +510,16 @@ export class InitialRenderSuite extends RenderTest {
       </select>`);
 
     this.assert.equal(selected.length, 2, 'two options are selected');
-    this.assert.equal(cast(selected[0], 'option').node.value, '1', 'first selected item is "1"');
-    this.assert.equal(cast(selected[1], 'option').node.value, '2', 'second selected item is "2"');
+    this.assert.equal(
+      castToBrowser(selected[0], 'option').value,
+      '1',
+      'first selected item is "1"'
+    );
+    this.assert.equal(
+      castToBrowser(selected[1], 'option').value,
+      '2',
+      'second selected item is "2"'
+    );
   }
 
   @test
@@ -690,19 +698,19 @@ export class InitialRenderSuite extends RenderTest {
     this.assertHTML('<svg></svg><svg></svg><div></div>');
 
     this.assert.equal(
-      cast(unwrap(this.element.childNodes[0]), 'SVG').namespaceURI,
+      castToBrowser(unwrap(this.element.childNodes[0]), 'SVG').namespaceURI,
       Namespace.SVG,
       'creates the first svg element with a namespace'
     );
 
     this.assert.equal(
-      cast(this.element.childNodes[1], 'SVG').namespaceURI,
+      castToBrowser(this.element.childNodes[1], 'SVG').namespaceURI,
       Namespace.SVG,
       'creates the second svg element with a namespace'
     );
 
     this.assert.equal(
-      cast(this.element.childNodes[2], 'HTML').namespaceURI,
+      castToBrowser(this.element.childNodes[2], 'HTML').namespaceURI,
       XHTML_NAMESPACE,
       'creates the div element without a namespace'
     );

--- a/packages/@glimmer/integration-tests/test/chaos-rehydration-test.ts
+++ b/packages/@glimmer/integration-tests/test/chaos-rehydration-test.ts
@@ -1,5 +1,5 @@
 import { Dict, Option } from '@glimmer/interfaces';
-import { cast, expect } from '@glimmer/util';
+import { castToBrowser, expect } from '@glimmer/util';
 import { NodeType, SimpleElement } from '@simple-dom/interface';
 import {
   blockStack,
@@ -92,7 +92,7 @@ class ChaosMonkeyRehydration extends RenderTest {
   }
 
   wreakHavoc(iteration = 0, shouldLog = false) {
-    let element = cast(this.element, 'HTML');
+    let element = castToBrowser(this.element, 'HTML');
 
     let original = element.innerHTML;
 
@@ -110,7 +110,7 @@ class ChaosMonkeyRehydration extends RenderTest {
     }
 
     // gather all the nodes recursively
-    let nodes: Node[] = collectChildNodes([], element.node);
+    let nodes: Node[] = collectChildNodes([], element);
 
     // cannot remove the first node, that is what makes it rehydrateable
     nodes = nodes.slice(1);
@@ -129,7 +129,7 @@ class ChaosMonkeyRehydration extends RenderTest {
         removedNodeDisplay = `<!--${nodeToRemove.nodeValue}-->`;
         break;
       case NodeType.ELEMENT_NODE:
-        removedNodeDisplay = cast(nodeToRemove, ['HTML', 'SVG']).outerHTML;
+        removedNodeDisplay = castToBrowser(nodeToRemove, ['HTML', 'SVG']).outerHTML;
         break;
       default:
         removedNodeDisplay = nodeToRemove.nodeValue;
@@ -149,7 +149,7 @@ class ChaosMonkeyRehydration extends RenderTest {
   }
 
   runIterations(template: string, context: Dict<unknown>, expectedHTML: string, count: number) {
-    let element = cast(this.element, 'HTML');
+    let element = castToBrowser(this.element, 'HTML');
     let elementResetValue = element.innerHTML;
 
     let urlParams = (QUnit as any).urlParams as Dict<string>;
@@ -160,7 +160,7 @@ class ChaosMonkeyRehydration extends RenderTest {
 
       this.renderClientSide(template, context);
 
-      let element = cast(this.element, 'HTML');
+      let element = castToBrowser(this.element, 'HTML');
       this.assert.equal(element.innerHTML, expectedHTML);
     } else {
       for (let i = 0; i < count; i++) {
@@ -172,7 +172,7 @@ class ChaosMonkeyRehydration extends RenderTest {
 
           this.renderClientSide(template, context);
 
-          let element = cast(this.element, 'HTML');
+          let element = castToBrowser(this.element, 'HTML');
           this.assert.equal(
             element.innerHTML,
             expectedHTML,

--- a/packages/@glimmer/integration-tests/test/env-test.ts
+++ b/packages/@glimmer/integration-tests/test/env-test.ts
@@ -1,11 +1,11 @@
-import { cast } from '@glimmer/util';
+import { castToSimple } from '@glimmer/util';
 import { EnvironmentImpl } from '@glimmer/runtime';
 
 QUnit.module('[integration] env');
 
 QUnit.test('assert against nested transactions', (assert) => {
   let env = new EnvironmentImpl(
-    { document: cast(document).simple },
+    { document: castToSimple(document) },
     {
       onTransactionBegin() {},
       onTransactionCommit() {},
@@ -22,7 +22,7 @@ QUnit.test('assert against nested transactions', (assert) => {
 
 QUnit.test('ensure commit cleans up when it can', (assert) => {
   let env = new EnvironmentImpl(
-    { document: cast(document).simple },
+    { document: castToSimple(document) },
     {
       onTransactionBegin() {},
       onTransactionCommit() {},

--- a/packages/@glimmer/integration-tests/test/i-n-u-r-test.ts
+++ b/packages/@glimmer/integration-tests/test/i-n-u-r-test.ts
@@ -1,9 +1,9 @@
-import { cast } from '@glimmer/util';
+import { castToSimple } from '@glimmer/util';
 import { JitRenderDelegate, RenderTest } from '..';
 import { module } from './support';
 
 module('Render Tests: I-N-U-R', ({ test }) => {
-  let doc = cast(document).simple;
+  let doc = castToSimple(document);
 
   test('Can set properties', (assert) => {
     new (class extends RenderTest {

--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -1,6 +1,6 @@
 import { Dict, Option } from '@glimmer/interfaces';
 import { SafeString } from '@glimmer/runtime';
-import { cast, expect } from '@glimmer/util';
+import { castToBrowser, expect } from '@glimmer/util';
 import { SimpleElement } from '@simple-dom/interface';
 import {
   assertElement,
@@ -209,7 +209,7 @@ class Rehydration extends AbstractRehydrationTests {
     );
 
     // remove the first `<!--%-b:1%-->`
-    let element = cast(this.element, 'HTML');
+    let element = castToBrowser(this.element, 'HTML');
     let [div] = element.children;
     let commentToRemove = div.childNodes[3];
     div.removeChild(commentToRemove);
@@ -324,7 +324,7 @@ class Rehydration extends AbstractRehydrationTests {
     this.assertServerOutput('<div data-foo="true"></div>');
 
     // remove the attribute
-    let element = cast(this.element, 'HTML');
+    let element = castToBrowser(this.element, 'HTML');
     let [div] = element.children;
     div.removeAttribute('data-foo');
 
@@ -341,7 +341,7 @@ class Rehydration extends AbstractRehydrationTests {
     this.assertServerOutput('<div data-foo="true"></div>');
 
     // add an extra attribute
-    let element = cast(this.element, 'HTML');
+    let element = castToBrowser(this.element, 'HTML');
     let [div] = element.children;
     div.setAttribute('data-bar', 'oops');
 
@@ -358,7 +358,7 @@ class Rehydration extends AbstractRehydrationTests {
     this.assertServerOutput('<div class="always-present show-me"></div>');
 
     // mutate the attribute
-    let element = cast(this.element, 'HTML');
+    let element = castToBrowser(this.element, 'HTML');
     let [div] = element.children;
     div.setAttribute('class', 'zomg');
 
@@ -372,7 +372,7 @@ class Rehydration extends AbstractRehydrationTests {
   'does not mutate attributes that already match'() {
     let observer = new MutationObserver((mutationList) => {
       mutationList.forEach((mutation) => {
-        let target = cast(mutation.target, 'HTML');
+        let target = castToBrowser(mutation.target, 'HTML');
         this.assert.ok(
           false,
           `should not have updated ${mutation.attributeName} on ${target.outerHTML}`
@@ -384,7 +384,7 @@ class Rehydration extends AbstractRehydrationTests {
     this.renderServerSide(template, {});
     this.assertServerOutput('<div data-foo="whatever"></div>');
 
-    observer.observe(cast(this.element, 'HTML').node, { attributes: true, subtree: true });
+    observer.observe(castToBrowser(this.element, 'HTML'), { attributes: true, subtree: true });
 
     this.renderClientSide(template, {});
     this.assertRehydrationStats({ nodesRemoved: 0 });

--- a/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/@glimmer/runtime/lib/compat/svg-inner-html-fix.ts
@@ -1,5 +1,5 @@
 import { Bounds } from '@glimmer/interfaces';
-import { assert, cast, clearElement, Option, unwrap } from '@glimmer/util';
+import { assert, castToBrowser, clearElement, Option, unwrap } from '@glimmer/util';
 import {
   InsertPosition,
   Namespace,
@@ -98,7 +98,7 @@ function shouldApplyFix(document: SimpleDocument, svgNamespace: SVG_NAMESPACE) {
     // FF: Old versions will create a node in the wrong namespace
     if (
       svg.childNodes.length === 1 &&
-      cast(unwrap(svg.firstChild), 'SVG').namespaceURI === SVG_NAMESPACE
+      castToBrowser(unwrap(svg.firstChild), 'SVG').namespaceURI === SVG_NAMESPACE
     ) {
       // The test worked as expected, no fix required
       return false;

--- a/packages/@glimmer/runtime/lib/dom/helper.ts
+++ b/packages/@glimmer/runtime/lib/dom/helper.ts
@@ -1,5 +1,5 @@
 import { GlimmerTreeChanges, GlimmerTreeConstruction } from '@glimmer/interfaces';
-import { cast, Option } from '@glimmer/util';
+import { castToSimple, Option } from '@glimmer/util';
 import {
   AttrNamespace,
   ElementNamespace,
@@ -61,7 +61,7 @@ import { BLACKLIST_TABLE, DOMOperations } from './operations';
 
 const WHITESPACE = /[\t-\r \xA0\u1680\u180E\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]/;
 
-let doc: Option<SimpleDocument> = typeof document === 'undefined' ? null : cast(document).simple;
+let doc: Option<SimpleDocument> = typeof document === 'undefined' ? null : castToSimple(document);
 
 export function isWhitespace(string: string) {
   return WHITESPACE.test(string);

--- a/packages/@glimmer/runtime/lib/vm/attributes/dynamic.ts
+++ b/packages/@glimmer/runtime/lib/vm/attributes/dynamic.ts
@@ -12,7 +12,7 @@ import { normalizeStringValue } from '../../dom/normalize';
 import { normalizeProperty } from '../../dom/props';
 import { requiresSanitization, sanitizeAttributeValue } from '../../dom/sanitized-values';
 import { DEBUG } from '@glimmer/env';
-import { cast } from '@glimmer/util';
+import { castToBrowser } from '@glimmer/util';
 
 export function dynamicAttribute(
   element: SimpleElement,
@@ -173,11 +173,11 @@ export class InputValueDynamicAttribute extends DefaultDynamicProperty {
   }
 
   update(value: unknown) {
-    let input = cast(this.attribute.element, ['input', 'textarea']);
-    let currentValue = input.node.value;
+    let input = castToBrowser(this.attribute.element, ['input', 'textarea']);
+    let currentValue = input.value;
     let normalizedValue = normalizeStringValue(value);
     if (currentValue !== normalizedValue) {
-      input.node.value = normalizedValue;
+      input.value = normalizedValue;
     }
   }
 }
@@ -190,12 +190,12 @@ export class OptionSelectedDynamicAttribute extends DefaultDynamicProperty {
   }
 
   update(value: unknown): void {
-    let option = cast(this.attribute.element, 'option');
+    let option = castToBrowser(this.attribute.element, 'option');
 
     if (value) {
-      option.node.selected = true;
+      option.selected = true;
     } else {
-      option.node.selected = false;
+      option.selected = false;
     }
   }
 }

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -1,5 +1,5 @@
 import { Bounds, ElementBuilder, Environment, Option } from '@glimmer/interfaces';
-import { assert, cast, expect, Maybe, Stack } from '@glimmer/util';
+import { assert, castToBrowser, castToSimple, expect, Maybe, Stack } from '@glimmer/util';
 import {
   AttrNamespace,
   Namespace,
@@ -413,7 +413,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
   getMarker(element: HTMLElement, guid: string): Option<SimpleNode> {
     let marker = element.querySelector(`script[glmr="${guid}"]`);
     if (marker) {
-      return cast(marker, 'NODE').simple;
+      return castToSimple(marker);
     }
     return null;
   }
@@ -423,7 +423,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     cursorId: string,
     insertBefore: Maybe<SimpleNode>
   ): Option<RemoteLiveBlock> {
-    let marker = this.getMarker(cast(element, 'HTML').node, cursorId);
+    let marker = this.getMarker(castToBrowser(element, 'HTML'), cursorId);
 
     assert(
       !marker || marker.parentNode === element,

--- a/packages/@glimmer/util/index.ts
+++ b/packages/@glimmer/util/index.ts
@@ -13,7 +13,7 @@ export * from './lib/string';
 export * from './lib/immediate';
 export * from './lib/template';
 export { default as _WeakSet } from './lib/weak-set';
-export { cast } from './lib/simple-cast';
+export { castToSimple, castToBrowser, checkNode } from './lib/simple-cast';
 
 export { default as debugToString } from './lib/debug-to-string';
 export { beginTestSteps, endTestSteps, logStep, verifySteps } from './lib/debug-steps';

--- a/packages/@glimmer/util/lib/simple-cast.ts
+++ b/packages/@glimmer/util/lib/simple-cast.ts
@@ -1,139 +1,5 @@
 import { unreachable } from './platform-utils';
-import {
-  Namespace,
-  NodeType,
-  SimpleDocument,
-  SimpleElement,
-  SimpleNode,
-} from '@simple-dom/interface';
-
-/**
- * This class is used to return a result from casting when only a simple
- * node is available.
- */
-class SimpleNodeUtils<S extends SimpleNode = SimpleNode> {
-  constructor(readonly simple: S) {}
-}
-
-/**
- * The base class for DOM nodes that were already validated as browser DOM nodes
- */
-class BrowserNodeUtils<B extends BrowserNode = BrowserNode, S extends SimpleNode = SimpleNode> {
-  constructor(readonly node: B) {}
-
-  /**
-   * Return the backing node as an equivalent SimpleNode
-   */
-  get simple(): S {
-    return (this.node as unknown) as S;
-  }
-}
-
-/**
- * This class provides utilities for interacting with an Element that was
- * already validated as a browser Element.
- */
-class BrowserElementUtils<E extends Element, S extends SimpleElement> extends BrowserNodeUtils<
-  E,
-  S
-> {
-  /**
-   * Get the DOM namespace for the backing element.
-   *
-   * @see {Namespace}
-   */
-  get namespaceURI(): Namespace | null {
-    return this.node.namespaceURI as Namespace | null;
-  }
-
-  /**
-   * Get the outerHTML for the backing element
-   */
-  get outerHTML(): string {
-    return this.node.outerHTML;
-  }
-
-  /**
-   * Get the `innerHTML` for the backing element
-   */
-  get innerHTML(): string {
-    return this.node.innerHTML;
-  }
-
-  /**
-   * Set the `innerHTML` for the backing element
-   */
-  set innerHTML(value: string) {
-    this.node.innerHTML = value;
-  }
-
-  /**
-   * Get the child elements for the backing element
-   */
-  get children(): Iterable<Element> {
-    return (this.node.children as unknown) as Iterable<Element>;
-  }
-
-  /**
-   * Add an event listener to the backing element
-   */
-  addEventListener(event: string, handler: EventListener): void {
-    this.node.addEventListener(event, handler);
-  }
-
-  /**
-   * Remove an event listener from the backing element
-   */
-  removeEventListener(event: string, handler: EventListener): void {
-    this.node.removeEventListener(event, handler);
-  }
-
-  /**
-   * @access test
-   *
-   * Get the first element child, apply an optional check, and return it as a
-   * `BrowserNode`. This should only be used in tests, so that these utilities
-   * can be stripped out in production.
-   */
-  checkFirstElementChild<S extends SugaryNodeCheck>(sugaryCheck?: S): NodeForSugaryCheck<S> {
-    let first = this.node.firstElementChild;
-
-    if (first === null) {
-      throw new Error(`firstElementChild unexpectedly returned null`);
-    }
-
-    if (sugaryCheck) {
-      let check = checkFor(sugaryCheck);
-      if (check(first)) {
-        return first as NodeForSugaryCheck<S>;
-      } else {
-        throw new Error(`firstElementChild didn't pass the check`);
-      }
-    } else {
-      return first as NodeForSugaryCheck<S>;
-    }
-  }
-}
-
-/**
- * This class provides utilities for interacting with a Document that was already
- * validated as a browser Document.
- */
-class BrowserDocumentUtils extends BrowserNodeUtils<Document, SimpleDocument> {
-  createElement(tag: string): SimpleElement {
-    return cast(this.node.createElement(tag), 'ELEMENT').simple;
-  }
-
-  getElementById(id: string): SimpleElement {
-    let queried = this.node.getElementById(id);
-
-    if (queried === null) {
-      throw new Error(`element #${id} was not found`);
-    } else {
-      return cast(queried, 'ELEMENT').simple;
-    }
-  }
-}
+import { NodeType, SimpleDocument, SimpleElement, SimpleNode } from '@simple-dom/interface';
 
 interface GenericElementTags {
   HTML: HTMLElement;
@@ -165,75 +31,66 @@ type NodeForSugaryCheck<S extends SugaryNodeCheck<BrowserTag>> = S extends NodeC
 
 type BrowserNode = Element | Document | DocumentFragment | Text | Comment | Node;
 
-// If it's a browser Document, return BrowserDocumentUtils
-export function cast<S extends SugaryNodeCheck<BrowserElementTag>>(
-  node: Document
-): BrowserDocumentUtils;
-// But if it's possibly a SimpleDocument, return SimpleNodeUtils
-export function cast<S extends SugaryNodeCheck<BrowserElementTag>>(
-  node: SimpleDocument | Document
-): SimpleNodeUtils<SimpleDocument>;
-// If it's definitely a browser Element, return a generic BrowserElementUtils
-export function cast(element: Element): BrowserElementUtils<Element, SimpleElement>;
-// If it's possibly a SimpleElement, return a SimpleNodeUtils for SimpleElement
-export function cast(element: Element | SimpleElement): SimpleNodeUtils<SimpleElement>;
+export function castToSimple(doc: Document | SimpleDocument): SimpleDocument;
+export function castToSimple(elem: Element | SimpleElement): SimpleElement;
+export function castToSimple(node: Node | SimpleNode): SimpleNode;
+export function castToSimple(
+  node: Document | Element | Node | SimpleDocument | SimpleElement | SimpleNode
+) {
+  if (isDocument(node)) {
+    return node as SimpleDocument;
+  } else if (isElement(node)) {
+    return node as SimpleElement;
+  } else {
+    return node as SimpleNode;
+  }
+}
+
+// If passed a document, verify we're in the browser and return it as a Document
+export function castToBrowser(doc: Document | SimpleDocument): Document;
 // If we don't know what this is, but the check requires it to be an element,
-// the cast will mandate that it's a browser element and return a
-// BrowserElementUtils corresponding to the check
-export function cast<S extends SugaryNodeCheck<BrowserElementTag>>(
+// the cast will mandate that it's a browser element
+export function castToBrowser<S extends SugaryNodeCheck<BrowserElementTag>>(
   node: BrowserNode | SimpleNode,
   check: S
-): BrowserElementUtils<NodeForSugaryCheck<S>, SimpleElement>;
+): NodeForSugaryCheck<S>;
 // Finally, if it's a more generic check, the cast will mandate that it's a
 // browser node and return a BrowserNodeUtils corresponding to the check
-export function cast<S extends SugaryNodeCheck<GenericNodeTag>>(
+export function castToBrowser<S extends SugaryNodeCheck<GenericNodeTag>>(
   element: BrowserNode | SimpleNode,
   check: S
-): BrowserNodeUtils<NodeForSugaryCheck<S>>;
-export function cast<K extends keyof HTMLElementTagNameMap>(
+): NodeForSugaryCheck<S>;
+export function castToBrowser<K extends keyof HTMLElementTagNameMap>(
   element: SimpleElement | Element,
   check: K
-): BrowserElementUtils<HTMLElementTagNameMap[K], SimpleElement>;
-export function cast(doc: SimpleDocument | Document): BrowserDocumentUtils;
-export function cast(doc: SimpleNode | Element | Document): BrowserNodeUtils;
-export function cast<S extends SugaryNodeCheck>(
+): HTMLElementTagNameMap[K];
+export function castToBrowser<S extends SugaryNodeCheck>(
   node: SimpleNode | BrowserNode | null | undefined,
   sugaryCheck?: S
-): BrowserNodeUtils | SimpleNodeUtils | null | undefined {
+): Document | NodeForSugaryCheck<S> | null {
   if (node === null || node === undefined) {
     return null;
   }
 
-  if (isDocument(node)) {
-    if ('getElementById' in node) {
-      return new BrowserDocumentUtils(node) as BrowserNodeUtils;
-    } else {
-      return new SimpleNodeUtils(node);
-    }
-  } else if (isElement(node)) {
-    if (isBrowserNode(node)) {
-      if (sugaryCheck) {
-        let check = checkFor(sugaryCheck);
-        if (check(node)) {
-          return new BrowserElementUtils(node) as BrowserNodeUtils;
-        } else {
-          throw checkError(`SimpleElement(${node.tagName})`, 'BrowserElementUtils', sugaryCheck);
-        }
-      } else {
-        return new BrowserElementUtils(node);
-      }
-    } else {
-      return new SimpleNodeUtils(node);
-    }
-  } else if (isBrowserNode(node)) {
-    return new BrowserNodeUtils(node);
-  } else {
-    return new SimpleNodeUtils(node);
+  if (typeof document === undefined) {
+    throw new Error('Attempted to cast to a browser node in a non-browser context');
   }
+
+  if (isDocument(node)) {
+    return node as Document;
+  }
+
+  if (node.ownerDocument !== document) {
+    throw new Error(
+      'Attempted to cast to a browser node with a node that was not created from this document'
+    );
+  }
+
+  return checkNode<S>(node, sugaryCheck!);
 }
 
-function checkError(from: string, to: string, check: SugaryNodeCheck): Error {
-  return new Error(`cannot cast a ${from} into ${to}, because ${checkDesc(check)} failed`);
+function checkError(from: string, check: SugaryNodeCheck): Error {
+  return new Error(`cannot cast a ${from} into ${check}`);
 }
 
 function isDocument(node: Node | SimpleNode | SimpleDocument): node is Document | SimpleDocument {
@@ -244,22 +101,26 @@ function isElement(node: Node | SimpleNode | SimpleElement): node is Element | S
   return node.nodeType === NodeType.ELEMENT_NODE;
 }
 
-function isBrowserNode(node: Node | SimpleNode): node is Node {
-  return typeof document !== undefined && node.ownerDocument === document;
-}
+export function checkNode<S extends SugaryNodeCheck>(
+  node: Node | null,
+  check: S
+): NodeForSugaryCheck<S> {
+  let isMatch = false;
 
-function checkFor<S extends SugaryNodeCheck>(check: S): NodeCheck<NodeForSugaryCheck<S>> {
-  if (typeof check === 'function') {
-    return (el: Node): el is NodeForSugaryCheck<S> =>
-      (check as NodeCheck<BrowserTags[BrowserTag]>)(el);
-  } else if (typeof check === 'string') {
-    return (node: Node): node is NodeForSugaryCheck<S> =>
-      stringCheckNode(node, check as BrowserTag);
-  } else if (Array.isArray(check)) {
-    return (node: Node): node is NodeForSugaryCheck<S> =>
-      check.some((c) => stringCheckNode(node, c as BrowserTag));
+  if (node !== null) {
+    if (typeof check === 'string') {
+      isMatch = stringCheckNode(node, check as BrowserTag);
+    } else if (Array.isArray(check)) {
+      isMatch = check.some((c) => stringCheckNode(node, c as BrowserTag));
+    } else {
+      throw unreachable();
+    }
+  }
+
+  if (isMatch) {
+    return node as NodeForSugaryCheck<S>;
   } else {
-    throw unreachable();
+    throw checkError(`SimpleElement(${node})`, check);
   }
 }
 
@@ -278,15 +139,5 @@ function stringCheckNode<S extends BrowserTag>(node: Node, check: S): node is Br
         throw new Error(`BUG: this code is missing handling for a generic node type`);
       }
       return node instanceof Element && node.tagName.toLowerCase() === check;
-  }
-}
-
-function checkDesc(check: SugaryNodeCheck): string {
-  if (typeof check === 'string') {
-    return `(tagName === ${check})`;
-  } else if (Array.isArray(check)) {
-    return `(tagName in ${check.join(' | ')})`;
-  } else {
-    return `(${check.toString()})`;
   }
 }


### PR DESCRIPTION
The new `cast` function added for the recent TS upgrade has a couple of
issues:

1. It creates wrapping objects which modify the values that are
   wrapped/casted. Removing `cast()`, as the production build currently
   does, breaks because of this.
2. These wrapping objects conflate casting _to_ SimpleDOM and casting
   _away_ from it, into browser APIs.

The new system makes `cast` into two pure validation utility functions,
which either downlevels to SimpleDOM (without any checks, as SimpleDOM
is a subset of the real DOM), or uplevels to DOM with appropriate checks
(e.g. are we actually in the browser? Is the node a DOM node? Is it the
expected type of DOM node?).