### PR TITLE
[REFACTOR] Integrate DebugRenderTree

### DIFF
--- a/packages/@glimmer/integration-tests/index.ts
+++ b/packages/@glimmer/integration-tests/index.ts
@@ -5,6 +5,7 @@ export * from './lib/dom/assertions';
 export * from './lib/dom/blocks';
 export * from './lib/dom/simple-utils';
 export * from './lib/markers';
+export * from './lib/modes/env';
 export * from './lib/modes/jit/delegate';
 export * from './lib/modes/jit/resolver';
 export * from './lib/modes/jit/register';

--- a/packages/@glimmer/integration-tests/lib/components/emberish-glimmer.ts
+++ b/packages/@glimmer/integration-tests/lib/components/emberish-glimmer.ts
@@ -7,15 +7,14 @@ import {
   CapturedNamedArguments,
   ComponentManager,
   WithStaticLayout,
-  RuntimeResolver,
   ComponentCapabilities,
   Environment,
   VMArguments,
   DynamicScope,
-  CompilableProgram,
   Destroyable,
+  Template,
 } from '@glimmer/interfaces';
-import { keys, assign, unwrapTemplate, expect } from '@glimmer/util';
+import { keys, assign, expect } from '@glimmer/util';
 import { TEMPLATE_ONLY_CAPABILITIES } from './capabilities';
 import { TestComponentDefinitionState } from './test-component';
 import { TestComponentConstructor } from './types';
