### PR TITLE
[REFACTOR] Use constants pool for definitions

### DIFF
--- a/benchmark/benchmarks/krausest/lib/components/Application.js
+++ b/benchmark/benchmarks/krausest/lib/components/Application.js
@@ -1,3 +1,7 @@
+import { templateFactory } from '@glimmer/opcode-compiler';
+import { setComponentTemplate } from '@glimmer/manager';
+import ApplicationTemplate from './Application.hbs';
+
 export default class Application {
   constructor(args) {
     this.args = args;
@@ -16,5 +20,7 @@ export default class Application {
     };
   }
 }
+
+setComponentTemplate(templateFactory(ApplicationTemplate), Application);
 
 /** @typedef {import('../utils/data').Item} Item */

--- a/benchmark/benchmarks/krausest/lib/components/Row.js
+++ b/benchmark/benchmarks/krausest/lib/components/Row.js
@@ -1,3 +1,7 @@
+import { templateFactory } from '@glimmer/opcode-compiler';
+import { setComponentTemplate } from '@glimmer/manager';
+import RowTemplate from './Row.hbs';
+
 export default class Row {
   constructor(args) {
     this.args = args;
@@ -8,3 +12,5 @@ export default class Row {
     };
   }
 }
+
+setComponentTemplate(templateFactory(RowTemplate), Row);

--- a/packages/@glimmer/benchmark-env/src/benchmark/basic-component-manager.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/basic-component-manager.ts
@@ -1,6 +1,7 @@
-import { WithCreateInstance, Environment, Dict, VMArguments } from '@glimmer/interfaces';
+import { WithCreateInstance, Environment, Dict, VMArguments, Template } from '@glimmer/interfaces';
 import { createConstRef, Reference } from '@glimmer/reference';
 import { EMPTY_ARGS } from '@glimmer/runtime';
+import { getComponentTemplate } from '@glimmer/manager';
 import { ComponentArgs } from '../interfaces';
 import argsProxy from './args-proxy';
 
@@ -68,6 +69,10 @@ class BasicComponentManager
 
   getDestroyable(state: BasicState) {
     return state.instance;
+  }
+
+  getStaticLayout(definition: object): Template {
+    return getComponentTemplate(definition)!();
   }
 }
 

--- a/packages/@glimmer/benchmark-env/src/benchmark/util.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/util.ts
@@ -1,14 +1,9 @@
-import {
-  SerializedTemplateWithLazyBlock,
-  CompilableProgram,
-  CompileTimeComponent,
-} from '@glimmer/interfaces';
+import { CompilableProgram, CompileTimeComponent, TemplateFactory } from '@glimmer/interfaces';
 import { unwrapTemplate, unwrapHandle } from '@glimmer/util';
-import { templateFactory } from '@glimmer/opcode-compiler';
 import { CompileTimeCompilationContext } from '@glimmer/interfaces';
 
