### PR TITLE
[BREAKING] Update benchmark-env API

### DIFF
--- a/benchmark/benchmarks/krausest/lib/index.js
+++ b/benchmark/benchmarks/krausest/lib/index.js
@@ -1,8 +1,6 @@
 import { createBenchmark } from '@glimmer/benchmark-env';
 
-import ApplicationTemplate from './components/Application.hbs';
 import Application from './components/Application';
-import RowTemplate from './components/Row.hbs';
 import Row from './components/Row';
 import buildData from './utils/data';
 
@@ -13,8 +11,8 @@ import buildData from './utils/data';
 export default async function render(element, isInteractive) {
   const benchmark = createBenchmark();
 
-  benchmark.basicComponent('Row', RowTemplate, Row);
-  benchmark.basicComponent('Application', ApplicationTemplate, Application);
+  benchmark.basicComponent('Row', Row);
+  benchmark.basicComponent('Application', Application);
 
   /** @type {{[name: string]: any}} */
   const args = {

--- a/packages/@glimmer/benchmark-env/src/create-benchmark.ts
+++ b/packages/@glimmer/benchmark-env/src/create-benchmark.ts
@@ -22,7 +22,7 @@ export default function createBenchmark(): Benchmark {
     templateOnlyComponent: (name) => {
       registry.registerComponent(name, null, TEMPLATE_ONLY_COMPONENT_MANAGER);
     },
-    basicComponent: (name, _template, component) => {
+    basicComponent: (name, component) => {
       registry.registerComponent(name, component, basicComponentManager);
     },
     render: registry.render,

--- a/packages/@glimmer/benchmark-env/src/interfaces.ts
+++ b/packages/@glimmer/benchmark-env/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { Dict, Template } from '@glimmer/interfaces';
+import { Dict } from '@glimmer/interfaces';
 import { SimpleElement } from '@simple-dom/interface';
 
 /**
@@ -27,7 +27,6 @@ export interface Benchmark {
    */
   basicComponent<TComponent extends object = object>(
     name: string,
-    _template: Template,
     component: new (args: ComponentArgs) => TComponent
   ): void;
 


### PR DESCRIPTION
This PR removes the template parameter from the benchmark-env APIs,
as the env now expects templates to be associated via setComponentTemplate.
This is expected to break the benchmark test, so it is done in an isolated
PR so that we can safely make this change without also missing a perf
regression.