### PR TITLE
Update syntax errors to not be a custom subclass

### DIFF
--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
@@ -1,4 +1,4 @@
-import { ASTv2, GlimmerSyntaxError, SourceSlice, SourceSpan } from '@glimmer/syntax';
+import { ASTv2, generateSyntaxError, SourceSlice, SourceSpan } from '@glimmer/syntax';
 import { expect } from '@glimmer/util';
 
 import { Err, Ok, Result } from '../../../shared/result';
@@ -28,7 +28,7 @@ export const APPEND_KEYWORDS = keywords('Append')
 
         if (args.named.size > 1 || target === null) {
           return Err(
-            new GlimmerSyntaxError(`yield only takes a single named argument: 'to'`, args.named.loc)
+            generateSyntaxError(`yield only takes a single named argument: 'to'`, args.named.loc)
           );
         }
 
@@ -36,7 +36,7 @@ export const APPEND_KEYWORDS = keywords('Append')
           return Ok({ target: target.toSlice(), positional: args.positional });
         } else {
           return Err(
-            new GlimmerSyntaxError(`you can only yield to a literal string value`, target.loc)
+            generateSyntaxError(`you can only yield to a literal string value`, target.loc)
           );
         }
       }
@@ -72,14 +72,14 @@ export const APPEND_KEYWORDS = keywords('Append')
 
       if (positional.isEmpty()) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `Partial found with no arguments. You must specify a template name`,
             node.loc
           )
         );
       } else if (positional.size !== 1) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `Partial found with ${positional.exprs.length} arguments. You must specify a template name`,
             node.loc
           )
@@ -89,7 +89,7 @@ export const APPEND_KEYWORDS = keywords('Append')
       if (named.isEmpty()) {
         if (trusting) {
           return Err(
-            new GlimmerSyntaxError(
+            generateSyntaxError(
               `{{{partial ...}}} is not supported, please use {{partial ...}} instea`,
               node.loc
             )
@@ -98,7 +98,7 @@ export const APPEND_KEYWORDS = keywords('Append')
 
         return Ok(expect(positional.nth(0), `already confirmed that positional has a 0th entry`));
       } else {
-        return Err(new GlimmerSyntaxError(`Partial does not take any named argument`, node.loc));
+        return Err(generateSyntaxError(`Partial does not take any named argument`, node.loc));
       }
     },
 
@@ -132,12 +132,10 @@ export const APPEND_KEYWORDS = keywords('Append')
         return Ok(undefined);
       } else {
         if (positional.isEmpty()) {
-          return Err(
-            new GlimmerSyntaxError(`debugger does not take any named arguments`, node.loc)
-          );
+          return Err(generateSyntaxError(`debugger does not take any named arguments`, node.loc));
         } else {
           return Err(
-            new GlimmerSyntaxError(`debugger does not take any positional arguments`, node.loc)
+            generateSyntaxError(`debugger does not take any positional arguments`, node.loc)
           );
         }
       }
@@ -198,7 +196,7 @@ export const APPEND_KEYWORDS = keywords('Append')
 
       if (definition === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{component}} requires a component definition or identifier as its first positional parameter, did not receive any parameters.`,
             args.loc
           )

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
@@ -1,4 +1,4 @@
-import { ASTv2, GlimmerSyntaxError } from '@glimmer/syntax';
+import { ASTv2, generateSyntaxError } from '@glimmer/syntax';
 
 import { Err, Ok, Result } from '../../../shared/result';
 import * as mir from '../../2-encoding/mir';
@@ -20,7 +20,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
       let guid = args.get('guid');
 
       if (guid) {
-        return Err(new GlimmerSyntaxError(`Cannot pass \`guid\` to \`{{#in-element}}\``, guid.loc));
+        return Err(generateSyntaxError(`Cannot pass \`guid\` to \`{{#in-element}}\``, guid.loc));
       }
 
       let insertBefore = args.get('insertBefore');
@@ -28,7 +28,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (destination === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#in-element}} requires a target element as its first positional parameter`,
             args.loc
           )
@@ -97,7 +97,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (!args.named.isEmpty()) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#if}} cannot receive named parameters, received ${args.named.entries
               .map((e) => e.name.chars)
               .join(', ')}.`,
@@ -108,7 +108,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (args.positional.size > 1) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#if}} can only receive one positional parameter, the conditional value. Received ${args.positional.size} parameters.`,
             args.positional.loc
           )
