### PR TITLE
[BUGFIX] Add output tag to attributes override

### DIFF
--- a/packages/@glimmer/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer/integration-tests/test/attributes-test.ts
@@ -181,6 +181,19 @@ export class AttributesTests extends RenderTest {
   }
 
   @test
+  'can set attributes on form properties'() {
+    this.render('<form id={{foo}}></form><output form={{foo}}></output>', { foo: 'bar' });
+
+    let outputElement = assertElement(this.element.lastChild);
+
+    this.assert.ok(hasAttribute(outputElement, 'form'));
+    this.assert.equal(this.readDOMAttr('form', outputElement), 'bar');
+
+    this.assertStableRerender();
+    this.assertStableNodes();
+  }
+
+  @test
   'handles null input values'() {
     this.render('<input value={{isNull}} />', { isNull: null });
     this.assert.equal(this.readDOMAttr('value'), '');

--- a/packages/@glimmer/runtime/lib/dom/props.ts
+++ b/packages/@glimmer/runtime/lib/dom/props.ts
@@ -66,6 +66,7 @@ const ATTR_OVERRIDES: Dict<Dict> = {
   FIELDSET: { form: true },
   LEGEND: { form: true },
   OBJECT: { form: true },
+  OUTPUT: { form: true },
   BUTTON: { form: true },
 };
 


### PR DESCRIPTION
Added `<output>` to `ATTR_OVERRIDES` as [MDN details how the `form` attribute can be set on `<output> tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output).

Failing test before fix:
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/12262029/99711044-47d7e600-2a6f-11eb-9d11-76f5ed6a112e.png">

Should fix this issue:
https://github.com/glimmerjs/glimmer-vm/issues/1207