### PR TITLE
[BUGFIX] Ensures keywords and elements can always be shadowed

### DIFF
--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords.ts
@@ -1,3 +1,4 @@
-export { EXPR_KEYWORDS } from './keywords/expr';
+export { CALL_KEYWORDS } from './keywords/call';
 export { APPEND_KEYWORDS } from './keywords/append';
 export { BLOCK_KEYWORDS } from './keywords/block';
+export { MODIFIER_KEYWORDS } from './keywords/modifier';

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
@@ -7,7 +7,7 @@ import { VISIT_EXPRS } from '../visitors/expressions';
 import { assertValidHasBlockUsage } from './has-block';
 import { ExprKeywordNode, keywords } from './impl';
 
-export const EXPR_KEYWORDS = keywords('Expr')
+export const CALL_KEYWORDS = keywords('Call')
   .kw('has-block', {
     assert(node: ExprKeywordNode): Result<SourceSlice> {
       return assertValidHasBlockUsage('has-block', node);
@@ -36,15 +36,6 @@ export const EXPR_KEYWORDS = keywords('Expr')
   })
   .kw('component', {
     assert(node: ExprKeywordNode): Result<{ definition: ASTv2.ExpressionNode; args: ASTv2.Args }> {
-      if (node.type !== 'Call') {
-        return Err(
-          generateSyntaxError(
-            'The (component) keyword must be called with arguments in order to curry a component definition. It cannot be used directly as a value.',
-            node.loc
-          )
-        );
-      }
-
       let { args } = node;
       let definition = args.nth(0);
 

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/modifier.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/modifier.ts
@@ -1,0 +1,3 @@
+import { keywords } from './impl';
+
+export const MODIFIER_KEYWORDS = keywords('Modifier');

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
@@ -2,18 +2,6 @@ import { PresentArray } from '@glimmer/interfaces';
 import { ASTv2, generateSyntaxError, SourceSlice } from '@glimmer/syntax';
 import { unreachable } from '@glimmer/util';
 
-import { KeywordNode } from '../keywords/impl';
-
-export function isPath(node: KeywordNode): node is ASTv2.PathExpression {
-  return node.type === 'Path';
-}
-
-export function isCall(
-  node: ASTv2.ExpressionNode | ASTv2.ContentNode
-): node is ASTv2.CallExpression | ASTv2.AppendContent {
-  return node.type === 'Call' || node.type === 'AppendContent';
-}
-
 export type HasPath<Node extends ASTv2.CallNode = ASTv2.CallNode> = Node & {
   head: ASTv2.PathExpression;
 };

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/element/component.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/element/component.ts
@@ -3,7 +3,7 @@ import { ASTv2 } from '@glimmer/syntax';
 import { Result } from '../../../../shared/result';
 import * as mir from '../../../2-encoding/mir';
 import { NormalizationState } from '../../context';
-import { VISIT_EXPRS } from '../expressions';
+import { convertPathToCallIfKeyword, VISIT_EXPRS } from '../expressions';
 import { VISIT_STMTS } from '../statements';
 import { Classified, ClassifiedElement, PreparedArgs } from './classified';
 
@@ -15,7 +15,7 @@ export class ClassifiedComponent implements Classified {
   arg(attr: ASTv2.ComponentArg, { state }: ClassifiedElement): Result<mir.NamedArgument> {
     let name = attr.name;
 
-    return VISIT_EXPRS.visit(attr.value, state).mapOk(
+    return VISIT_EXPRS.visit(convertPathToCallIfKeyword(attr.value), state).mapOk(
       (value) =>
         new mir.NamedArgument({
           loc: attr.loc,

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/expressions.ts
@@ -1,30 +1,30 @@
 import { PresentArray } from '@glimmer/interfaces';
-import { ASTv2 } from '@glimmer/syntax';
+import { ASTv2, KEYWORDS_TYPES } from '@glimmer/syntax';
 import { isPresent } from '@glimmer/util';
 
 import { AnyOptionalList, PresentList } from '../../../shared/list';
 import { Ok, Result, ResultArray } from '../../../shared/result';
 import * as mir from '../../2-encoding/mir';
 import { NormalizationState } from '../context';
-import { EXPR_KEYWORDS } from '../keywords';
+import { CALL_KEYWORDS } from '../keywords';
 import { assertIsValidHelper, hasPath } from '../utils/is-node';
 
 export class NormalizeExpressions {
   visit(node: ASTv2.ExpressionNode, state: NormalizationState): Result<mir.ExpressionNode> {
-    let translated = EXPR_KEYWORDS.translate(node, state);
-
-    if (translated !== null) {
-      return translated;
-    }
-
     switch (node.type) {
       case 'Literal':
         return Ok(this.Literal(node));
       case 'Interpolate':
         return this.Interpolate(node, state);
       case 'Path':
-        return this.PathExpression(node, state);
+        return this.PathExpression(node);
       case 'Call':
+        let translated = CALL_KEYWORDS.translate(node, state);
+
+        if (translated !== null) {
+          return translated;
+        }
+
         return this.CallExpression(node, state);
     }
   }
@@ -50,16 +50,7 @@ export class NormalizeExpressions {
    * TODO since keywords don't support tails anyway, distinguish PathExpression from
    * VariableReference in ASTv2.
    */
-  PathExpression(
-    path: ASTv2.PathExpression,
-    state: NormalizationState
-  ): Result<mir.ExpressionNode> {
-    let expr = EXPR_KEYWORDS.translate(path, state);
-
-    if (expr !== null) {
-      return expr;
-    }
-
+  PathExpression(path: ASTv2.PathExpression): Result<mir.ExpressionNode> {
     let ref = this.VariableReference(path.ref);
     let { tail } = path;
 
@@ -89,7 +80,9 @@ export class NormalizeExpressions {
     expr: ASTv2.InterpolateExpression,
     state: NormalizationState
   ): Result<mir.InterpolateExpression> {
-    return VISIT_EXPRS.visitList(expr.parts, state).mapOk(
+    let parts = expr.parts.map(convertPathToCallIfKeyword) as PresentArray<ASTv2.ExpressionNode>;
+
+    return VISIT_EXPRS.visitList(parts, state).mapOk(
       (parts) => new mir.InterpolateExpression({ loc: expr.loc, parts: parts })
     );
   }
@@ -145,21 +138,35 @@ export class NormalizeExpressions {
     named: ASTv2.NamedArguments,
     state: NormalizationState
   ): Result<mir.NamedArguments> {
-    let pairs = named.entries.map((arg) =>
-      VISIT_EXPRS.visit(arg.value, state).mapOk(
+    let pairs = named.entries.map((arg) => {
+      let value = convertPathToCallIfKeyword(arg.value);
+
+      return VISIT_EXPRS.visit(value, state).mapOk(
         (value) =>
           new mir.NamedArgument({
             loc: arg.loc,
             key: arg.name,
             value,
           })
-      )
-    );
+      );
+    });
 
     return new ResultArray(pairs)
       .toOptionalList()
       .mapOk((pairs) => new mir.NamedArguments({ loc: named.loc, entries: pairs }));
   }
+}
+
+export function convertPathToCallIfKeyword(path: ASTv2.ExpressionNode): ASTv2.ExpressionNode {
+  if (path.type === 'Path' && path.ref.type === 'Free' && path.ref.name in KEYWORDS_TYPES) {
+    return new ASTv2.CallExpression({
+      callee: path,
+      args: ASTv2.Args.empty(path.loc),
+      loc: path.loc,
+    });
+  }
+
+  return path;
 }
 
 export const VISIT_EXPRS = new NormalizeExpressions();

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
@@ -18,8 +18,9 @@ export class ExpressionEncoder {
       case 'PathExpression':
         return this.PathExpression(expr);
       case 'Arg':
-      case 'Local':
         return [SexpOpcodes.GetSymbol, expr.symbol];
+      case 'Local':
+        return this.Local(expr);
       case 'This':
         return [SexpOpcodes.GetSymbol, 0];
       case 'Free':
@@ -66,18 +67,14 @@ export class ExpressionEncoder {
     ];
   }
 
-  Free({
+  Local({
+    isTemplateLocal,
     symbol,
-    context,
-  }: mir.GetFreeWithContext):
-    | WireFormat.Expressions.GetContextualFree
-    | WireFormat.Expressions.GetStrictFree {
-    return [context.resolution(), symbol];
+  }: ASTv2.LocalVarReference):
+    | WireFormat.Expressions.GetSymbol
+    | WireFormat.Expressions.GetTemplateSymbol {
+    return [isTemplateLocal ? SexpOpcodes.GetTemplateSymbol : SexpOpcodes.GetSymbol, symbol];
   }
-
-  // GetFree({ symbol }: mir.GetFree): WireFormat.Expressions.GetStrictFree {
-  //   return [SexpOpcodes.GetStrictFree, symbol];
-  // }
 
   GetWithResolver({ symbol }: mir.GetWithResolver): WireFormat.Expressions.GetContextualFree {
     return [SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback, symbol];

--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -205,6 +205,10 @@ export default class WireFormatDebugger {
           }
         }
 
+        case Op.GetTemplateSymbol: {
+          return ['get-template-symbol', opcode[1], opcode[2]];
+        }
+
         case Op.If:
           return [
             'if',

--- a/packages/@glimmer/integration-tests/lib/suites/has-block.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/has-block.ts
@@ -137,6 +137,18 @@ export class HasBlockSuite extends RenderTest {
   }
 
   @test({ kind: 'curly' })
+  'has-block works when used directly as an argument without extra parens (prop, default)'() {
+    this.registerComponent('TemplateOnly', 'Foo', '{{@hasBlock}}');
+
+    this.render({
+      layout: '<Foo @hasBlock={{has-block}}></Foo>',
+    });
+
+    this.assertComponent('false');
+    this.assertStableRerender();
+  }
+
+  @test({ kind: 'curly' })
   'parameterized has-block (attr, else) when else supplied'() {
     this.render({
       layout: '<button data-has-block="{{has-block "inverse"}}"></button>',

--- a/packages/@glimmer/integration-tests/test/keyword-errors-test.ts
+++ b/packages/@glimmer/integration-tests/test/keyword-errors-test.ts
@@ -1,0 +1,178 @@
+import { RenderTest, jitSuite, test, preprocess } from '..';
+import { KEYWORDS_TYPES } from '@glimmer/syntax';
+
+const KEYWORDS = Object.keys(KEYWORDS_TYPES);
+
+const BLOCK_KEYWORDS = KEYWORDS.filter((key) => KEYWORDS_TYPES[key].indexOf('Block') !== -1);
+
+const APPEND_KEYWORDS = KEYWORDS.filter((key) => KEYWORDS_TYPES[key].indexOf('Append') !== -1);
+
+const CALL_KEYWORDS = KEYWORDS.filter((key) => KEYWORDS_TYPES[key].indexOf('Call') !== -1);
+
+const MODIFIER_KEYWORDS = KEYWORDS.filter((key) => KEYWORDS_TYPES[key].indexOf('Modifier') !== -1);
+
+for (let keyword of KEYWORDS) {
+  class KeywordSyntaxErrors extends RenderTest {
+    static suiteName = `\`${keyword}\` keyword errors`;
+
+    @test
+    'keyword can be used as a value in non-strict mode'() {
+      preprocess(`{{some-helper ${keyword}}}`, { meta: { moduleName: 'test-module' } });
+    }
+
+    @test
+    'keyword can be used as a value in strict mode'() {
+      preprocess(`{{some-helper ${keyword}}}`, {
+        strictMode: true,
+        locals: [keyword],
+        meta: { moduleName: 'test-module' },
+      });
+    }
+
+    @test
+    'keyword can be yielded as a parameter in other keywords in non-strict mode'() {
+      preprocess(
+        `
+          {{#let value as |${keyword}|}}
+            {{some-helper ${keyword}}}
+          {{/let}}
+        `,
+        { meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'keyword can be yielded as a parameter in other keywords in strict mode'() {
+      preprocess(
+        `
+          {{#let value as |${keyword}|}}
+            {{some-helper ${keyword}}}
+          {{/let}}
+        `,
+        { strictMode: true, meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'keyword can be yielded as a parameter in curly invocation in non-strict mode'() {
+      preprocess(
+        `
+          {{#my-component value as |${keyword}|}}
+            {{some-helper ${keyword}}}
+          {{/my-component}}
+        `,
+        { meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'keyword can be yielded as a parameter in curly invocation in strict mode'() {
+      preprocess(
+        `
+          {{#my-component value as |${keyword}|}}
+            {{some-helper ${keyword}}}
+          {{/my-component}}
+        `,
+        { strictMode: true, meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'keyword can be yielded as a parameter in component blocks in non-strict mode'() {
+      preprocess(
+        `
+          <SomeComponent as |${keyword}|>
+            {{some-helper ${keyword}}}
+          </SomeComponent>
+        `,
+        { meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'keyword can be yielded as a parameter in component blocks in strict mode'() {
+      preprocess(
+        `
+          <SomeComponent as |${keyword}|>
+            {{some-helper ${keyword}}}
+          </SomeComponent>
+        `,
+        { strictMode: true, meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'keyword can be yielded as a parameter in component named blocks in non-strict mode'() {
+      preprocess(
+        `
+          <SomeComponent>
+            <:main as |${keyword}|>
+              {{some-helper ${keyword}}}
+            </:main>
+          </SomeComponent>
+        `,
+        { meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'keyword can be yielded as a parameter in component named blocks in strict mode'() {
+      preprocess(
+        `
+          <SomeComponent>
+            <:main as |${keyword}|>
+              {{some-helper ${keyword}}}
+            </:main>
+          </SomeComponent>
+        `,
+        { strictMode: true, meta: { moduleName: 'test-module' } }
+      );
+    }
+
+    @test
+    'non-block keywords cannot be used as blocks'() {
+      if (BLOCK_KEYWORDS.indexOf(keyword) !== -1) {
+        return;
+      }
+
+      this.assert.throws(() => {
+        preprocess(`{{#${keyword}}}{{/${keyword}}}`, { meta: { moduleName: 'test-module' } });
+      }, new RegExp(`The \`${keyword}\` keyword was used incorrectly. It was used as a block statement, but its valid usages are:`));
+    }
+
+    @test
+    'non-append keywords cannot be used as appends'() {
+      if (APPEND_KEYWORDS.indexOf(keyword) !== -1) {
+        return;
+      }
+
+      this.assert.throws(() => {
+        preprocess(`{{${keyword}}}`, { meta: { moduleName: 'test-module' } });
+      }, new RegExp(`The \`${keyword}\` keyword was used incorrectly. It was used as an append statement, but its valid usages are:`));
+    }
+
+    @test
+    'non-expr keywords cannot be used as expr'() {
+      if (CALL_KEYWORDS.indexOf(keyword) !== -1) {
+        return;
+      }
+
+      this.assert.throws(() => {
+        preprocess(`{{some-helper (${keyword})}}`, { meta: { moduleName: 'test-module' } });
+      }, new RegExp(`The \`${keyword}\` keyword was used incorrectly. It was used as a call expression, but its valid usages are:`));
+    }
+
+    @test
+    'non-modifier keywords cannot be used as modifier'() {
+      if (MODIFIER_KEYWORDS.indexOf(keyword) !== -1) {
+        return;
+      }
+
+      this.assert.throws(() => {
+        preprocess(`<div {{${keyword}}}></div>`, { meta: { moduleName: 'test-module' } });
+      }, new RegExp(`The \`${keyword}\` keyword was used incorrectly. It was used as a modifier, but its valid usages are:`));
+    }
+  }
+
+  jitSuite(KeywordSyntaxErrors);
+}

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -62,37 +62,41 @@ export const enum SexpOpcodes {
   Concat = 29,
 
   // Get
+  // Get a local value via symbol
   GetSymbol = 30, // GetPath + 0-2,
+  // Template symbol are values that are in scope in the template in strict mode
+  GetTemplateSymbol = 32,
+  // Free variables are only keywords in strict mode
   GetStrictFree = 31,
 
   // falls back to `this.` (or locals in the case of partials), but
   // never turns into a component or helper invocation
-  GetFreeAsFallback = 32,
+  GetFreeAsFallback = 33,
   // `{{x}}` in append position (might be a helper or component invocation, otherwise fall back to `this`)
-  GetFreeAsComponentOrHelperHeadOrThisFallback = 33,
+  GetFreeAsComponentOrHelperHeadOrThisFallback = 34,
   // a component or helper (`{{<expr> x}}` in append position)
-  GetFreeAsComponentOrHelperHead = 34,
+  GetFreeAsComponentOrHelperHead = 35,
   // a helper or `this` fallback `attr={{x}}`
-  GetFreeAsHelperHeadOrThisFallback = 35,
+  GetFreeAsHelperHeadOrThisFallback = 36,
   // a call head `(x)`
-  GetFreeAsHelperHead = 36,
-  GetFreeAsModifierHead = 37,
-  GetFreeAsComponentHead = 38,
+  GetFreeAsHelperHead = 37,
+  GetFreeAsModifierHead = 38,
+  GetFreeAsComponentHead = 39,
 
   // Keyword Statements
-  InElement = 39,
-  If = 40,
-  Unless = 41,
-  Each = 42,
-  With = 43,
-  Let = 44,
-  WithDynamicVars = 45,
-  InvokeComponent = 46,
+  InElement = 40,
+  If = 41,
+  Unless = 42,
+  Each = 43,
+  With = 44,
+  Let = 45,
+  WithDynamicVars = 46,
+  InvokeComponent = 47,
 
   // Keyword Expressions
-  HasBlock = 47,
-  HasBlockParams = 48,
-  CurryComponent = 49,
+  HasBlock = 48,
+  HasBlockParams = 49,
+  CurryComponent = 50,
 
   GetStart = GetSymbol,
   GetEnd = GetFreeAsComponentHead,
@@ -156,6 +160,7 @@ export namespace Expressions {
   export type Hash = Core.Hash;
 
   export type GetSymbol = [SexpOpcodes.GetSymbol, number];
+  export type GetTemplateSymbol = [SexpOpcodes.GetTemplateSymbol, number];
   export type GetStrictFree = [SexpOpcodes.GetStrictFree, number];
   export type GetFreeAsFallback = [SexpOpcodes.GetFreeAsFallback, number];
   export type GetFreeAsComponentOrHelperHeadOrThisFallback = [
@@ -180,9 +185,10 @@ export namespace Expressions {
     | GetFreeAsModifierHead
     | GetFreeAsComponentHead;
   export type GetFree = GetStrictFree | GetContextualFree;
-  export type GetVar = GetSymbol | GetFree;
+  export type GetVar = GetSymbol | GetTemplateSymbol | GetFree;
 
   export type GetPathSymbol = [SexpOpcodes.GetSymbol, number, Path];
+  export type GetPathTemplateSymbol = [SexpOpcodes.GetTemplateSymbol, number, Path];
   export type GetPathStrictFree = [SexpOpcodes.GetStrictFree, number, Path];
   export type GetPathFreeAsFallback = [SexpOpcodes.GetFreeAsFallback, number, Path];
   export type GetPathFreeAsComponentOrHelperHeadOrThisFallback = [
@@ -213,7 +219,7 @@ export namespace Expressions {
     | GetPathFreeAsModifierHead
     | GetPathFreeAsComponentHead;
   export type GetPathFree = GetPathStrictFree | GetPathContextualFree;
-  export type GetPath = GetPathSymbol | GetPathFree;
+  export type GetPath = GetPathSymbol | GetPathTemplateSymbol | GetPathFree;
 
   export type Get = GetVar | GetPath;
 

--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -20,6 +20,7 @@ export { default as traverse } from './lib/traversal/traverse';
 export { NodeVisitor } from './lib/traversal/visitor';
 export { cannotRemoveNode, cannotReplaceNode } from './lib/traversal/errors';
 export { default as WalkerPath } from './lib/traversal/path';
+export { isKeyword, KeywordType, KEYWORDS_TYPES } from './lib/keywords';
 
 export { SourceSlice } from './lib/source/slice';
 export { SourceSpan } from './lib/source/span';

--- a/packages/@glimmer/syntax/lib/keywords.ts
+++ b/packages/@glimmer/syntax/lib/keywords.ts
@@ -1,0 +1,34 @@
+export type KeywordType = 'Call' | 'Modifier' | 'Append' | 'Block';
+
+export function isKeyword(word: string): boolean {
+  return word in KEYWORDS_TYPES;
+}
+
+/**
+ * This includes the full list of keywords currently in use in the template
+ * language, and where their valid usages are.
+ */
+export const KEYWORDS_TYPES: { [key: string]: KeywordType[] } = {
+  component: ['Call', 'Append', 'Block'],
+  debugger: ['Append'],
+  'each-in': ['Block'],
+  each: ['Block'],
+  'has-block-params': ['Call', 'Append'],
+  'has-block': ['Call', 'Append'],
+  helper: ['Call', 'Append'],
+  if: ['Call', 'Append', 'Block'],
+  'in-element': ['Block'],
+  let: ['Block'],
+  'link-to': ['Append', 'Block'],
+  log: ['Call', 'Append'],
+  modifier: ['Call'],
+  mount: ['Append'],
+  mut: ['Call', 'Append'],
+  outlet: ['Append'],
+  'query-params': ['Call'],
+  readonly: ['Call', 'Append'],
+  unbound: ['Call', 'Append'],
+  unless: ['Call', 'Append', 'Block'],
+  with: ['Block'],
+  yield: ['Append'],
+};

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -334,6 +334,8 @@ export interface PrecompileOptions extends PreprocessOptions {
 }
 
 export interface PreprocessOptions {
+  strictMode?: boolean;
+  locals?: string[];
   meta?: {
     moduleName?: string;
   };
@@ -411,6 +413,10 @@ export function preprocess(
   };
 
   let program = new TokenizerEventHandlers(source, entityParser, mode).acceptTemplate(ast);
+
+  if (options.strictMode) {
+    program.blockParams = options.locals ?? [];
+  }
 
   if (options && options.plugins && options.plugins.ast) {
     for (let i = 0, l = options.plugins.ast.length; i < l; i++) {

--- a/packages/@glimmer/syntax/lib/traversal/scope.ts
+++ b/packages/@glimmer/syntax/lib/traversal/scope.ts
@@ -1,0 +1,138 @@
+import * as ASTv1 from '../v1/api';
+
+function getLocalName(node: ASTv1.Node): string | undefined {
+  switch (node.type) {
+    case 'ElementNode':
+      // unfortunately the ElementNode stores `tag` as a string
+      // if that changes in glimmer-vm this will need to be updated
+      return node.tag.split('.')[0];
+
+    case 'SubExpression':
+    case 'MustacheStatement':
+    case 'BlockStatement':
+      return getLocalName(node.path);
+
+    case 'UndefinedLiteral':
+    case 'NullLiteral':
+    case 'BooleanLiteral':
+    case 'StringLiteral':
+    case 'NumberLiteral':
+    case 'TextNode':
+    case 'Template':
+    case 'Block':
+    case 'CommentStatement':
+    case 'MustacheCommentStatement':
+    case 'PartialStatement':
+    case 'ElementModifierStatement':
+    case 'AttrNode':
+    case 'ConcatStatement':
+    case 'Program':
+    case 'Hash':
+    case 'HashPair':
+      return undefined;
+    case 'PathExpression':
+    default:
+      return node.parts.length ? node.parts[0] : undefined;
+  }
+}
+
+function getLocals(node: ASTv1.Node): string[] | undefined {
+  switch (node.type) {
+    case 'ElementNode':
+    case 'Program':
+    case 'Block':
+    case 'Template':
+      return node.blockParams;
+
+    case 'BlockStatement':
+      return node.program.blockParams;
+
+    default:
+      return undefined;
+  }
+}
+
+export abstract class TransformScope {
+  hasPartial = false;
+  usedLocals: { [key: string]: boolean } = {};
+
+  constructor(protected locals: string[]) {
+    for (const local of locals) {
+      this.usedLocals[local] = false;
+    }
+  }
+
+  child(node: ASTv1.Node): TransformScope {
+    let locals = getLocals(node);
+
+    return locals ? new ChildTransformScope(locals, this) : this;
+  }
+
+  usePartial(): void {
+    this.hasPartial = true;
+  }
+
+  abstract isLocal(name: string): boolean;
+  abstract useLocal(node: ASTv1.Node): void;
+  abstract currentUnusedLocals(): string[] | false;
+}
+
+export default class RootTransformScope extends TransformScope {
+  constructor(node: ASTv1.Node) {
+    let locals = getLocals(node) ?? [];
+
+    super(locals);
+  }
+
+  useLocal(node: ASTv1.Node): void {
+    let name = getLocalName(node);
+
+    if (name && name in this.usedLocals) {
+      this.usedLocals[name] = true;
+    }
+  }
+
+  isLocal(name: string): boolean {
+    return this.locals.indexOf(name) !== -1;
+  }
+
+  currentUnusedLocals(): string[] | false {
+    if (!this.hasPartial && this.locals.length > 0) {
+      return this.locals.filter((local) => !this.usedLocals[local]);
+    }
+
+    return false;
+  }
+}
+
+class ChildTransformScope extends TransformScope {
+  constructor(locals: string[], private parent: TransformScope) {
+    super(locals);
+  }
+
+  useLocal(node: ASTv1.Node): void {
+    let name = getLocalName(node);
+
+    if (name && name in this.usedLocals) {
+      this.usedLocals[name] = true;
+    } else {
+      this.parent.useLocal(node);
+    }
+  }
+
+  isLocal(name: string): boolean {
+    return this.locals.indexOf(name) !== -1 || this.parent.isLocal(name);
+  }
+
+  currentUnusedLocals(): string[] | false {
+    if (!this.hasPartial && this.locals.length > 0) {
+      // We only care about the last local, because if it is used then it implies
+      // usage of the others (specifically when in a child block, |foo bar|)
+      if (!this.usedLocals[this.locals[this.locals.length - 1]]) {
+        return [this.locals[this.locals.length - 1]];
+      }
+    }
+
+    return false;
+  }
+}

--- a/packages/@glimmer/syntax/lib/v2-a/builders.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/builders.ts
@@ -192,7 +192,12 @@ export class Builder {
     });
   }
 
-  localVar(name: string, symbol: number, loc: SourceSpan): ASTv2.VariableReference {
+  localVar(
+    name: string,
+    symbol: number,
+    isTemplateLocal: boolean,
+    loc: SourceSpan
+  ): ASTv2.VariableReference {
     assert(name !== 'this', `You called builders.var() with 'this'. Call builders.this instead`);
     assert(
       name[0] !== '@',
@@ -202,6 +207,7 @@ export class Builder {
     return new ASTv2.LocalVarReference({
       loc,
       name,
+      isTemplateLocal,
       symbol,
     });
   }

--- a/packages/@glimmer/syntax/lib/v2-a/objects/refs.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/objects/refs.ts
@@ -16,7 +16,11 @@ export class ArgReference extends node('Arg').fields<{ name: SourceSlice; symbol
  * Corresponds to `<ident>` at the beginning of an expression, when `<ident>` is in the current
  * block's scope.
  */
-export class LocalVarReference extends node('Local').fields<{ name: string; symbol: number }>() {}
+export class LocalVarReference extends node('Local').fields<{
+  name: string;
+  isTemplateLocal: boolean;
+  symbol: number;
+}>() {}
 
 /**
  * Corresponds to `<ident>` at the beginning of an expression, when `<ident>` is *not* in the

--- a/packages/@glimmer/syntax/test/traversal/scope-test.ts
+++ b/packages/@glimmer/syntax/test/traversal/scope-test.ts
@@ -1,0 +1,61 @@
+import { preprocess, traverse } from '../..';
+
+const { module, test } = QUnit;
+
+module('[glimmer-syntax] Traversal - scope', () => {
+  test(`Scope is available in template root`, (assert) => {
+    let ast = preprocess(`<x y={{z}} />`, { strictMode: true, locals: ['x', 'y', 'z'] });
+
+    traverse(ast, {
+      Template: {
+        exit(_node, path) {
+          let unusedLocals = path.scope.currentUnusedLocals();
+
+          assert.deepEqual(unusedLocals, ['y'], 'locals marked as used/unused correctly');
+          assert.ok(path.scope.isLocal('x'), 'x is a local');
+          assert.ok(path.scope.isLocal('y'), 'y is a local');
+          assert.ok(path.scope.isLocal('z'), 'z is a local');
+        },
+      },
+    });
+  });
+
+  test(`Scope is available in blocks`, (assert) => {
+    let ast = preprocess(`<x as |y z|></x>`, { strictMode: true, locals: ['x', 'y'] });
+
+    traverse(ast, {
+      ElementNode: {
+        exit(_node, path) {
+          let unusedLocals = path.scope.currentUnusedLocals();
+
+          assert.deepEqual(unusedLocals, ['z'], 'locals marked as used/unused correctly');
+          assert.ok(path.scope.isLocal('x'), 'x is a local');
+          assert.ok(path.scope.isLocal('y'), 'y is a local');
+          assert.ok(path.scope.isLocal('z'), 'z is a local');
+        },
+      },
+    });
+  });
+
+  test(`currentUnusedLocals returns false if all locals are used in the current block, string names otherwise`, (assert) => {
+    let ast = preprocess(`<x as |y z|>{{z}}</x>`, { strictMode: true, locals: ['x', 'y'] });
+
+    traverse(ast, {
+      ElementNode: {
+        exit(_node, path) {
+          let unusedLocals = path.scope.currentUnusedLocals();
+
+          assert.deepEqual(unusedLocals, false, 'locals marked as used correctly');
+        },
+      },
+
+      Template: {
+        exit(_node, path) {
+          let unusedLocals = path.scope.currentUnusedLocals();
+
+          assert.deepEqual(unusedLocals, ['y'], 'locals marked as used correctly');
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Prior to this change, there was no way for root scope elements and
keywords to be shadowed. Elements and keywords were in principle
shadowable in every other context, but not within the root scope of
templates as there was no notion of a local scope.

This PR changes strict mode so that it receives a list of local
variable names, the template locals. These are then used to determine if
a particular value is a local variable. Template locals are treated much
like normal locals throughout the process, with the only difference
being that at the end they don't translate into a `GetSymbol` but a
`GetTemplateSymbol` opcode, the difference being that template symbols
are looked up in the scope object.

Free variables in strict mode are now limited solely to keywords, and as
a catch-all for throwing runtime errors if the value does not exist. We
could make this a stricter compile time error in the future potentially,
but for now it's left to be in strict mode.

## Notes

- Certain expressions are ambiguous "MaybeCall" expressions, e.g.
  `<Foo @arg={{maybeCallOrPath}}/>`. These are currently passed through
  the system as PathExpressions with a different resolution mode, and
  prior to this change, this required the keyword infrastructure to run
  on all PathExpressions. This was incorrect behavior however, as only
  these specific "MaybeCall" type expressions should have been converted
  into a keyword, when appropriate.

  This information needs to be more effectively threaded through the
  system, not just to fix this issue, but also because when strict mode
  is enabled, it will no longer be clear when something is a path
  expression vs. a MaybeCall. At the moment, this PR patches these
  specific PathExpressions and converts them into CallExpressions IFF
  they are keywords, so they can be converted by the keyword infra.

- A `scope` value has been added to the `path` provided to AST
  transforms, which gives users information about the template scope
  overall. This can be used for template linting rules.

## Breaking

- Keywords that are used in the incorrect position will give a helpful
  syntax error.
- Keywords can now only be used in the following positions:
  - Call
  - Append
  - Block
  - Modifier