### PR TITLE
Update simple-html-tokenizer and use its codemod mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@simple-dom/void-map": "^1.4.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "fs-extra": "^9.0.0",
-    "simple-html-tokenizer": "^0.5.9",
+    "simple-html-tokenizer": "^0.5.10",
     "symlink-or-copy": "^1.3.1"
   },
   "devDependencies": {

--- a/packages/@glimmer/integration-tests/package.json
+++ b/packages/@glimmer/integration-tests/package.json
@@ -21,7 +21,7 @@
     "@simple-dom/interface": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0",
-    "simple-html-tokenizer": "^0.5.9"
+    "simple-html-tokenizer": "^0.5.10"
   },
   "devDependencies": {
     "@types/qunit": "^2.9.0"

--- a/packages/@glimmer/syntax/lib/parser.ts
+++ b/packages/@glimmer/syntax/lib/parser.ts
@@ -39,9 +39,13 @@ export abstract class Parser {
   > = null;
   public tokenizer: EventedTokenizer;
 
-  constructor(source: string, entityParser = new EntityParser(namedCharRefs)) {
+  constructor(
+    source: string,
+    entityParser = new EntityParser(namedCharRefs),
+    mode: 'precompile' | 'codemod' = 'precompile'
+  ) {
     this.source = source.split(/(?:\r\n?|\n)/g);
-    this.tokenizer = new EventedTokenizer(this, entityParser);
+    this.tokenizer = new EventedTokenizer(this, entityParser, mode);
   }
 
   abstract Program(node: HBS.Program): HBS.Output<'Program'>;

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -396,7 +396,7 @@ export function preprocess(html: string, options: PreprocessOptions = {}): AST.T
     entityParser = new EntityParser({});
   }
 
-  let program = new TokenizerEventHandlers(html, entityParser).acceptTemplate(ast);
+  let program = new TokenizerEventHandlers(html, entityParser, mode).acceptTemplate(ast);
 
   if (options && options.plugins && options.plugins.ast) {
     for (let i = 0, l = options.plugins.ast.length; i < l; i++) {

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -6,7 +6,7 @@
     "@glimmer/interfaces": "0.62.2",
     "@glimmer/util": "0.62.2",
     "@handlebars/parser": "^1.1.0",
-    "simple-html-tokenizer": "^0.5.9"
+    "simple-html-tokenizer": "^0.5.10"
   },
   "devDependencies": {
     "@glimmer/local-debug-flags": "0.62.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7806,10 +7806,10 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.1:
   dependencies:
     debug "^2.2.0"
 
-simple-html-tokenizer@^0.5.9:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.9.tgz#1a83fe97f5a3e39b335fddf71cfe9b0263b581c2"
-  integrity sha512-w/3FEDN94r4JQ9WoYrIr8RqDIPZdyNkdpbK9glFady1CAEyD97XWCv8HFetQO21w81e7h7Nh59iYTyG1mUJftg==
+simple-html-tokenizer@^0.5.10, simple-html-tokenizer@^0.5.9:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.10.tgz#0843e4f00c9677f1c81e3dfeefcee0a4aca8e5d0"
+  integrity sha512-1DHMUmvUOGuUZ9/+cX/+hOhWhRD5dEw6lodn8WuV+T+cQ31hhBcCu1dcDsNotowi4mMaNhrLyKoS+DtB81HdDA==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This ensures that source <-> source codemod packages that leverage `@glimmer/syntax` are not accidentally trimming `\n` in the `<pre>` and `<textarea>` contents.