@@ -119,7 +119,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (condition === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#if}} requires a condition as its first positional parameter, did not receive any parameters.`,
             args.loc
           )
@@ -161,7 +161,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (!args.named.isEmpty()) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#unless}} cannot receive named parameters, received ${args.named.entries
               .map((e) => e.name.chars)
               .join(', ')}.`,
@@ -172,7 +172,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (args.positional.size > 1) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#unless}} can only receive one positional parameter, the conditional value. Received ${args.positional.size} parameters.`,
             args.positional.loc
           )
@@ -183,7 +183,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (condition === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#unless}} requires a condition as its first positional parameter, did not receive any parameters.`,
             args.loc
           )
@@ -226,7 +226,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (!args.named.entries.every((e) => e.name.chars === 'key')) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#each}} can only receive the 'key' named parameter, received ${args.named.entries
               .filter((e) => e.name.chars !== 'key')
               .map((e) => e.name.chars)
@@ -238,7 +238,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (args.positional.size > 1) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#each}} can only receive one positional parameter, the collection being iterated. Received ${args.positional.size} parameters.`,
             args.positional.loc
           )
@@ -250,7 +250,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (value === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#each}} requires an iterable value to be passed as its first positional parameter, did not receive any parameters.`,
             args.loc
           )
@@ -295,7 +295,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (!args.named.isEmpty()) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#with}} cannot receive named parameters, received ${args.named.entries
               .map((e) => e.name.chars)
               .join(', ')}.`,
@@ -306,7 +306,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (args.positional.size > 1) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#with}} can only receive one positional parameter. Received ${args.positional.size} parameters.`,
             args.positional.loc
           )
@@ -317,7 +317,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (value === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#with}} requires a value as its first positional parameter, did not receive any parameters.`,
             args.loc
           )
@@ -359,7 +359,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (!args.named.isEmpty()) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#let}} cannot receive named parameters, received ${args.named.entries
               .map((e) => e.name.chars)
               .join(', ')}.`,
@@ -370,7 +370,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (args.positional.size === 0) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#let}} requires at least one value as its first positional parameter, did not receive any parameters.`,
             args.positional.loc
           )
@@ -379,7 +379,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (node.blocks.get('else')) {
         return Err(
-          new GlimmerSyntaxError(`{{#let}} cannot receive an {{else}} block`, args.positional.loc)
+          generateSyntaxError(`{{#let}} cannot receive an {{else}} block`, args.positional.loc)
         );
       }
 
@@ -445,7 +445,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
 
       if (definition === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `{{#component}} requires a component definition or identifier as its first positional parameter, did not receive any parameters.`,
             args.loc
           )

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/expr.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/expr.ts
@@ -1,4 +1,4 @@
-import { ASTv2, GlimmerSyntaxError, SourceSlice } from '@glimmer/syntax';
+import { ASTv2, generateSyntaxError, SourceSlice } from '@glimmer/syntax';
 
 import { Err, Ok, Result } from '../../../shared/result';
 import * as mir from '../../2-encoding/mir';
