### PR TITLE
[BUGFIX] Exports Owner for IE11

### DIFF
--- a/packages/@glimmer/runtime/lib/owner.ts
+++ b/packages/@glimmer/runtime/lib/owner.ts
@@ -1,6 +1,6 @@
 import { symbol } from '@glimmer/util';
 
-const OWNER: unique symbol = symbol('OWNER') as any;
+export const OWNER: unique symbol = symbol('OWNER') as any;
 
 interface OwnedObject<O extends object> {
   [OWNER]: O | undefined;


### PR DESCRIPTION
Exports Owner so it can be used to prevent enumerability in IE11.