### PR TITLE
[BUGFIX] Prevent args from being created/evaluated twice

### DIFF
--- a/packages/@glimmer/integration-tests/lib/suites/emberish-components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/emberish-components.ts
@@ -28,6 +28,26 @@ export class EmberishComponentTests extends RenderTest {
   }
 
   @test({ kind: 'glimmer' })
+  'Only one arg reference is created per argument'() {
+    let count = 0;
+
+    this.registerHelper('count', () => count++);
+
+    class MainComponent extends EmberishGlimmerComponent {
+      salutation = 'Glimmer';
+    }
+    this.registerComponent(
+      'Glimmer',
+      'Main',
+      '<div><Child @value={{count}} /></div>',
+      MainComponent
+    );
+    this.registerComponent('Glimmer', 'Child', '{{@value}} {{this.value}}');
+    this.render('<Main />');
+    this.assertHTML('<div>0 0</div>');
+  }
+
+  @test({ kind: 'glimmer' })
   '[BUG] Gracefully handles application of curried args when invoke starts with 0 args'() {
     class MainComponent extends EmberishGlimmerComponent {
       salutation = 'Glimmer';

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -1,4 +1,4 @@
-import { Option, Op, ScopeBlock, VM as PublicVM } from '@glimmer/interfaces';
+import { Op, ScopeBlock, VM as PublicVM } from '@glimmer/interfaces';
 import {
   Reference,
   childRefFor,
@@ -52,13 +52,11 @@ APPEND_OPCODES.add(Op.SetVariable, (vm, { op1: symbol }) => {
 });
 
 APPEND_OPCODES.add(Op.SetBlock, (vm, { op1: symbol }) => {
-  let handle = check(vm.stack.popJs(), CheckOption(CheckCompilableBlock));
+  let handle = check(vm.stack.popJs(), CheckCompilableBlock);
   let scope = check(vm.stack.popJs(), CheckScope);
-  let table = check(vm.stack.popJs(), CheckOption(CheckBlockSymbolTable));
+  let table = check(vm.stack.popJs(), CheckBlockSymbolTable);
 
-  let block: Option<ScopeBlock> = table ? [handle!, scope, table] : null;
-
-  vm.scope().bindBlock(symbol, block);
+  vm.scope().bindBlock(symbol, [handle, scope, table]);
 });
 
 APPEND_OPCODES.add(Op.ResolveMaybeLocal, (vm, { op1: _name }) => {


### PR DESCRIPTION
Currently arg references are created twice for static components which
have the `createArgs` capability. They are created once when creating
the args proxy, and then a second time when they are bound to the root
scope of the component.

This PR ensures that refs are only created once by restructuring the
static component logic. Refs are now pushed first, and the args proxy
uses the same refs that are later popped and set on the scope.