### PR TITLE
Ensure `loc` is populated by `builders.element(...)`

### DIFF
--- a/packages/@glimmer/syntax/lib/v1/public-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/public-builders.ts
@@ -199,7 +199,7 @@ export interface BuildElementOptions {
   children?: ASTv1.Statement[];
   comments?: ElementComment[];
   blockParams?: string[];
-  loc: SourceSpan;
+  loc?: SourceSpan;
 }
 
 function buildElement(tag: TagDescriptor, options: BuildElementOptions): ASTv1.ElementNode {
@@ -228,7 +228,7 @@ function buildElement(tag: TagDescriptor, options: BuildElementOptions): ASTv1.E
     modifiers: modifiers || [],
     comments: (comments as ASTv1.MustacheCommentStatement[]) || [],
     children: children || [],
-    loc,
+    loc: buildLoc(loc || null),
   };
 }
 


### PR DESCRIPTION
Fixes issues with AST transforms that were previously not passing `loc` in the `builders.element` options.

Many AST transform based builders exist, and not all of them thread through a `loc` property. Some examples:

https://github.com/DockYard/ember-maybe-in-element/blob/68067d0cb45554db309af540f4c5e8754c90c742/lib/ast-transform.js#L28-L34

https://github.com/DockYard/ember-maybe-in-element/blob/68067d0cb45554db309af540f4c5e8754c90c742/lib/ast-transform.js#L38-L42

https://github.com/ember-template-lint/ember-template-recast/blob/7ad3aec371df48a76907a743779b0fa5cac97b39/src/parse-result.test.ts#L11

https://github.com/ember-template-lint/ember-template-recast/blob/7ad3aec371df48a76907a743779b0fa5cac97b39/src/parse-result.test.ts#L234-L248

Should fix https://github.com/cibernox/ember-basic-dropdown/issues/586