-export function createProgram(template: SerializedTemplateWithLazyBlock): CompilableProgram {
-  return unwrapTemplate(templateFactory(template)()).asLayout();
+export function createProgram(template: TemplateFactory): CompilableProgram {
+  return unwrapTemplate(template()).asLayout();
 }
 
 export function compileEntry(entry: CompileTimeComponent, context: CompileTimeCompilationContext) {

--- a/packages/@glimmer/benchmark-env/src/create-benchmark.ts
+++ b/packages/@glimmer/benchmark-env/src/create-benchmark.ts
@@ -1,22 +1,29 @@
 import { TemplateOnlyComponentManager } from '@glimmer/runtime';
+import { getComponentTemplate } from '@glimmer/manager';
 import { Benchmark } from './interfaces';
 import createRegistry from './benchmark/create-registry';
 import onModifier from './benchmark/on-modifier';
 import ifHelper from './benchmark/if-helper';
 import basicComponentManager from './benchmark/basic-component-manager';
 
-const TEMPLATE_ONLY_COMPONENT_MANAGER = new TemplateOnlyComponentManager();
+class TemplateOnlyComponentManagerWithGetComponentTemplate extends TemplateOnlyComponentManager {
+  getStaticLayout(definition: object) {
+    return getComponentTemplate(definition)!();
+  }
+}
+
+const TEMPLATE_ONLY_COMPONENT_MANAGER = new TemplateOnlyComponentManagerWithGetComponentTemplate();
 
 export default function createBenchmark(): Benchmark {
   const registry = createRegistry();
   registry.registerModifier('on', null, onModifier);
   registry.registerHelper('if', ifHelper);
   return {
-    templateOnlyComponent: (name, template) => {
-      registry.registerComponent(name, template, null, TEMPLATE_ONLY_COMPONENT_MANAGER);
+    templateOnlyComponent: (name) => {
+      registry.registerComponent(name, null, TEMPLATE_ONLY_COMPONENT_MANAGER);
     },
-    basicComponent: (name, template, component) => {
-      registry.registerComponent(name, template, component, basicComponentManager);
+    basicComponent: (name, _template, component) => {
+      registry.registerComponent(name, component, basicComponentManager);
     },
     render: registry.render,
   };

--- a/packages/@glimmer/benchmark-env/src/interfaces.ts
+++ b/packages/@glimmer/benchmark-env/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { SerializedTemplateWithLazyBlock, Dict } from '@glimmer/interfaces';
+import { Dict, Template } from '@glimmer/interfaces';
 import { SimpleElement } from '@simple-dom/interface';
 
 /**
@@ -17,7 +17,7 @@ export interface Benchmark {
    * @param name
    * @param template
    */
-  templateOnlyComponent(name: string, template: SerializedTemplateWithLazyBlock): void;
+  templateOnlyComponent(name: string): void;
 
   /**
    * Register a basic component
@@ -27,7 +27,7 @@ export interface Benchmark {
    */
   basicComponent<TComponent extends object = object>(
     name: string,
-    template: SerializedTemplateWithLazyBlock,
+    _template: Template,
     component: new (args: ComponentArgs) => TComponent
   ): void;
 

--- a/packages/@glimmer/debug/lib/debug.ts
+++ b/packages/@glimmer/debug/lib/debug.ts
@@ -2,7 +2,6 @@ import {
   CompileTimeConstants,
   Recast,
   RuntimeOp,
-  HandleResolver,
   Dict,
   Maybe,
   TemplateCompilationContext,
@@ -36,7 +35,6 @@ export function debugSlice(context: TemplateCompilationContext, start: number, e
       opcode.offset = i;
       let [name, params] = debug(
         context.program.constants as Recast<CompileTimeConstants, DebugConstants>,
-        context.program.resolver,
         opcode,
         opcode.isMachine
       )!;
@@ -90,7 +88,6 @@ function json(param: unknown) {
 
 export function debug(
   c: DebugConstants,
-  resolver: HandleResolver,
   op: RuntimeOp,
   isMachine: 0 | 1
 ): [string, Dict] | undefined {
@@ -113,7 +110,7 @@ export function debug(
           out[operand.name] = actualOperand;
           break;
         case 'handle':
-          out[operand.name] = resolver.resolve(actualOperand);
+          out[operand.name] = c.getValue(actualOperand);
           break;
         case 'str':
         case 'option-str':

--- a/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/compilation-context.ts
@@ -1,26 +1,29 @@
-import { CompileTimeResolver, Option, CompileTimeComponent } from '@glimmer/interfaces';
+import {
+  CompileTimeResolver,
+  Option,
+  ComponentDefinition,
+  PartialDefinition,
+  Helper,
+  ModifierDefinition,
+} from '@glimmer/interfaces';
 import { TestJitRuntimeResolver } from './resolver';
 
 export default class JitCompileTimeLookup implements CompileTimeResolver {
   constructor(private resolver: TestJitRuntimeResolver) {}
 
-  resolve<T>(handle: number): T {
-    return this.resolver.resolve(handle);
-  }
-
-  lookupHelper(name: string): Option<number> {
+  lookupHelper(name: string): Option<Helper> {
     return this.resolver.lookupHelper(name);
   }
 
-  lookupModifier(name: string): Option<number> {
+  lookupModifier(name: string): Option<ModifierDefinition> {
     return this.resolver.lookupModifier(name);
   }
 
-  lookupComponent(name: string, owner?: object): Option<CompileTimeComponent> {
-    return this.resolver.lookupCompileTimeComponent(name, owner);
+  lookupComponent(name: string, owner?: object): Option<ComponentDefinition> {
+    return this.resolver.lookupComponent(name, owner);
   }
 
-  lookupPartial(name: string): Option<number> {
+  lookupPartial(name: string): Option<PartialDefinition> {
     return this.resolver.lookupPartial(name);
   }
 }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
@@ -2,7 +2,6 @@ import { PrecompileOptions } from '@glimmer/syntax';
 import {
   CapturedRenderNode,
   CompileTimeCompilationContext,
-  ComponentDefinition,
   Cursor,
   Dict,
   DynamicScope,
@@ -53,6 +52,7 @@ import {
 import { TestJitRegistry } from './registry';
 import { renderTemplate } from './render';
 import { TestJitRuntimeResolver } from './resolver';
+import { getCompilable } from './util';
 
 export interface JitTestDelegateContext {
   runtime: RuntimeContext;
@@ -129,7 +129,7 @@ export class JitRenderDelegate implements RenderDelegate {
   }
 
   createCurriedComponent(name: string): Option<CurriedComponentDefinition> {
-    return componentHelper(this.resolver, this.registry, name);
+    return componentHelper(this.registry, name);
   }
 
   registerPlugin(plugin: ASTPluginBuilder): void {
@@ -218,8 +218,8 @@ export class JitRenderDelegate implements RenderDelegate {
     let { program, runtime } = this.context;
     let builder = this.getElementBuilder(runtime.env, cursor);
 
-    let { handle, compilable } = this.registry.lookupCompileTimeComponent(name)!;
-    let component = this.registry.resolve<ComponentDefinition>(handle);
+    let component = this.registry.lookupComponent(name)!;
+    let compilable = getCompilable(component);
 
     let iterator = renderComponent(
       runtime,

--- a/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
@@ -6,7 +6,6 @@ import {
   InternalModifierManager,
   InternalComponentManager,
   InternalComponentCapabilities,
-  ComponentDefinition,
   PartialDefinition,
   TemplateFactory,
 } from '@glimmer/interfaces';
@@ -22,7 +21,6 @@ import {
   TestModifierManager,
 } from '../../modifiers';
 import { PartialDefinitionImpl } from '@glimmer/opcode-compiler';
-import { TestJitRuntimeResolver } from './resolver';
 import { ComponentKind, ComponentTypes } from '../../components';
 import { TestComponentDefinitionState } from '../../components/test-component';
 import {
@@ -146,22 +144,6 @@ export function registerPartial(
   return definition;
 }
 
-export function resolveHelper(
-  resolver: TestJitRuntimeResolver,
-  helperName: string
-): Option<GlimmerHelper> {
-  let handle = resolver.lookupHelper(helperName);
-  return typeof handle === 'number' ? resolver.resolve<GlimmerHelper>(handle) : null;
-}
-
-export function resolvePartial(
-  resolver: TestJitRuntimeResolver,
-  partialName: string
-): Option<PartialDefinition> {
-  let handle = resolver.lookupPartial(partialName);
-  return typeof handle === 'number' ? resolver.resolve<PartialDefinition>(handle) : null;
-}
-
 export function registerComponent<K extends ComponentKind>(
   registry: TestJitRegistry,
   type: K,
@@ -220,14 +202,12 @@ function registerSomeComponent(
 }
 
 export function componentHelper(
-  resolver: TestJitRuntimeResolver,
   registry: TestJitRegistry,
   name: string
 ): Option<CurriedComponentDefinition> {
-  let handle = registry.lookupComponentHandle(name);
+  let definition = registry.lookupComponent(name);
 
-  if (handle === null) return null;
+  if (definition === null) return null;
 
-  let spec = resolver.resolve<ComponentDefinition>(handle);
-  return curry(spec);
+  return curry(definition);
 }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/resolver.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/resolver.ts
@@ -2,40 +2,28 @@ import {
   RuntimeResolver,
   Option,
   ComponentDefinition,
-  CompileTimeComponent,
+  Helper,
+  ModifierDefinition,
+  PartialDefinition,
 } from '@glimmer/interfaces';
-import { LookupType, TestJitRegistry } from './registry';
+import { TestJitRegistry } from './registry';
 
 export class TestJitRuntimeResolver implements RuntimeResolver {
   constructor(private registry: TestJitRegistry) {}
 
-  lookup(type: LookupType, name: string): Option<number> {
-    return this.registry.lookup(type, name);
+  lookupHelper(name: string): Option<Helper> {
+    return this.registry.lookup('helper', name);
   }
 
-  lookupHelper(name: string): Option<number> {
-    return this.lookup('helper', name);
-  }
-
-  lookupModifier(name: string): Option<number> {
-    return this.lookup('modifier', name);
+  lookupModifier(name: string): Option<ModifierDefinition> {
+    return this.registry.lookup('modifier', name);
   }
 
   lookupComponent(name: string, _owner?: object): Option<ComponentDefinition> {
-    let handle = this.registry.lookupComponentHandle(name);
-    if (handle === null) return null;
-    return this.resolve(handle) as ComponentDefinition;
+    return this.registry.lookupComponent(name);
   }
 
-  lookupCompileTimeComponent(name: string, _owner?: object): Option<CompileTimeComponent> {
-    return this.registry.lookupCompileTimeComponent(name);
-  }
-
-  lookupPartial(name: string): Option<number> {
-    return this.lookup('partial', name);
-  }
-
-  resolve<T>(handle: number): T {
-    return this.registry.resolve(handle);
+  lookupPartial(name: string): Option<PartialDefinition> {
+    return this.registry.lookup('partial', name);
   }
 }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/util.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/util.ts
@@ -1,0 +1,16 @@
+import { CompilableProgram, ComponentDefinition, WithStaticLayout } from '@glimmer/interfaces';
+import { expect, unwrapTemplate } from '@glimmer/util';
+
+export function getCompilable(definition: ComponentDefinition) {
+  let { manager, state } = definition;
+
+  let capabilities = manager.getCapabilities(state);
+  let compilable: CompilableProgram | null = null;
+
+  if (!capabilities.dynamicLayout) {
+    let template = unwrapTemplate((manager as WithStaticLayout).getStaticLayout(state));
+    compilable = capabilities.wrapped ? template.asWrappedLayout() : template.asLayout();
+  }
+
+  return expect(compilable, 'attempted to render a top level component without a static template');
+}

--- a/packages/@glimmer/integration-tests/lib/modes/rehydration/partial-rehydration-delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/rehydration/partial-rehydration-delegate.ts
@@ -1,9 +1,10 @@
-import { Dict, ComponentDefinition, RenderResult } from '@glimmer/interfaces';
+import { Dict, RenderResult } from '@glimmer/interfaces';
 import { renderComponent, renderSync } from '@glimmer/runtime';
 import { createConstRef, childRefFor, Reference } from '@glimmer/reference';
 import { RehydrationDelegate } from './delegate';
 import { SimpleElement } from '@simple-dom/interface';
 import { DebugRehydrationBuilder } from './builder';
+import { getCompilable } from '../jit/util';
 
 function dictToReference(dict: Dict<unknown>): Dict<Reference> {
   const root = createConstRef(dict, 'args');
@@ -27,15 +28,14 @@ export class PartialRehydrationDelegate extends RehydrationDelegate {
     let cursor = { element, nextSibling: null };
     let { program, runtime } = this.clientEnv;
     let builder = this.getElementBuilder(runtime.env, cursor) as DebugRehydrationBuilder;
-    let { handle, compilable } = this.clientRegistry.lookupCompileTimeComponent(name)!;
-    let component = this.clientRegistry.resolve<ComponentDefinition>(handle);
+    let component = this.clientRegistry.lookupComponent(name)!;
 
     let iterator = renderComponent(
       runtime,
       builder,
       program,
       component,
-      compilable!,
+      getCompilable(component),
       dictToReference(args)
     );
 
@@ -54,15 +54,14 @@ export class PartialRehydrationDelegate extends RehydrationDelegate {
     let { program, runtime } = this.serverEnv;
     let builder = this.getElementBuilder(runtime.env, cursor);
 
-    let { handle, compilable } = this.serverRegistry.lookupCompileTimeComponent(name)!;
-    let component = this.serverRegistry.resolve<ComponentDefinition>(handle);
+    let component = this.serverRegistry.lookupComponent(name)!;
 
     let iterator = renderComponent(
       runtime,
       builder,
       program,
       component,
-      compilable!,
+      getCompilable(component),
       dictToReference(args)
     );
 

--- a/packages/@glimmer/integration-tests/test/owner-test.ts
+++ b/packages/@glimmer/integration-tests/test/owner-test.ts
@@ -1,4 +1,4 @@
-import { CompileTimeComponent, ComponentDefinition } from '@glimmer/interfaces';
+import { ComponentDefinition } from '@glimmer/interfaces';
 import {
   test,
   suite,
@@ -14,12 +14,6 @@ class OwnerJitRuntimeResolver extends TestJitRuntimeResolver {
     if (typeof owner === 'function') owner();
 
     return super.lookupComponent(name, owner);
-  }
-
-  lookupCompileTimeComponent(name: string, owner: () => void): CompileTimeComponent | null {
-    if (typeof owner === 'function') owner();
-
-    return super.lookupCompileTimeComponent(name, owner);
   }
 }
 

--- a/packages/@glimmer/interfaces/lib/serialize.d.ts
+++ b/packages/@glimmer/interfaces/lib/serialize.d.ts
@@ -63,10 +63,6 @@ import { ModifierDefinition } from './runtime/modifier';
 import { Owner, Helper } from './runtime';
 import { InternalComponentCapabilities } from './managers';
 
-export interface HandleResolver {
-  resolve(handle: number): unknown;
-}
-
 export interface CompileTimeComponent {
   handle: number;
   capabilities?: InternalComponentCapabilities;
@@ -80,14 +76,11 @@ export const enum ResolverContext {
   HelperOrComponent,
 }
 
-export interface CompileTimeResolver<O extends Owner = Owner> extends HandleResolver {
-  lookupHelper(name: string, owner: O): Option<number>;
-  lookupModifier(name: string, owner: O): Option<number>;
-  lookupComponent(name: string, owner: O): Option<CompileTimeComponent>;
-  lookupPartial(name: string, owner: O): Option<number>;
-
-  // For debugging
-  resolve<U extends ResolvedValue>(handle: number): U | null;
+export interface CompileTimeResolver<O extends Owner = Owner> {
+  lookupHelper(name: string, owner: O): Option<Helper>;
+  lookupModifier(name: string, owner: O): Option<ModifierDefinition>;
+  lookupComponent(name: string, owner: O): Option<ComponentDefinition>;
+  lookupPartial(name: string, owner: O): Option<PartialDefinition>;
 }
 
 export interface PartialDefinition {
@@ -100,8 +93,7 @@ export interface PartialDefinition {
 
 export type ResolvedValue = ComponentDefinition | ModifierDefinition | Helper | PartialDefinition;
 
-export interface RuntimeResolver<O extends Owner = Owner> extends HandleResolver {
+export interface RuntimeResolver<O extends Owner = Owner> {
   lookupComponent(name: string, owner: O): Option<ComponentDefinition>;
-  lookupPartial(name: string, owner: O): Option<number>;
-  resolve<U extends ResolvedValue>(handle: number): U;
+  lookupPartial(name: string, owner: O): Option<PartialDefinition>;
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -80,17 +80,17 @@ export function encodeOp(
         return encoder.stopLabels();
 
       case HighLevelResolutionOpcode.ResolveComponent:
-        return resolveComponent(resolver, meta, op);
+        return resolveComponent(resolver, constants, meta, op);
       case HighLevelResolutionOpcode.ResolveModifier:
-        return resolveModifier(resolver, meta, op);
+        return resolveModifier(resolver, constants, meta, op);
       case HighLevelResolutionOpcode.ResolveHelper:
-        return resolveHelper(resolver, meta, op);
+        return resolveHelper(resolver, constants, meta, op);
       case HighLevelResolutionOpcode.ResolveComponentOrHelper:
-        return resolveComponentOrHelper(resolver, meta, op);
+        return resolveComponentOrHelper(resolver, constants, meta, op);
       case HighLevelResolutionOpcode.ResolveOptionalHelper:
-        return resolveOptionalHelper(resolver, meta, op);
+        return resolveOptionalHelper(resolver, constants, meta, op);
       case HighLevelResolutionOpcode.ResolveOptionalComponentOrHelper:
-        return resolveOptionalComponentOrHelper(resolver, meta, op);
+        return resolveOptionalComponentOrHelper(resolver, constants, meta, op);
 
       case HighLevelResolutionOpcode.ResolveLocal:
         let freeVar = op[1];

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -144,7 +144,7 @@ APPEND_OPCODES.add(Op.CurryComponent, (vm, { op1: _owner }) => {
 });
 
 APPEND_OPCODES.add(Op.PushComponentDefinition, (vm, { op1: handle }) => {
-  let definition = vm.runtime.resolver.resolve<ComponentDefinition>(handle);
+  let definition = vm[CONSTANTS].getValue<ComponentDefinition>(handle);
   assert(!!definition, `Missing component for ${handle}`);
 
   let { manager } = definition;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -89,7 +89,7 @@ APPEND_OPCODES.add(Op.CloseElement, (vm) => {
 });
 
 APPEND_OPCODES.add(Op.Modifier, (vm, { op1: handle }) => {
-  let { manager, state } = vm.runtime.resolver.resolve<ModifierDefinition>(handle);
+  let { manager, state } = vm[CONSTANTS].getValue<ModifierDefinition>(handle);
   let stack = vm.stack;
   let args = check(stack.popJs(), CheckArguments);
   let { constructing, updateOperations } = vm.elements();

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -33,7 +33,7 @@ export type FunctionExpression<T> = (vm: PublicVM) => Reference<T>;
 
 APPEND_OPCODES.add(Op.Helper, (vm, { op1: handle }) => {
   let stack = vm.stack;
-  let helper = check(vm.runtime.resolver.resolve(handle), CheckHelper);
+  let helper = check(vm[CONSTANTS].getValue(handle), CheckHelper);
   let args = check(stack.popJs(), CheckArguments);
   let value = helper(args, vm);
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/partial.ts
@@ -2,7 +2,7 @@ import { Reference, valueForRef } from '@glimmer/reference';
 import { APPEND_OPCODES } from '../../opcodes';
 import { assert, unwrapHandle, decodeHandle } from '@glimmer/util';
 import { check } from '@glimmer/debug';
-import { Op, Dict, PartialDefinition, Owner } from '@glimmer/interfaces';
+import { Op, Dict, Owner } from '@glimmer/interfaces';
 import { CheckReference } from './-debug-strip';
 import { CONSTANTS } from '../../symbols';
 
@@ -15,12 +15,9 @@ APPEND_OPCODES.add(Op.InvokePartial, (vm, { op1: _owner, op2: _symbols, op3: _ev
   let owner = constants.getValue<Owner>(decodeHandle(_owner));
   let outerSymbols = constants.getArray<string>(_symbols);
   let evalInfo = constants.getArray<number>(decodeHandle(_evalInfo));
+  let definition = vm.runtime.resolver.lookupPartial(name as string, owner);
 
-  let handle = vm.runtime.resolver.lookupPartial(name as string, owner);
-
-  assert(handle !== null, `Could not find a partial named "${name}"`);
-
-  let definition = vm.runtime.resolver.resolve<PartialDefinition>(handle!);
+  assert(definition !== null, `Could not find a partial named "${name}"`);
 
   let { symbolTable, handle: vmHandle } = definition.getPartial(vm.context);
 

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -60,7 +60,7 @@ export class AppendOpcodes {
     if (LOCAL_SHOULD_LOG) {
       let pos = vm[INNER_VM].fetchRegister($pc) - opcode.size;
 
-      [opName, params] = debug(vm[CONSTANTS], vm.runtime.resolver, opcode, opcode.isMachine)!;
+      [opName, params] = debug(vm[CONSTANTS], opcode, opcode.isMachine)!;
 
       // console.log(`${typePos(vm['pc'])}.`);
       LOCAL_LOGGER.log(`${pos}. ${logOpcode(opName, params)}`);


### PR DESCRIPTION
Uses the constants pool to store and retrieve component definitions,
rather than using the resolver again. This reduces the reliance on
the embedding environment providing functionality, and allows strict
mode resolution to be almost completely handled in the VM.

## Breaking Changes

- `resolve` has been removed from both the CompileTimeResolver and RuntimeResolver
- The CompileTimeResolver and RuntimeResolver and now both expected to return the actual values they are resolving, rather than handles directly