@@ -86,7 +85,7 @@ export interface EmberishGlimmerComponentState {
 export class EmberishGlimmerComponentManager
   implements
     ComponentManager<EmberishGlimmerComponentState, TestComponentDefinitionState>,
-    WithStaticLayout<EmberishGlimmerComponentState, TestComponentDefinitionState, RuntimeResolver> {
+    WithStaticLayout<EmberishGlimmerComponentState, TestComponentDefinitionState> {
   getCapabilities(state: TestComponentDefinitionState): ComponentCapabilities {
     return state.capabilities;
   }
@@ -126,8 +125,8 @@ export class EmberishGlimmerComponentManager
     return { args, component, selfRef };
   }
 
-  getStaticLayout({ template }: TestComponentDefinitionState): CompilableProgram {
-    return unwrapTemplate(expect(template, 'expected component layout')).asLayout();
+  getStaticLayout({ template }: TestComponentDefinitionState): Template {
+    return expect(template, 'expected component layout');
   }
 
   getSelf({ selfRef }: EmberishGlimmerComponentState): Reference<unknown> {

--- a/packages/@glimmer/integration-tests/lib/components/template-only.ts
+++ b/packages/@glimmer/integration-tests/lib/components/template-only.ts
@@ -1,15 +1,10 @@
-import {
-  WithStaticLayout,
-  RuntimeResolver,
-  CompilableProgram,
-  ComponentCapabilities,
-} from '@glimmer/interfaces';
+import { WithStaticLayout, ComponentCapabilities, Template } from '@glimmer/interfaces';
 import { TestComponentDefinitionState } from './test-component';
-import { expect, unwrapTemplate } from '@glimmer/util';
+import { expect } from '@glimmer/util';
 import { Reference, NULL_REFERENCE } from '@glimmer/reference';
 
 export class TemplateOnlyComponentManager
-  implements WithStaticLayout<null, TestComponentDefinitionState, RuntimeResolver> {
+  implements WithStaticLayout<null, TestComponentDefinitionState> {
   getCapabilities(state: TestComponentDefinitionState): ComponentCapabilities {
     return state.capabilities;
   }
@@ -18,8 +13,8 @@ export class TemplateOnlyComponentManager
     return state.name;
   }
 
-  getStaticLayout({ template }: TestComponentDefinitionState): CompilableProgram {
-    return unwrapTemplate(expect(template, 'expected component layout')).asLayout();
+  getStaticLayout({ template }: TestComponentDefinitionState): Template {
+    return expect(template, 'expected component layout');
   }
 
   getSelf(): Reference {

--- a/packages/@glimmer/integration-tests/lib/components/types.ts
+++ b/packages/@glimmer/integration-tests/lib/components/types.ts
@@ -3,7 +3,7 @@ import { EmberishCurlyComponent } from './emberish-curly';
 import { Dict } from '@glimmer/interfaces';
 import { TemplateOnlyComponent } from '@glimmer/runtime';
 
-export type ComponentKind = 'Glimmer' | 'Curly' | 'Dynamic' | 'TemplateOnly' | 'unknown';
+export type ComponentKind = 'Glimmer' | 'Curly' | 'Dynamic' | 'TemplateOnly' | 'Custom' | 'unknown';
 
 export interface TestComponentConstructor<T> {
   new (): T;
@@ -14,6 +14,7 @@ export interface ComponentTypes {
   Curly: TestComponentConstructor<EmberishCurlyComponent>;
   Dynamic: TestComponentConstructor<EmberishCurlyComponent>;
   TemplateOnly: TemplateOnlyComponent;
+  Custom: unknown;
   unknown: unknown;
 }
 

--- a/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/registry.ts
@@ -10,7 +10,7 @@ import {
   Template,
   WithStaticLayout,
 } from '@glimmer/interfaces';
-import { assert, dict } from '@glimmer/util';
+import { assert, dict, unwrapTemplate } from '@glimmer/util';
 import { getComponentTemplate } from '@glimmer/runtime';
 import { TestComponentDefinitionState } from '../../components/test-component';
 
@@ -140,10 +140,13 @@ export class TestJitRegistry {
       };
     }
 
+    let template = unwrapTemplate(manager.getStaticLayout(state));
+    let layout = capabilities.wrapped ? template.asWrappedLayout() : template.asLayout();
+
     return {
       handle: handle,
       capabilities,
-      compilable: manager.getStaticLayout(state),
+      compilable: layout,
     };
   }
 

--- a/packages/@glimmer/integration-tests/lib/suites/components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/components.ts
@@ -730,8 +730,9 @@ export class GlimmerishComponents extends RenderTest {
     let originalConsoleError = console.error;
 
     console.error = (message: string) => {
+      console.log(message);
       this.assert.ok(
-        message.match(/Error occurred while rendering:(\n\nBar\n {2}Foo)?/),
+        message.match(/Error occurred:\n\n(- While rendering:\nBar\n {2}Foo)?/),
         'message logged'
       );
     };

--- a/packages/@glimmer/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer/integration-tests/test/debug-render-tree-test.ts
@@ -1,0 +1,541 @@
+import {
+  CapturedArguments,
+  CapturedRenderNode,
+  ComponentManager,
+  CustomRenderNode,
+} from '@glimmer/interfaces';
+import { expect, assign } from '@glimmer/util';
+import { SimpleElement, SimpleNode } from '@simple-dom/interface';
+import {
+  test,
+  RenderTest,
+  suite,
+  BaseEnv,
+  JitRenderDelegate,
+  EmberishCurlyComponent,
+  EmberishGlimmerComponent,
+  EmberishGlimmerArgs,
+  TestComponentDefinitionState,
+  createTemplate,
+  TemplateOnlyComponentManager,
+  TEMPLATE_ONLY_CAPABILITIES,
+} from '..';
+import {
+  EMPTY_ARGS,
+  setComponentTemplate,
+  TemplateOnlyComponent,
+  templateOnlyComponent,
+} from '@glimmer/runtime';
+
+interface CapturedBounds {
+  parentElement: SimpleElement;
+  firstNode: SimpleNode;
+  lastNode: SimpleNode;
+}
+
+type Expected<T> = T | ((actual: T) => boolean);
+
+function isExpectedFunc<T>(expected: Expected<T>): expected is (actual: T) => boolean {
+  return typeof expected === 'function';
+}
+
+interface ExpectedRenderNode {
+  type: CapturedRenderNode['type'];
+  name: CapturedRenderNode['name'];
+  args: Expected<CapturedRenderNode['args']>;
+  instance: Expected<CapturedRenderNode['instance']>;
+  template: Expected<CapturedRenderNode['template']>;
+  bounds: Expected<CapturedRenderNode['bounds']>;
+  children: Expected<CapturedRenderNode['children']> | ExpectedRenderNode[];
+}
+
+class DebugRenderTreeDelegate extends JitRenderDelegate {
+  registerCustomComponent(name: string, template: string, Manager: { new (): ComponentManager }) {
+    const ComponentClass = templateOnlyComponent();
+
+    let state: TestComponentDefinitionState = {
+      name,
+      capabilities: TEMPLATE_ONLY_CAPABILITIES,
+      ComponentClass,
+      template: null,
+    };
+
+    setComponentTemplate(createTemplate(template), ComponentClass);
+
+    let definition = {
+      state,
+      manager: new Manager(),
+    };
+
+    this.registry.register('component', name, definition);
+  }
+}
+
+class DebugRenderTreeTest extends RenderTest {
+  static suiteName = 'Application test: debug render tree';
+
+  declare delegate: DebugRenderTreeDelegate;
+
+  @test 'template-only components'() {
+    this.registerComponent('TemplateOnly', 'HelloWorld', '{{@arg}}');
+
+    this.render(
+      `<HelloWorld @arg="first"/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      {
+        showSecond: false,
+      }
+    );
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: true });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+        children: [],
+      },
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'second' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().lastChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: false });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+        children: [],
+      },
+    ]);
+  }
+
+  @test 'emberish curly components'() {
+    this.registerComponent('Curly', 'HelloWorld', 'Hello World');
+
+    this.render(
+      `<HelloWorld @arg="first"/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      {
+        showSecond: false,
+      }
+    );
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: true });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'second' } },
+        instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'second',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.lastChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: false });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+    ]);
+  }
+
+  @test 'emberish glimmer components'() {
+    this.registerComponent('Glimmer', 'HelloWorld', 'Hello World');
+
+    this.render(
+      `<HelloWorld @arg="first"/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      {
+        showSecond: false,
+      }
+    );
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: (instance: EmberishGlimmerComponent) => (instance as any).arg === 'first',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: true });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: (instance: EmberishGlimmerComponent) => (instance as any).arg === 'first',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'second' } },
+        instance: (instance: EmberishGlimmerComponent) => (instance as any).arg === 'second',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.lastChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: false });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: (instance: EmberishGlimmerComponent) => (instance as any).arg === 'first',
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+    ]);
+  }
+
+  @test 'getDebugCustomRenderTree works'() {
+    let bucket1 = {};
+    let instance1 = {};
+
+    let bucket2 = {};
+    let instance2 = {};
+
+    this.delegate.registerCustomComponent(
+      'HelloWorld',
+      '{{@arg}}',
+      class extends TemplateOnlyComponentManager {
+        getDebugCustomRenderTree(
+          _definition: TemplateOnlyComponent,
+          _state: null,
+          args: CapturedArguments
+        ): CustomRenderNode[] {
+          return [
+            {
+              bucket: bucket1,
+              type: 'route-template',
+              name: 'foo',
+              instance: instance1,
+              args,
+              template: undefined,
+            },
+            {
+              bucket: bucket2,
+              type: 'engine',
+              name: 'bar',
+              instance: instance2,
+              args: EMPTY_ARGS,
+              template: undefined,
+            },
+          ];
+        }
+      }
+    );
+
+    this.registerComponent('TemplateOnly', 'HelloWorld2', '{{@arg}}');
+
+    this.render(
+      `<HelloWorld2 @arg="first"/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      {
+        showSecond: false,
+      }
+    );
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld2',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: true });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld2',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+      {
+        type: 'route-template',
+        name: 'foo',
+        args: { positional: [], named: { arg: 'second' } },
+        instance: instance1,
+        template: null,
+        bounds: this.nodeBounds(this.element.lastChild),
+        children: [
+          {
+            type: 'engine',
+            name: 'bar',
+            args: { positional: [], named: {} },
+            instance: instance2,
+            template: null,
+            bounds: this.nodeBounds(this.element.lastChild),
+            children: [],
+          },
+        ],
+      },
+    ]);
+
+    this.rerender({ showSecond: false });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld2',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+    ]);
+  }
+
+  @test 'empty getDebugCustomRenderTree works'() {
+    this.delegate.registerCustomComponent(
+      'HelloWorld',
+      '{{@arg}}',
+      class extends TemplateOnlyComponentManager {
+        getDebugCustomRenderTree(): CustomRenderNode[] {
+          return [];
+        }
+      }
+    );
+
+    this.registerComponent('TemplateOnly', 'HelloWorld2', '{{@arg}}');
+
+    this.render(
+      `<HelloWorld2 @arg="first"/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      {
+        showSecond: false,
+      }
+    );
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld2',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: true });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld2',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+    ]);
+
+    this.rerender({ showSecond: false });
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: 'HelloWorld2',
+        args: { positional: [], named: { arg: 'first' } },
+        instance: null,
+        template: '(unknown template module)',
+        bounds: this.nodeBounds(this.element.firstChild),
+        children: [],
+      },
+    ]);
+  }
+
+  @test 'cleans up correctly after errors'(assert: Assert) {
+    this.registerComponent(
+      'Glimmer',
+      'HelloWorld',
+      'Hello World',
+      class extends EmberishGlimmerComponent {
+        constructor(args: EmberishGlimmerArgs) {
+          super(args);
+          throw new Error('oops!');
+        }
+      }
+    );
+
+    assert.throws(() => {
+      this.render('<HelloWorld @arg="first"/>');
+    }, /oops!/);
+
+    assert.deepEqual(this.delegate.getCapturedRenderTree(), [], 'there was no output');
+  }
+
+  nodeBounds(_node: SimpleNode | null): CapturedBounds {
+    let node = expect(_node, 'BUG: Expected node');
+
+    return {
+      parentElement: ((expect(
+        node.parentNode,
+        'BUG: detached node'
+      ) as unknown) as SimpleNode) as SimpleElement,
+      firstNode: (node as unknown) as SimpleNode,
+      lastNode: (node as unknown) as SimpleNode,
+    };
+  }
+
+  elementBounds(element: Element): CapturedBounds {
+    return {
+      parentElement: (element as unknown) as SimpleElement,
+      firstNode: (element.firstChild! as unknown) as SimpleNode,
+      lastNode: (element.lastChild! as unknown) as SimpleNode,
+    };
+  }
+
+  assertRenderTree(expected: ExpectedRenderNode[]): void {
+    let actual = this.delegate.getCapturedRenderTree();
+
+    this.assertRenderNodes(actual, expected, 'root');
+  }
+
+  assertRenderNodes(
+    actual: CapturedRenderNode[],
+    expected: ExpectedRenderNode[],
+    path: string
+  ): void {
+    this.assert.strictEqual(
+      actual.length,
+      expected.length,
+      `Expecting ${expected.length} render nodes at ${path}, got ${actual.length}.\n`
+    );
+
+    if (actual.length === expected.length) {
+      let byTypeAndName = <T, U, V extends { type: T; name: U }>(a: V, b: V): number => {
+        if (a.type > b.type) {
+          return 1;
+        } else if (a.type < b.type) {
+          return -1;
+        } else if (a.name > b.name) {
+          return 1;
+        } else if (a.name < b.name) {
+          return -1;
+        } else {
+          return 0;
+        }
+      };
+
+      actual = actual.sort(byTypeAndName);
+      expected = expected.sort(byTypeAndName);
+
+      for (let i = 0; i < actual.length; i++) {
+        this.assertRenderNode(actual[i], expected[i], `${actual[i].type}:${actual[i].name}`);
+      }
+    } else {
+      this.assert.deepEqual(actual, [], path);
+    }
+  }
+
+  assertRenderNode(actual: CapturedRenderNode, expected: ExpectedRenderNode, path: string): void {
+    this.assertProperty(actual.type, expected.type, false, `${path} (type)`);
+    this.assertProperty(actual.name, expected.name, false, `${path} (name)`);
+    this.assertProperty(actual.args, expected.args, true, `${path} (args)`);
+    this.assertProperty(actual.instance, expected.instance, false, `${path} (instance)`);
+    this.assertProperty(actual.template, expected.template, false, `${path} (template)`);
+    this.assertProperty(actual.bounds, expected.bounds, true, `${path} (bounds)`);
+
+    if (Array.isArray(expected.children)) {
+      this.assertRenderNodes(actual.children, expected.children, path);
+    } else {
+      this.assertProperty(actual.children, expected.children, false, `${path} (children)`);
+    }
+  }
+
+  assertProperty<T>(actual: T, expected: Expected<T>, deep: boolean, path: string): void {
+    if (isExpectedFunc(expected)) {
+      this.assert.ok(expected(actual), `Matching ${path}, got ${actual}`);
+    } else if (deep) {
+      this.assert.deepEqual(actual, expected, `Matching ${path}`);
+    } else {
+      this.assert.strictEqual(actual, expected, `Matching ${path}`);
+    }
+  }
+}
+
+suite(DebugRenderTreeTest, DebugRenderTreeDelegate, {
+  env: assign({}, BaseEnv, {
+    enableDebugTooling: true,
+  }),
+});

--- a/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
@@ -35,9 +35,6 @@ export interface DebugRenderTree<Bucket extends object = object> {
 
   update(state: Bucket): void;
 
-  // for dynamic layouts
-  setTemplate(state: Bucket, template: Template): void;
-
   didRender(state: Bucket, bounds: Bounds): void;
 
   willDestroy(state: Bucket): void;

--- a/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
@@ -37,6 +37,6 @@ export interface Environment<O extends Owner = Owner> {
   getAppendOperations(): GlimmerTreeConstruction;
 
   isInteractive: boolean;
-  debugRenderTree: DebugRenderTree;
+  debugRenderTree?: DebugRenderTree;
   owner: O;
 }

--- a/packages/@glimmer/runtime/lib/component/interfaces.ts
+++ b/packages/@glimmer/runtime/lib/component/interfaces.ts
@@ -3,8 +3,8 @@ import {
   ComponentDefinitionState,
   ComponentInstanceState,
   ComponentManager,
+  WithCustomDebugRenderTree,
   WithStaticLayout,
-  RuntimeResolver,
 } from '@glimmer/interfaces';
 import { hasCapability, Capability } from '../capabilities';
 
@@ -12,11 +12,15 @@ import { hasCapability, Capability } from '../capabilities';
 export function hasStaticLayout<
   D extends ComponentDefinitionState,
   I extends ComponentInstanceState
->(
-  capabilities: Capability,
-  _manager: ComponentManager<I, D>
-): _manager is WithStaticLayout<I, D, RuntimeResolver> {
+>(capabilities: Capability, _manager: ComponentManager<I, D>): _manager is WithStaticLayout<I, D> {
   return !hasCapability(capabilities, Capability.DynamicLayout);
+}
+
+export function hasCustomDebugRenderTreeLifecycle<
+  D extends ComponentDefinitionState,
+  I extends ComponentInstanceState
+>(manager: ComponentManager<I, D>): manager is WithCustomDebugRenderTree<I, D> {
+  return 'getDebugCustomRenderTree' in manager;
 }
 
 export const DEFAULT_CAPABILITIES: ComponentCapabilities = {

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -84,7 +84,7 @@ class TransactionImpl implements Transaction {
           // eslint-disable-next-line no-loop-func
           () => manager.install(modifier),
           DEBUG &&
-            `- While rendering:\n\n  (instance of a \`${manager.getDebugName(modifier)}\` modifier)`
+            `- While rendering:\n  (instance of a \`${manager.getDebugName(modifier)}\` modifier)`
         );
         updateTag(modifierTag, tag);
       } else {
@@ -124,8 +124,7 @@ export class EnvironmentImpl implements Environment {
   public isInteractive = this.delegate.isInteractive;
   public owner = this.delegate.owner;
 
-  private enableDebugTooling = this.delegate.enableDebugTooling;
-  private _debugRenderTree = this.enableDebugTooling ? new DebugRenderTree() : undefined;
+  debugRenderTree = this.delegate.enableDebugTooling ? new DebugRenderTree() : undefined;
 
   constructor(options: EnvironmentOptions, private delegate: EnvironmentDelegate) {
     if (options.appendOperations) {
@@ -136,16 +135,6 @@ export class EnvironmentImpl implements Environment {
       this.updateOperations = new DOMChangesImpl(options.document);
     } else if (DEBUG) {
       throw new Error('you must pass document or appendOperations to a new runtime');
-    }
-  }
-
-  get debugRenderTree(): DebugRenderTree {
-    if (this.enableDebugTooling) {
-      return this._debugRenderTree!;
-    } else {
-      throw new Error(
-        "Can't access debug render tree outside of the inspector (_DEBUG_RENDER_TREE flag is disabled)"
-      );
     }
   }
 
@@ -166,9 +155,7 @@ export class EnvironmentImpl implements Environment {
       'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.'
     );
 
-    if (this.enableDebugTooling) {
-      this.debugRenderTree.begin();
-    }
+    this.debugRenderTree?.begin();
 
     this[TRANSACTION] = new TransactionImpl();
   }
@@ -202,9 +189,7 @@ export class EnvironmentImpl implements Environment {
     this[TRANSACTION] = null;
     transaction.commit();
 
-    if (this.enableDebugTooling) {
-      this.debugRenderTree.commit();
-    }
+    this.debugRenderTree?.commit();
 
     this.delegate.onTransactionCommit();
   }

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -18,6 +18,8 @@ import { ARGS } from './symbols';
 import VM, { InternalVM } from './vm/append';
 import { DynamicScopeImpl } from './scope';
 import { inTransaction } from './environment';
+import { DEBUG } from '@glimmer/env';
+import { runInTrackingTransaction } from '@glimmer/validator';
 
 class TemplateIteratorImpl implements TemplateIterator {
   constructor(private vm: InternalVM) {}
@@ -26,7 +28,11 @@ class TemplateIteratorImpl implements TemplateIterator {
   }
 
   sync(): RenderResult {
-    return this.vm.execute();
+    if (DEBUG) {
+      return runInTrackingTransaction!(() => this.vm.execute(), '- While rendering:');
+    } else {
+      return this.vm.execute();
+    }
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -568,7 +568,7 @@ export default class VM implements PublicVM, InternalVM {
             elements.popBlock();
           }
 
-          console.error(`\n\nError occurred while rendering:\n\n${resetTracking()}\n\n`);
+          console.error(`\n\nError occurred:\n\n${resetTracking()}\n\n`);
         }
       }
     } else {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -19,7 +19,7 @@ import {
   updateRef,
 } from '@glimmer/reference';
 import { expect, Option, Stack, logStep } from '@glimmer/util';
-import { resetTracking } from '@glimmer/validator';
+import { resetTracking, runInTrackingTransaction } from '@glimmer/validator';
 import { SimpleComment } from '@simple-dom/interface';
 import { move as moveBounds, clear } from '../bounds';
 import { UpdatingOpcode } from '../opcodes';
@@ -45,14 +45,14 @@ export default class UpdatingVM {
     if (DEBUG) {
       let hasErrored = true;
       try {
-        this._execute(opcodes, handler);
+        runInTrackingTransaction!(() => this._execute(opcodes, handler), '- While rendering:');
 
         // using a boolean here to avoid breaking ergonomics of "pause on uncaught exceptions"
         // which would happen with a `catch` + `throw`
         hasErrored = false;
       } finally {
         if (hasErrored) {
-          console.error(`\n\nError occurred while rendering:\n\n${resetTracking()}\n\n`);
+          console.error(`\n\nError occurred:\n\n${resetTracking()}\n\n`);
         }
       }
     } else {

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -65,5 +65,7 @@ export {
   logTrackingStack,
   setTrackingTransactionEnv,
   runInTrackingTransaction,
+  beginTrackingTransaction,
+  endTrackingTransaction,
   deprecateMutationsInTrackingTransaction,
 } from './lib/debug';

--- a/packages/@glimmer/validator/lib/debug.ts
+++ b/packages/@glimmer/validator/lib/debug.ts
@@ -7,7 +7,7 @@ export let beginTrackingTransaction:
 export let endTrackingTransaction: undefined | (() => void);
 export let runInTrackingTransaction:
   | undefined
-  | ((fn: () => void, debuggingContext?: string | false) => void);
+  | (<T>(fn: () => T, debuggingContext?: string | false) => T);
 export let deprecateMutationsInTrackingTransaction: undefined | ((fn: () => void) => void);
 
 export let resetTrackingTransaction: undefined | (() => string);
@@ -121,13 +121,18 @@ if (DEBUG) {
    *
    * TODO: Only throw an error if the `track` is consumed.
    */
-  runInTrackingTransaction = (fn: () => void, debugLabel?: string | false) => {
+  runInTrackingTransaction = <T>(fn: () => T, debugLabel?: string | false) => {
     beginTrackingTransaction!(debugLabel);
+    let didError = true;
 
     try {
-      fn();
+      let value = fn();
+      didError = false;
+      return value;
     } finally {
-      endTrackingTransaction!();
+      if (didError !== true) {
+        endTrackingTransaction!();
+      }
     }
   };
 


### PR DESCRIPTION
Integrates the DebugRenderTree into Glimmer VM directly, so it doesn't
have to be managed by individual component managers.

Major changes:

1. `getDebugRenderTreeName` API added if managers need to override the
  name provided by `getDebugName`
2. `getCustomDebugRenderTree` API added, allows managers like `outlet`
  and `mount` to specify custom render trees via a list of render nodes.
3. TemplateOnly components can now integrate in the render tree without
  having to optionally have `createArgs` or `createInstance`
  capabilities.

Breaking changes:

* `env.debugRenderTree` has been made optional, it could potentially be undefined and will not assert if it is not
* `DebugRenderTree#setTemplate` has been removed