### PR TITLE
Add test confirming parsing + printing `{{#in-element` is safe.

### DIFF
--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -20,6 +20,7 @@ let templates = [
   '<Foo></Foo>',
   '<Foo />',
   '<Foo as |bar|>{{bar}}</Foo>',
+  '{{#in-element this.someElement}}Content here{{/in-element}}',
 
   // void elements
   '<br>',


### PR DESCRIPTION
Closes https://github.com/glimmerjs/glimmer-vm/pull/1159