### PR TITLE
[WIP] Add support for nextSibling for partial rehydration

### DIFF
--- a/packages/@glimmer/integration-tests/lib/modes/rehydration/partial-rehydration-delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/rehydration/partial-rehydration-delegate.ts
@@ -1,4 +1,4 @@
-import { Dict, ComponentDefinition, RenderResult } from '@glimmer/interfaces';
+import { Dict, ComponentDefinition, RenderResult, Option } from '@glimmer/interfaces';
 import { renderComponent, renderSync } from '@glimmer/runtime';
 import { createConstRef, childRefFor, Reference } from '@glimmer/reference';
 import { RehydrationDelegate } from './delegate';
@@ -22,9 +22,10 @@ export class PartialRehydrationDelegate extends RehydrationDelegate {
   renderComponentClientSide(
     name: string,
     args: Dict<unknown>,
-    element: SimpleElement
+    element: SimpleElement,
+    nextSibling: Option<SimpleElement> = null
   ): RenderResult {
-    let cursor = { element, nextSibling: null };
+    let cursor = { element, nextSibling };
     let { syntax, runtime } = this.clientEnv;
     let builder = this.getElementBuilder(runtime.env, cursor) as DebugRehydrationBuilder;
     let { handle, compilable } = this.clientRegistry.lookupCompileTimeComponent(name, null)!;


### PR DESCRIPTION
Putting up a draft PR for supporting nextSibling use cases for partial rehydration. I am not sure we want to do this before a refactoring of element builders but putting up a draft for future reference. 

**Why**
With partial rehydration we need to be able to let the rehydrate builder which particular component in the container is being rehydrated. This can be achieved by passing a nextSibling in the initial cursor to the renderComponent call

**How**
- Modify rehydrate builder to walk backwards from the nextSibling to find the first closing block
- Then walk backwards from there to find the first opening block at the same depth