### PR TITLE
Fix splattributes handling of type attribute.

### DIFF
--- a/packages/@glimmer/compiler/lib/template-compiler.ts
+++ b/packages/@glimmer/compiler/lib/template-compiler.ts
@@ -129,8 +129,15 @@ export default class TemplateCompiler implements Processor<InputOps> {
       // TODO: Assert no attributes
       let typeAttr: Option<AST.AttrNode> = null;
       let attrs = action.attributes;
+
       for (let i = 0; i < attrs.length; i++) {
-        if (attrs[i].name === 'type') {
+        // Unlike most attributes, the `type` attribute can change how
+        // subsequent attributes are interpreted by the browser. To address
+        // this, in simple cases, we special case the `type` attribute to be set
+        // last. For elements with splattributes, where attribute order affects
+        // precedence, this re-ordering happens at runtime instead.
+        // See https://github.com/glimmerjs/glimmer-vm/pull/726
+        if (simple && attrs[i].name === 'type') {
           typeAttr = attrs[i];
           continue;
         }

--- a/packages/@glimmer/integration-tests/lib/suites/components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/components.ts
@@ -766,6 +766,16 @@ export class BasicComponents extends RenderTest {
   }
 
   @test({ kind: 'glimmer' })
+  'angle bracket invocation can allow invocation side to override the type attribute with ...attributes'() {
+    this.registerComponent('Glimmer', 'Qux', '<div type="qux" ...attributes />');
+    this.registerComponent('Glimmer', 'Bar', '<Qux type="bar" ...attributes />');
+    this.registerComponent('Glimmer', 'Foo', '<Bar type="foo" ...attributes />');
+
+    this.render('<Foo type="top" />');
+    this.assertHTML('<div type="top"></div>');
+  }
+
+  @test({ kind: 'glimmer' })
   'angle bracket invocation can override invocation side attributes with ...attributes'() {
     this.registerComponent('Glimmer', 'Qux', '<div ...attributes id="qux" />');
     this.registerComponent('Glimmer', 'Bar', '<Qux ...attributes id="bar" />');
@@ -773,6 +783,16 @@ export class BasicComponents extends RenderTest {
 
     this.render('<Foo id="top" />');
     this.assertHTML('<div id="qux"></div>');
+  }
+
+  @test({ kind: 'glimmer' })
+  'angle bracket invocation can override invocation side type attribute with ...attributes'() {
+    this.registerComponent('Glimmer', 'Qux', '<div ...attributes type="qux" />');
+    this.registerComponent('Glimmer', 'Bar', '<Qux ...attributes type="bar" />');
+    this.registerComponent('Glimmer', 'Foo', '<Bar ...attributes type="foo" />');
+
+    this.render('<Foo type="top" />');
+    this.assertHTML('<div type="qux"></div>');
   }
 
   @test({ kind: 'glimmer' })

--- a/packages/@glimmer/integration-tests/test/input-range-test.ts
+++ b/packages/@glimmer/integration-tests/test/input-range-test.ts
@@ -76,26 +76,8 @@ class EmberInputRangeComponent extends EmberishCurlyComponent {
   type = 'range';
 }
 
-abstract class EmberComponentRangeTests extends RangeTests {
-  abstract component(): EmberishCurlyComponentFactory;
-
-  renderRange(value: number): void {
-    this.registerComponent('Curly', 'range-input', '', this.component());
-    this.render(`{{range-input max=max min=min value=value}}`, {
-      max: this.max,
-      min: this.min,
-      value,
-    });
-  }
-
-  assertRangeValue(value: number): void {
-    let attr = (this.element.firstChild as any)['value'];
-    this.assert.equal(attr, value.toString());
-  }
-}
-
 jitSuite(
-  class extends EmberComponentRangeTests {
+  class EmberComponentRangeTests extends RangeTests {
     static suiteName = `Components - [emberjs/ember.js#15675] - type value min max`;
 
     component(): EmberishCurlyComponentFactory {
@@ -103,26 +85,74 @@ jitSuite(
         attributeBindings = ['type', 'value', 'min', 'max'];
       } as any;
     }
+
+    renderRange(value: number): void {
+      this.registerComponent('Curly', 'range-input', '', this.component());
+      this.render(`{{range-input max=max min=min value=value}}`, {
+        max: this.max,
+        min: this.min,
+        value,
+      });
+    }
+
+    assertRangeValue(value: number): void {
+      let attr = (this.element.firstChild as any)['value'];
+      this.assert.equal(attr, value.toString());
+    }
   }
 );
 
-class BasicComponentImplicitAttributesRangeTest extends RangeTests {
-  attrs!: string;
-
-  renderRange(value: number): void {
-    this.registerComponent('Glimmer', 'RangeInput', '<input ...attributes/>');
-    this.render(`<RangeInput ${this.attrs.replace('%x', value.toString())} />`);
-  }
-
-  assertRangeValue(value: number): void {
-    let attr = this.readDOMAttr('value');
-    this.assert.equal(attr, value.toString());
-  }
-}
-
 jitSuite(
-  class extends BasicComponentImplicitAttributesRangeTest {
+  class BasicComponentImplicitAttributesRangeTest extends RangeTests {
     static suiteName = `integration - GlimmerComponent - [emberjs/ember.js#15675] ...attributes <input type="range" value="%x" min="-5" max="50" />`;
     attrs = 'type="range" value="%x" min="-5" max="50"';
+
+    renderRange(value: number): void {
+      this.registerComponent('Glimmer', 'RangeInput', '<input ...attributes/>');
+      this.render(`<RangeInput ${this.attrs.replace('%x', value.toString())} />`);
+    }
+
+    assertRangeValue(value: number): void {
+      let attr = this.readDOMAttr('value');
+      this.assert.equal(attr, value.toString());
+    }
+  }
+);
+
+jitSuite(
+  class BasicComponentSplattributesLastRangeTest extends RangeTests {
+    static suiteName = `integration - GlimmerComponent - [emberjs/ember.js#15675] ...attributes last <input type="range" value="%x" min="-5" max="50" />`;
+    attrs = 'type="range" value="%x" min="-5" max="50"';
+
+    renderRange(value: number): void {
+      this.registerComponent('Glimmer', 'RangeInput', '<input type="text" ...attributes/>');
+      this.render(`<RangeInput ${this.attrs.replace('%x', value.toString())} />`);
+    }
+
+    assertRangeValue(value: number): void {
+      let attr = this.readDOMAttr('value');
+      this.assert.equal(attr, value.toString());
+    }
+  }
+);
+
+jitSuite(
+  class BasicComponentSplattributesFirstRangeTest extends RangeTests {
+    static suiteName = `integration - GlimmerComponent - [emberjs/ember.js#15675] ...attributes first <input type="range" value="%x" min="-5" max="50" />`;
+    attrs = 'type="text" min="-5" max="50"';
+
+    renderRange(value: number): void {
+      this.registerComponent(
+        'Glimmer',
+        'RangeInput',
+        `<input ...attributes type="range" value="${value}" />`
+      );
+      this.render(`<RangeInput ${this.attrs.replace('%x', value.toString())} />`);
+    }
+
+    assertRangeValue(value: number): void {
+      let attr = this.readDOMAttr('value');
+      this.assert.equal(attr, value.toString());
+    }
   }
 );


### PR DESCRIPTION
This PR resolves an issue where a `type` attribute, passed in a component invocation, would not correctly override the `type` attribute in a template when applied with `...attributes`. 

In the existing implementation, we special case the `type` attribute in two places. One is at compile time, when we reorder the `setAttribute` opcodes to apply the `type` attribute last. However, this does not address dynamic cases that are not known at compile time, such as `...attributes` or legacy features such as Ember's `attributeBindings`. A second special case exists in the `ComponentElementOperations` class, which collects aggregate attribute values and applies them once all values are known.

However, currently we do not disable the first special casing when the second will apply. This introduced a bug with `...attributes`, which relies on order to determine attribute precedence. Because we always "moved" the `type` attribute to the last position, values specified in a template could never be overridden by the invocation.

To fix this, we rely on the fact that these cases are mutually exclusive and only apply one or the other. At compile time, if we see `...attributes`, we do not reorder the `type` attribute because we know it will be appropriately re-ordered at runtime.

Closes emberjs/ember.js#18232