### PR TITLE
Adding support for partial rehydration

### DIFF
--- a/packages/@glimmer/integration-tests/index.ts
+++ b/packages/@glimmer/integration-tests/index.ts
@@ -9,6 +9,7 @@ export * from './lib/modes/jit/delegate';
 export * from './lib/modes/jit/register';
 export * from './lib/modes/node/env';
 export * from './lib/modes/rehydration/delegate';
+export * from './lib/modes/rehydration/partial-rehydration-delegate';
 export * from './lib/render-test';
 export * from './lib/snapshot';
 export * from './lib/suites';

--- a/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
@@ -183,20 +183,8 @@ export class TestJitRegistry {
     return {
       handle: definitionHandle,
       capabilities: this.getCapabilities(definitionHandle),
-      compilable: template.asWrappedLayout(),
+      compilable: template.asLayout(),
     };
-
-    // let handle = this.resolver.lookupComponentHandle(name, referrer);
-
-    // if (handle === null) {
-    //   return null;
-    // }
-
-    // return {
-    //   handle,
-    //   capabilities: this.getCapabilities(handle),
-    //   compilable: this.getLayout(handle),
-    // };
   }
 
   resolve<T>(handle: number): T {

--- a/packages/@glimmer/integration-tests/lib/modes/rehydration/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/rehydration/delegate.ts
@@ -56,8 +56,8 @@ export class RehydrationDelegate implements RenderDelegate {
   private clientResolver: TestJitRuntimeResolver;
   private serverResolver: TestJitRuntimeResolver;
 
-  private clientRegistry: TestJitRegistry;
-  private serverRegistry: TestJitRegistry;
+  protected clientRegistry: TestJitRegistry;
+  protected serverRegistry: TestJitRegistry;
 
   public clientDoc: SimpleDocument;
   public serverDoc: SimpleDocument;

--- a/packages/@glimmer/integration-tests/lib/modes/rehydration/partial-rehydration-delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/rehydration/partial-rehydration-delegate.ts
@@ -1,0 +1,73 @@
+import { Dict, ComponentDefinition, RenderResult } from '@glimmer/interfaces';
+import { renderComponent, renderSync } from '@glimmer/runtime';
+import { createConstRef, childRefFor, Reference } from '@glimmer/reference';
+import { RehydrationDelegate } from './delegate';
+import { SimpleElement } from '@simple-dom/interface';
+import { DebugRehydrationBuilder } from './builder';
+
+function dictToReference(dict: Dict<unknown>): Dict<Reference> {
+  const root = createConstRef(dict, 'args');
+
+  return Object.keys(dict).reduce((acc, key) => {
+    acc[key] = childRefFor(root, key);
+    return acc;
+  }, {} as Dict<Reference>);
+}
+
+export class PartialRehydrationDelegate extends RehydrationDelegate {
+  registerBasicComponent(name: string, layout: string) {
+    this.registerComponent('Basic', 'Basic', name, layout);
+  }
+
+  renderComponentClientSide(
+    name: string,
+    args: Dict<unknown>,
+    element: SimpleElement
+  ): RenderResult {
+    let cursor = { element, nextSibling: null };
+    let { syntax, runtime } = this.clientEnv;
+    let builder = this.getElementBuilder(runtime.env, cursor) as DebugRehydrationBuilder;
+    let { handle, compilable } = this.clientRegistry.lookupCompileTimeComponent(name, null)!;
+    let component = this.clientRegistry.resolve<ComponentDefinition>(handle);
+
+    let iterator = renderComponent(
+      runtime,
+      builder,
+      syntax,
+      component,
+      compilable!,
+      dictToReference(args)
+    );
+
+    const result = renderSync(runtime.env, iterator);
+
+    this.rehydrationStats = {
+      clearedNodes: builder.clearedNodes,
+    };
+
+    return result;
+  }
+
+  renderComponentServerSide(name: string, args: Dict<unknown>): string {
+    const element = this.serverDoc.createElement('div');
+    let cursor = { element, nextSibling: null };
+    let { syntax, runtime } = this.serverEnv;
+    let builder = this.getElementBuilder(runtime.env, cursor);
+
+    let { handle, compilable } = this.serverRegistry.lookupCompileTimeComponent(name, null)!;
+    let component = this.serverRegistry.resolve<ComponentDefinition>(handle);
+
+    let iterator = renderComponent(
+      runtime,
+      builder,
+      syntax,
+      component,
+      compilable!,
+      dictToReference(args)
+    );
+
+    renderSync(runtime.env, iterator);
+
+    return this.serialize(element);
+  }
+}

--- a/packages/@glimmer/integration-tests/test/partial-rehydration-test.ts
+++ b/packages/@glimmer/integration-tests/test/partial-rehydration-test.ts
@@ -1,0 +1,77 @@
+import {
+  PartialRehydrationDelegate,
+  test,
+  RenderTest,
+  suite,
+  content,
+  OPEN,
+  CLOSE,
+  replaceHTML,
+  qunitFixture,
+} from '..';
+import { castToSimple } from '@glimmer/util';
+
+export class PartialRehydrationTest extends RenderTest {
+  static suiteName = 'partial rehydration';
+  delegate!: PartialRehydrationDelegate;
+
+  @test
+  'can rehydrate from non starting blocks'() {
+    this.delegate.registerBasicComponent('RehydratingComponent', '{{@a}}{{@b}}{{@c}}');
+
+    this.delegate.registerBasicComponent(
+      'Root',
+      '<div id="placeholder"><RehydratingComponent @a={{@a}} @b={{@b}} @c={{@c}}/></div>'
+    );
+
+    const args = {
+      a: 'a',
+      b: 'b',
+      c: 'c',
+    };
+
+    const html = this.delegate.renderComponentServerSide('Root', args);
+    this.assert.equal(
+      html,
+      content([
+        OPEN,
+        OPEN,
+        '<div id="placeholder">',
+        OPEN,
+        OPEN,
+        'a',
+        CLOSE,
+        OPEN,
+        'b',
+        CLOSE,
+        OPEN,
+        'c',
+        CLOSE,
+        CLOSE,
+        '</div>',
+        CLOSE,
+        CLOSE,
+      ]),
+      'Expect server output to match'
+    );
+
+    replaceHTML(qunitFixture(), html);
+
+    this.element = castToSimple(document.getElementById('placeholder')!);
+    this.renderResult = this.delegate.renderComponentClientSide(
+      'RehydratingComponent',
+      args,
+      this.element
+    );
+    this.element = qunitFixture();
+    this.assertHTML(content([OPEN, OPEN, '<div id="placeholder">abc</div>', CLOSE, CLOSE]));
+    this.assert.ok(
+      this.delegate.rehydrationStats.clearedNodes.length === 0,
+      'No nodes were cleared'
+    );
+    this.assertStableNodes();
+    this.assertStableRerender();
+  }
+}
+
+suite(PartialRehydrationTest, PartialRehydrationDelegate);

--- a/packages/@glimmer/integration-tests/test/partial-rehydration-test.ts
+++ b/packages/@glimmer/integration-tests/test/partial-rehydration-test.ts
@@ -8,6 +8,7 @@ import {
   CLOSE,
   replaceHTML,
   qunitFixture,
+  stripTight,
 } from '..';
 import { castToSimple } from '@glimmer/util';
 
@@ -56,15 +57,131 @@ export class PartialRehydrationTest extends RenderTest {
     );
 
     replaceHTML(qunitFixture(), html);
-
-    this.element = castToSimple(document.getElementById('placeholder')!);
+    this.element = qunitFixture();
     this.renderResult = this.delegate.renderComponentClientSide(
       'RehydratingComponent',
       args,
-      this.element
+      castToSimple(document.getElementById('placeholder')!)
     );
-    this.element = qunitFixture();
     this.assertHTML(content([OPEN, OPEN, '<div id="placeholder">abc</div>', CLOSE, CLOSE]));
+    this.assert.ok(
+      this.delegate.rehydrationStats.clearedNodes.length === 0,
+      'No nodes were cleared'
+    );
+    this.assertStableNodes();
+    this.assertStableRerender();
+  }
+
+  @test
+  'can rehydrate multiple call sites'() {
+    this.delegate.registerBasicComponent('Nav', '{{@title}}');
+    this.delegate.registerBasicComponent('Carousel', '{{@name}}');
+    this.delegate.registerBasicComponent('Header', '<h1>I am a test</h1>');
+
+    this.delegate.registerBasicComponent(
+      'Root',
+      stripTight`
+        <div class="nav-container">
+          <Nav @title={{@nav.title}}/>
+        </div>
+        <Header/>
+        <div class="carousel-container">
+          <Carousel @name={{@carousel.name}}/>
+        </div>
+      `
+    );
+
+    const args = {
+      nav: {
+        title: 'Nav',
+      },
+      carousel: {
+        name: 'Carousel',
+      },
+    };
+
+    const html = this.delegate.renderComponentServerSide('Root', args);
+    this.assert.equal(
+      html,
+      content([
+        OPEN,
+        OPEN,
+        '<div class="nav-container">',
+        OPEN,
+        OPEN,
+        'Nav',
+        CLOSE,
+        CLOSE,
+        '</div>',
+        OPEN,
+        '<h1>I am a test</h1>',
+        CLOSE,
+        '<div class="carousel-container">',
+        OPEN,
+        OPEN,
+        'Carousel',
+        CLOSE,
+        CLOSE,
+        '</div>',
+        CLOSE,
+        CLOSE,
+      ])
+    );
+
+    replaceHTML(qunitFixture(), html);
+    this.element = qunitFixture();
+
+    // Rehydrate First Component
+    this.renderResult = this.delegate.renderComponentClientSide(
+      'Nav',
+      args.nav,
+      castToSimple(document.querySelector('.nav-container')!)
+    );
+    this.assertHTML(
+      content([
+        OPEN,
+        OPEN,
+        '<div class="nav-container">Nav</div>',
+        OPEN,
+        '<h1>I am a test</h1>',
+        CLOSE,
+        '<div class="carousel-container">',
+        OPEN,
+        OPEN,
+        'Carousel',
+        CLOSE,
+        CLOSE,
+        '</div>',
+        CLOSE,
+        CLOSE,
+      ])
+    );
+    this.assert.ok(
+      this.delegate.rehydrationStats.clearedNodes.length === 0,
+      'No nodes were cleared'
+    );
+    this.assertStableNodes();
+    this.assertStableRerender();
+
+    // Rehydrate the second component
+    this.renderResult = this.delegate.renderComponentClientSide(
+      'Carousel',
+      args.carousel,
+      castToSimple(document.querySelector('.carousel-container')!)
+    );
+    this.assertHTML(
+      content([
+        OPEN,
+        OPEN,
+        '<div class="nav-container">Nav</div>',
+        OPEN,
+        '<h1>I am a test</h1>',
+        CLOSE,
+        '<div class="carousel-container">Carousel</div>',
+        CLOSE,
+        CLOSE,
+      ])
+    );
     this.assert.ok(
       this.delegate.rehydrationStats.clearedNodes.length === 0,
       'No nodes were cleared'

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -71,7 +71,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
       }
 
       assert(closingNode, 'Must have closing comment for starting block comment');
-      const newClosingBlock = this.dom.createComment(`%-b:${newBlockDepth}%`)
+      const newClosingBlock = this.dom.createComment(`%-b:${newBlockDepth}%`);
       node!.parentNode!.insertBefore(newClosingBlock, closingNode!.nextSibling);
       this.candidate = newCandidate;
       this.startingBlockOffset = newBlockDepth;

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -58,6 +58,7 @@ export class RehydrateBuilder extends NewElementBuilder implements ElementBuilde
     if (startingBlockOffset !== 0) {
       // We are rehydrating from a partial tree and not the root component
       // We need to add an extra block before the first block to rehydrate correctly
+      // The extra block is needed since the renderComponent API creates a synthetic component invocation which generates the extra block
       const newBlockDepth = startingBlockOffset - 1;
       const newCandidate = this.dom.createComment(`%+b:${newBlockDepth}%`);
 


### PR DESCRIPTION
**Why**
Currently if using rehydration with glimmer-vm, the rehydrate builder expects rehydration to resume from the root component that was rendered on the server. This eventually leads to shipping a whole bunch of static templates to the browser that are never used. This PR enables support for rehydrating from any arbitrary dom node that was generated on the server. This will allow glimmer apps to further improve their rehydration performance by only sending components to the client that have interaction logic.

**How**
- Update rehydrate-builder to insert a opening and closing block next to blocks where we would be rehydrating
- Update rehydrate-builder to calculate block depth based on initial blocks offset