### PR TITLE
Ensure `@tracked` assertion can be made a deprecation.

### DIFF
--- a/packages/@glimmer/validator/lib/debug.ts
+++ b/packages/@glimmer/validator/lib/debug.ts
@@ -21,7 +21,7 @@ export let setTrackingTransactionEnv:
 
 export let assertTagNotConsumed:
   | undefined
-  | (<T>(tag: Tag, obj?: T, keyName?: keyof T | string | symbol, forceHardError?: boolean) => void);
+  | (<T>(tag: Tag, obj?: T, keyName?: keyof T | string | symbol) => void);
 
 export let markTagAsConsumed: undefined | ((_tag: Tag) => void);
 
@@ -223,12 +223,7 @@ if (DEBUG) {
     }
   };
 
-  assertTagNotConsumed = <T>(
-    tag: Tag,
-    obj?: T,
-    keyName?: keyof T | string | symbol,
-    forceHardError: boolean | undefined = false
-  ) => {
+  assertTagNotConsumed = <T>(tag: Tag, obj?: T, keyName?: keyof T | string | symbol) => {
     if (CONSUMED_TAGS === null) return;
 
     let transaction = CONSUMED_TAGS.get(tag);
@@ -237,7 +232,7 @@ if (DEBUG) {
 
     let currentTransaction = TRANSACTION_STACK[TRANSACTION_STACK.length - 1];
 
-    if (currentTransaction.deprecate && !forceHardError) {
+    if (currentTransaction.deprecate) {
       TRANSACTION_ENV.deprecate(makeTrackingErrorMessage(transaction, obj, keyName));
     } else {
       // This hack makes the assertion message nicer, we can cut off the first

--- a/packages/@glimmer/validator/lib/meta.ts
+++ b/packages/@glimmer/validator/lib/meta.ts
@@ -35,7 +35,7 @@ export function dirtyTagFor<T extends object>(
       unwrap(assertTagNotConsumed)(propertyTag, obj, key);
     }
 
-    DIRTY_TAG(propertyTag);
+    DIRTY_TAG(propertyTag, true);
   }
 }
 

--- a/packages/@glimmer/validator/lib/tracked-data.ts
+++ b/packages/@glimmer/validator/lib/tracked-data.ts
@@ -1,6 +1,4 @@
-import { DEBUG } from '@glimmer/env';
 import { tagFor, dirtyTagFor } from './meta';
-import { assertTagNotConsumed } from './debug';
 import { consumeTag } from './tracking';
 
 export type Getter<T, K extends keyof T> = (self: T) => T[K] | undefined;
@@ -30,10 +28,6 @@ export function trackedData<T extends object, K extends keyof T>(
   }
 
   function setter(self: T, value: T[K]): void {
-    if (DEBUG) {
-      assertTagNotConsumed!(tagFor(self, key), self, key, true);
-    }
-
     dirtyTagFor(self, key);
     values.set(self, value);
   }

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -203,7 +203,7 @@ class MonomorphicTagImpl<T extends MonomorphicTagTypes = MonomorphicTagTypes> {
     }
   }
 
-  static dirtyTag(tag: DirtyableTag | UpdatableTag) {
+  static dirtyTag(tag: DirtyableTag | UpdatableTag, disableConsumptionAssertion?: boolean) {
     if (
       DEBUG &&
       !(tag[TYPE] === MonomorphicTagTypes.Updatable || tag[TYPE] === MonomorphicTagTypes.Dirtyable)
@@ -211,7 +211,7 @@ class MonomorphicTagImpl<T extends MonomorphicTagTypes = MonomorphicTagTypes> {
       throw new Error('Attempted to dirty a tag that was not dirtyable');
     }
 
-    if (DEBUG) {
+    if (DEBUG && disableConsumptionAssertion !== true) {
       // Usually by this point, we've already asserted with better error information,
       // but this is our last line of defense.
       unwrap(assertTagNotConsumed)(tag);


### PR DESCRIPTION
During recent refactors that landed in glimmer-vm@0.57 (Glimmer VM version that landed in Ember 3.22) we moved the internal infrastructure to ensure **everything** was in a tracking frame. This greatly increased the number of locations that would now fall under the standard read + write assertions.

For example, in glimmer-vm@0.56 the following would run without error:

```js
import Component from '@glimmer/component';
import { tracked } from '@glimmer/tracking';

export default class extends Component {
  @tracked counter = 0;

  constructor() {
    super(...arguments);

    this.counter++;
  }
}
```

Now, obviously this is a bit contrived, but the point is that since component construction was not previously within a tracking frame it would **not** error due to the read then write of a tracked property.

As of glimmer-vm@0.60+ we **do** run this within a tracking frame (becauase nearly everything is automatically within a tracking frame).

The infrastructure being updated here (`forceHardError` argument to `assertTagNotConsumed`) was intended to ensure that it was not possible to end up with a `@tracked` property that was set after consumption during a tracking frame, but to still allow for things using Ember's `markObjectsAsDirty` (via `notifyPropertyChange`) to trigger a deprecation. Unfortunately, now that we have _increased_ the areas of the codebase that are within tracking frames we can no longer use `forceHardError` internally if we want our host environments to satisfy their SemVer requirements (shouldn't be adding new failures for things that worked "fine" in a minor release of Ember).

This change in and of itself doesn't _really_ do anything (all of the same things would still error) however it does allow host environments to leverage `deprecateMutationsInTrackingTransaction` as appropriate to issue a warning instead of a failure for cases that previously worked.

Related to https://github.com/emberjs/ember.js/issues/19192
PR in Ember to take advantage: https://github.com/emberjs/ember.js/pull/19282