### PR TITLE
[BUGFIX] Absorb breakage in benchmark-env instead of benchmark

### DIFF
--- a/benchmark/benchmarks/krausest/lib/components/Application.js
+++ b/benchmark/benchmarks/krausest/lib/components/Application.js
@@ -1,7 +1,3 @@
-import { templateFactory } from '@glimmer/opcode-compiler';
-import { setComponentTemplate } from '@glimmer/manager';
-import ApplicationTemplate from './Application.hbs';
-
 export default class Application {
   constructor(args) {
     this.args = args;
@@ -20,7 +16,5 @@ export default class Application {
     };
   }
 }
-
-setComponentTemplate(templateFactory(ApplicationTemplate), Application);
 
 /** @typedef {import('../utils/data').Item} Item */

--- a/benchmark/benchmarks/krausest/lib/components/Row.js
+++ b/benchmark/benchmarks/krausest/lib/components/Row.js
@@ -1,7 +1,3 @@
-import { templateFactory } from '@glimmer/opcode-compiler';
-import { setComponentTemplate } from '@glimmer/manager';
-import RowTemplate from './Row.hbs';
-
 export default class Row {
   constructor(args) {
     this.args = args;
@@ -12,5 +8,3 @@ export default class Row {
     };
   }
 }
-
-setComponentTemplate(templateFactory(RowTemplate), Row);

--- a/packages/@glimmer/benchmark-env/src/create-benchmark.ts
+++ b/packages/@glimmer/benchmark-env/src/create-benchmark.ts
@@ -1,10 +1,11 @@
 import { TemplateOnlyComponentManager } from '@glimmer/runtime';
-import { getComponentTemplate } from '@glimmer/manager';
+import { getComponentTemplate, setComponentTemplate } from '@glimmer/manager';
 import { Benchmark } from './interfaces';
 import createRegistry from './benchmark/create-registry';
 import onModifier from './benchmark/on-modifier';
 import ifHelper from './benchmark/if-helper';
 import basicComponentManager from './benchmark/basic-component-manager';
+import { templateFactory } from '@glimmer/opcode-compiler';
 
 class TemplateOnlyComponentManagerWithGetComponentTemplate extends TemplateOnlyComponentManager {
   getStaticLayout(definition: object) {
@@ -19,10 +20,15 @@ export default function createBenchmark(): Benchmark {
   registry.registerModifier('on', null, onModifier);
   registry.registerHelper('if', ifHelper);
   return {
-    templateOnlyComponent: (name) => {
+    templateOnlyComponent: (name, template) => {
+      let definition = {};
+      setComponentTemplate(templateFactory(template), definition);
+
       registry.registerComponent(name, null, TEMPLATE_ONLY_COMPONENT_MANAGER);
     },
-    basicComponent: (name, _template, component) => {
+    basicComponent: (name, template, component) => {
+      setComponentTemplate(templateFactory(template), component);
+
       registry.registerComponent(name, component, basicComponentManager);
     },
     render: registry.render,

--- a/packages/@glimmer/benchmark-env/src/interfaces.ts
+++ b/packages/@glimmer/benchmark-env/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { Dict, Template } from '@glimmer/interfaces';
+import { Dict, SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
 import { SimpleElement } from '@simple-dom/interface';
 
 /**
@@ -17,7 +17,7 @@ export interface Benchmark {
    * @param name
    * @param template
    */
-  templateOnlyComponent(name: string): void;
+  templateOnlyComponent(name: string, template: SerializedTemplateWithLazyBlock): void;
 
   /**
    * Register a basic component
@@ -27,7 +27,7 @@ export interface Benchmark {
    */
   basicComponent<TComponent extends object = object>(
     name: string,
-    _template: Template,
+    template: SerializedTemplateWithLazyBlock,
     component: new (args: ComponentArgs) => TComponent
   ): void;
 


### PR DESCRIPTION
Some previous PRs made changes to the benchmark, but this made the benchmark
itself incompatible with previous versions of Glimmer. This is something that
is valuable to be able to test, so for now are going to keep absorbing all
breakage in the benchmark-env.