### PR TITLE
[BUGFIX] args lost when passed to {{component}}

### DIFF
--- a/packages/@glimmer/integration-tests/lib/suites/emberish-components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/emberish-components.ts
@@ -50,25 +50,37 @@ export class EmberishComponentTests extends RenderTest {
 
   @test({ kind: 'glimmer' })
   'Static block component helper'() {
-    this.registerComponent('Glimmer', 'A', 'A {{#component "B" arg1=@one}}{{/component}}');
-    this.registerComponent('Glimmer', 'B', 'B {{@arg1}}');
-    this.render('<A @one={{arg}} />', { arg: 1 });
-    this.assertHTML('A B 1');
+    this.registerComponent(
+      'Glimmer',
+      'A',
+      'A {{#component "B" arg1=@one arg2=@two arg3=@three}}{{/component}}'
+    );
+    this.registerComponent('Glimmer', 'B', 'B {{@arg1}} {{@arg2}} {{@arg3}}');
+    this.render('<A @one={{first}} @two={{second}} @three={{third}} />', {
+      first: 1,
+      second: 2,
+      third: 3,
+    });
+    this.assertHTML('A B 1 2 3');
     this.assertStableRerender();
-    this.rerender({ arg: 2 });
-    this.assertHTML('A B 2');
+    this.rerender({ first: 2, second: 3, third: 4 });
+    this.assertHTML('A B 2 3 4');
     this.assertStableNodes();
   }
 
   @test({ kind: 'glimmer' })
   'Static inline component helper'() {
-    this.registerComponent('Glimmer', 'A', 'A {{component "B" arg1=@one}}');
-    this.registerComponent('Glimmer', 'B', 'B {{@arg1}}');
-    this.render('<A @one={{arg}} />', { arg: 1 });
-    this.assertHTML('A B 1');
+    this.registerComponent('Glimmer', 'A', 'A {{component "B" arg1=@one arg2=@two arg3=@three}}');
+    this.registerComponent('Glimmer', 'B', 'B {{@arg1}} {{@arg2}} {{@arg3}}');
+    this.render('<A @one={{first}} @two={{second}} @three={{third}} />', {
+      first: 1,
+      second: 2,
+      third: 3,
+    });
+    this.assertHTML('A B 1 2 3');
     this.assertStableRerender();
-    this.rerender({ arg: 2 });
-    this.assertHTML('A B 2');
+    this.rerender({ first: 2, second: 3, third: 4 });
+    this.assertHTML('A B 2 3 4');
     this.assertStableNodes();
   }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
@@ -95,8 +95,8 @@ export function StaticComponentHelper(
 
     if (compilable) {
       if (hash) {
-        for (let i = 0; i < hash.length; i = i + 2) {
-          hash[i][0] = `@${hash[i][0]}`;
+        for (let i = 0; i < hash[0].length; i = i + 1) {
+          hash[0][i] = `@${hash[0][i]}`;
         }
       }
 


### PR DESCRIPTION
As reported by @samselikoff  in emberjs/ember.js#19061,
arguments passed to {{component}} helper, except for the first one, are ignored.

Component
```hbs
{{component "reproduce" one="first" two="second" three="third" four="fourth"}}
```
Resulted in 
```js
hash = [["@one", "two", "three"], ["first", "second", "third"]]
```
instead of
```js
hash = [["@one", "@two", "@three"], ["first", "second", "third"]]
```