@@ -38,7 +38,7 @@ export const EXPR_KEYWORDS = keywords('Expr')
     assert(node: ExprKeywordNode): Result<{ definition: ASTv2.ExpressionNode; args: ASTv2.Args }> {
       if (node.type !== 'Call') {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             'The (component) keyword must be called with arguments in order to curry a component definition. It cannot be used directly as a value.',
             node.loc
           )
@@ -50,7 +50,7 @@ export const EXPR_KEYWORDS = keywords('Expr')
 
       if (definition === null) {
         return Err(
-          new GlimmerSyntaxError(
+          generateSyntaxError(
             `(component) requires a component definition or identifier as its first positional parameter, did not receive any parameters.`,
             args.loc
           )

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/has-block.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/has-block.ts
@@ -1,4 +1,4 @@
-import { ASTv2, GlimmerSyntaxError, SourceSlice } from '@glimmer/syntax';
+import { ASTv2, generateSyntaxError, SourceSlice } from '@glimmer/syntax';
 
 import { Err, Ok, Result } from '../../../shared/result';
 import { GenericKeywordNode } from './impl';
@@ -13,7 +13,7 @@ export function assertValidHasBlockUsage(
   let positionals = call.type === 'Call' ? call.args.positional : null;
 
   if (named && !named.isEmpty()) {
-    return Err(new GlimmerSyntaxError(`${type} does not take any named arguments`, call.loc));
+    return Err(generateSyntaxError(`${type} does not take any named arguments`, call.loc));
   }
 
   if (!positionals || positionals.isEmpty()) {
@@ -23,9 +23,9 @@ export function assertValidHasBlockUsage(
     if (ASTv2.isLiteral(positional, 'string')) {
       return Ok(positional.toSlice());
     } else {
-      return Err(new GlimmerSyntaxError(`you can only yield to a literal value`, call.loc));
+      return Err(generateSyntaxError(`you can only yield to a literal value`, call.loc));
     }
   } else {
-    return Err(new GlimmerSyntaxError(`${type} only takes a single positional argument`, call.loc));
+    return Err(generateSyntaxError(`${type} only takes a single positional argument`, call.loc));
   }
 }

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/impl.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/impl.ts
@@ -319,7 +319,7 @@ export class BlockKeywords<KeywordList extends BlockKeyword = never>
  *     }
  *
  *     if (node.params.length || node.hash) {
- *       return Err(new GlimmerSyntaxError(`(hello) does not take any arguments`), node.loc);
+ *       return Err(generateSyntaxError(`(hello) does not take any arguments`), node.loc);
  *     } else {
  *       return Ok();
  *     }

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
@@ -1,5 +1,5 @@
 import { PresentArray } from '@glimmer/interfaces';
-import { ASTv2, GlimmerSyntaxError, SourceSlice } from '@glimmer/syntax';
+import { ASTv2, generateSyntaxError, SourceSlice } from '@glimmer/syntax';
 import { unreachable } from '@glimmer/util';
 
 import { KeywordNode } from '../keywords/impl';
@@ -87,7 +87,7 @@ export function assertIsValidHelper<N extends HasPath>(
     return;
   }
 
-  throw new GlimmerSyntaxError(
+  throw generateSyntaxError(
     `\`${printPath(helper.callee)}\` is not a valid name for a ${context}`,
     helper.loc
   );

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/element/simple-element.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/element/simple-element.ts
@@ -1,4 +1,4 @@
-import { ASTv2, GlimmerSyntaxError, SourceSlice } from '@glimmer/syntax';
+import { ASTv2, generateSyntaxError, SourceSlice } from '@glimmer/syntax';
 
 import { Err, Result } from '../../../../shared/result';
 import * as mir from '../../../2-encoding/mir';
@@ -16,7 +16,7 @@ export class ClassifiedSimpleElement implements Classified {
 
   arg(attr: ASTv2.ComponentArg): Result<mir.NamedArgument> {
     return Err(
-      new GlimmerSyntaxError(
+      generateSyntaxError(
         `${attr.name.chars} is not a valid attribute name. @arguments are only allowed on components, but the tag for this element (\`${this.tag.chars}\`) is a regular, non-component HTML element.`,
         attr.loc
       )

--- a/packages/@glimmer/integration-tests/lib/compile.ts
+++ b/packages/@glimmer/integration-tests/lib/compile.ts
@@ -28,7 +28,11 @@ export function syntaxErrorFor(
 ): Error {
   let quotedCode = code ? `\n\n|\n|  ${code.split('\n').join('\n|  ')}\n|\n\n` : '';
 
-  return new Error(
-    `Syntax Error: ${message}: ${quotedCode}(error occurred in '${moduleName}' @ line ${line} : column ${column})`
+  let error = new Error(
+    `${message}: ${quotedCode}(error occurred in '${moduleName}' @ line ${line} : column ${column})`
   );
+
+  error.name = 'SyntaxError';
+
+  return error;
 }

--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -4,7 +4,7 @@ export * as ASTv1 from './lib/v1/api';
 export * as ASTv2 from './lib/v2-a/api';
 export { normalize } from './lib/v2-a/normalize';
 export { SymbolTable, BlockSymbolTable, ProgramSymbolTable } from './lib/symbol-table';
-export { GlimmerSyntaxError } from './lib/syntax-error';
+export { generateSyntaxError, GlimmerSyntaxError } from './lib/syntax-error';
 export {
   preprocess,
   ASTPlugin,

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -3,7 +3,7 @@ import { TokenizerState } from 'simple-html-tokenizer';
 
 import { Parser, ParserNodeBuilder, Tag } from '../parser';
 import { NON_EXISTENT_LOCATION } from '../source/location';
-import { GlimmerSyntaxError } from '../syntax-error';
+import { generateSyntaxError } from '../syntax-error';
 import { appendChild, isHBSLiteral, printLiteral } from '../utils';
 import * as ASTv1 from '../v1/api';
 import * as HBS from '../v1/handlebars-ast';
@@ -59,7 +59,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
     if (poppedNode !== node) {
       let elementNode = poppedNode as ASTv1.ElementNode;
 
-      throw new GlimmerSyntaxError(`Unclosed element \`${elementNode.tag}\``, elementNode.loc);
+      throw generateSyntaxError(`Unclosed element \`${elementNode.tag}\``, elementNode.loc);
     }
 
     return node;
@@ -75,7 +75,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
       this.tokenizer.state !== TokenizerState.data &&
       this.tokenizer.state !== TokenizerState.beforeData
     ) {
-      throw new GlimmerSyntaxError(
+      throw generateSyntaxError(
         'A block may only be used inside an HTML element or another block.',
         this.source.spanFor(block.loc)
       );
@@ -153,7 +153,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
       // Tag helpers
       case TokenizerState.tagOpen:
       case TokenizerState.tagName:
-        throw new GlimmerSyntaxError(`Cannot use mustaches in an elements tagname`, mustache.loc);
+        throw generateSyntaxError(`Cannot use mustaches in an elements tagname`, mustache.loc);
 
       case TokenizerState.beforeAttributeName:
         addElementModifier(this.currentStartTag, mustache);
@@ -240,7 +240,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
         break;
 
       default:
-        throw new GlimmerSyntaxError(
+        throw generateSyntaxError(
           `Using a Handlebars comment when in the \`${tokenizer['state']}\` state is not supported`,
           this.source.spanFor(rawComment.loc)
         );
@@ -250,28 +250,28 @@ export abstract class HandlebarsNodeVisitors extends Parser {
   }
 
   PartialStatement(partial: HBS.PartialStatement): never {
-    throw new GlimmerSyntaxError(
+    throw generateSyntaxError(
       `Handlebars partials are not supported`,
       this.source.spanFor(partial.loc)
     );
   }
 
   PartialBlockStatement(partialBlock: HBS.PartialBlockStatement): never {
-    throw new GlimmerSyntaxError(
+    throw generateSyntaxError(
       `Handlebars partial blocks are not supported`,
       this.source.spanFor(partialBlock.loc)
     );
   }
 
   Decorator(decorator: HBS.Decorator): never {
-    throw new GlimmerSyntaxError(
+    throw generateSyntaxError(
       `Handlebars decorators are not supported`,
       this.source.spanFor(decorator.loc)
     );
   }
 
   DecoratorBlock(decoratorBlock: HBS.DecoratorBlock): never {
-    throw new GlimmerSyntaxError(
+    throw generateSyntaxError(
       `Handlebars decorator blocks are not supported`,
       this.source.spanFor(decoratorBlock.loc)
     );
@@ -288,26 +288,26 @@ export abstract class HandlebarsNodeVisitors extends Parser {
 
     if (original.indexOf('/') !== -1) {
       if (original.slice(0, 2) === './') {
-        throw new GlimmerSyntaxError(
+        throw generateSyntaxError(
           `Using "./" is not supported in Glimmer and unnecessary`,
           this.source.spanFor(path.loc)
         );
       }
       if (original.slice(0, 3) === '../') {
-        throw new GlimmerSyntaxError(
+        throw generateSyntaxError(
           `Changing context using "../" is not supported in Glimmer`,
           this.source.spanFor(path.loc)
         );
       }
       if (original.indexOf('.') !== -1) {
-        throw new GlimmerSyntaxError(
+        throw generateSyntaxError(
           `Mixing '.' and '/' in paths is not supported in Glimmer; use only '.' to separate property paths`,
           this.source.spanFor(path.loc)
         );
       }
       parts = [path.parts.join('/')];
     } else if (original === '.') {
-      throw new GlimmerSyntaxError(
+      throw generateSyntaxError(
         `'.' is not a supported path in Glimmer; check for a path with a trailing '.'`,
         this.source.spanFor(path.loc)
       );
@@ -344,7 +344,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
       let head = parts.shift();
 
       if (head === undefined) {
-        throw new GlimmerSyntaxError(
+        throw generateSyntaxError(
           `Attempted to parse a path expression, but it was not valid. Paths beginning with @ must start with a-z.`,
           this.source.spanFor(path.loc)
         );
@@ -362,7 +362,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
       let head = parts.shift();
 
       if (head === undefined) {
-        throw new GlimmerSyntaxError(
+        throw generateSyntaxError(
           `Attempted to parse a path expression, but it was not valid. Paths must start with a-z or A-Z.`,
           this.source.spanFor(path.loc)
         );
@@ -497,7 +497,7 @@ function addElementModifier(
     let modifier = `{{${printLiteral(path)}}}`;
     let tag = `<${element.name} ... ${modifier} ...`;
 
-    throw new GlimmerSyntaxError(`In ${tag}, ${modifier} is not a valid modifier`, mustache.loc);
+    throw generateSyntaxError(`In ${tag}, ${modifier} is not a valid modifier`, mustache.loc);
   }
 
   let modifier = b.elementModifier({ path, params, hash, loc });

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -8,7 +8,7 @@ import { voidMap } from '../generation/printer';
 import { Tag } from '../parser';
 import { Source } from '../source/source';
 import { SourceOffset, SourceSpan } from '../source/span';
-import { GlimmerSyntaxError } from '../syntax-error';
+import { generateSyntaxError } from '../syntax-error';
 import traverse from '../traversal/traverse';
 import { NodeVisitor } from '../traversal/visitor';
 import Walker from '../traversal/walker';
@@ -205,7 +205,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     let tokenizerPos = this.offset();
 
     if (tag.type === 'EndTag') {
-      throw new GlimmerSyntaxError(
+      throw generateSyntaxError(
         `Invalid end tag: closing tag must not have attributes`,
         this.source.spanFor({ start: tag.loc.toJSON(), end: tokenizerPos.toJSON() })
       );
@@ -221,7 +221,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
   }
 
   reportSyntaxError(message: string): void {
-    throw new GlimmerSyntaxError(message, this.offset().collapsed());
+    throw generateSyntaxError(message, this.offset().collapsed());
   }
 
   assembleConcatenatedValue(
@@ -231,7 +231,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       let part: ASTv1.BaseNode = parts[i];
 
       if (part.type !== 'MustacheStatement' && part.type !== 'TextNode') {
-        throw new GlimmerSyntaxError(
+        throw generateSyntaxError(
           'Unsupported node in quoted attribute value: ' + part['type'],
           part.loc
         );
@@ -265,7 +265,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     }
 
     if (error) {
-      throw new GlimmerSyntaxError(error, tag.loc);
+      throw generateSyntaxError(error, tag.loc);
     }
   }
 
@@ -287,7 +287,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
         ) {
           return parts[0];
         } else {
-          throw new GlimmerSyntaxError(
+          throw generateSyntaxError(
             `An unquoted attribute value must be a string or a mustache, ` +
               `preceded by whitespace or a '=' character, and ` +
               `followed by whitespace, a '>' character, or '/>'`,

--- a/packages/@glimmer/syntax/lib/utils.ts
+++ b/packages/@glimmer/syntax/lib/utils.ts
@@ -1,7 +1,7 @@
 import { Option } from '@glimmer/interfaces';
 import { expect } from '@glimmer/util';
 
-import { GlimmerSyntaxError } from './syntax-error';
+import { generateSyntaxError } from './syntax-error';
 import * as ASTv1 from './v1/api';
 import * as HBS from './v1/handlebars-ast';
 
@@ -36,7 +36,7 @@ function parseBlockParams(element: ASTv1.ElementNode): Option<string[]> {
       paramsString.charAt(paramsString.length - 1) !== '|' ||
       expect(paramsString.match(/\|/g), `block params must exist here`).length !== 2
     ) {
-      throw new GlimmerSyntaxError(
+      throw generateSyntaxError(
         "Invalid block parameters syntax, '" + paramsString + "'",
         element.loc
       );
@@ -47,7 +47,7 @@ function parseBlockParams(element: ASTv1.ElementNode): Option<string[]> {
       let param = attrNames[i].replace(/\|/g, '');
       if (param !== '') {
         if (ID_INVERSE_PATTERN.test(param)) {
-          throw new GlimmerSyntaxError(
+          throw generateSyntaxError(
             "Invalid identifier for block parameters, '" + param + "'",
             element.loc
           );
@@ -57,7 +57,7 @@ function parseBlockParams(element: ASTv1.ElementNode): Option<string[]> {
     }
 
     if (params.length === 0) {
-      throw new GlimmerSyntaxError('Cannot use zero block parameters', element.loc);
+      throw generateSyntaxError('Cannot use zero block parameters', element.loc);
     }
 
     element.attributes = element.attributes.slice(0, asIndex);


### PR DESCRIPTION
This updates syntax errors to throw normal errors, with an additional property added. This allows them to work with browser tooling the right way.