### PR TITLE
[BUGFIX] Make the custom tag system non-enumerable

### DIFF
--- a/packages/@glimmer/manager/index.ts
+++ b/packages/@glimmer/manager/index.ts
@@ -12,4 +12,4 @@ export { modifierCapabilities, CustomModifierManager } from './lib/public/modifi
 export { helperCapabilities, hasDestroyable, hasValue, customHelper } from './lib/public/helper';
 export { getComponentTemplate, setComponentTemplate } from './lib/public/template';
 export { capabilityFlagsFrom, hasCapability, managerHasCapability } from './lib/util/capabilities';
-export { CUSTOM_TAG_FOR } from './lib/util/args-proxy';
+export { getCustomTagFor, setCustomTagFor } from './lib/util/args-proxy';

--- a/packages/@glimmer/util/index.ts
+++ b/packages/@glimmer/util/index.ts
@@ -23,6 +23,7 @@ export * from './lib/template';
 export { default as _WeakSet } from './lib/weak-set';
 export { castToSimple, castToBrowser, checkNode } from './lib/simple-cast';
 export * from './lib/present';
+export { default as intern } from './lib/intern';
 
 export { default as debugToString } from './lib/debug-to-string';
 export { beginTestSteps, endTestSteps, logStep, verifySteps } from './lib/debug-steps';

--- a/packages/@glimmer/util/lib/intern.ts
+++ b/packages/@glimmer/util/lib/intern.ts
@@ -1,0 +1,49 @@
+/**
+  Strongly hint runtimes to intern the provided string.
+
+  When do I need to use this function?
+
+  For the most part, never. Pre-mature optimization is bad, and often the
+  runtime does exactly what you need it to, and more often the trade-off isn't
+  worth it.
+
+  Why?
+
+  Runtimes store strings in at least 2 different representations:
+  Ropes and Symbols (interned strings). The Rope provides a memory efficient
+  data-structure for strings created from concatenation or some other string
+  manipulation like splitting.
+
+  Unfortunately checking equality of different ropes can be quite costly as
+  runtimes must resort to clever string comparison algorithms. These
+  algorithms typically cost in proportion to the length of the string.
+  Luckily, this is where the Symbols (interned strings) shine. As Symbols are
+  unique by their string content, equality checks can be done by pointer
+  comparison.
+
+  How do I know if my string is a rope or symbol?
+
+  Typically (warning general sweeping statement, but truthy in runtimes at
+  present) static strings created as part of the JS source are interned.
+  Strings often used for comparisons can be interned at runtime if some
+  criteria are met.  One of these criteria can be the size of the entire rope.
+  For example, in chrome 38 a rope longer then 12 characters will not
+  intern, nor will segments of that rope.
+
+  Some numbers: http://jsperf.com/eval-vs-keys/8
+
+  Known Trick™
+
+  @private
+  @return {String} interned version of the provided string
+*/
+export default function intern(str: string): string {
+  let obj: Record<string, number> = {};
+  obj[str] = 1;
+  for (let key in obj) {
+    if (key === str) {
+      return key;
+    }
+  }
+  return str;
+}

--- a/packages/@glimmer/util/lib/platform-utils.ts
+++ b/packages/@glimmer/util/lib/platform-utils.ts
@@ -1,4 +1,5 @@
 import { Maybe } from '@glimmer/interfaces';
+import intern from './intern';
 
 export type Factory<T> = new (...args: unknown[]) => T;
 
@@ -40,7 +41,7 @@ export type Lit = string | number | boolean | undefined | null | void | {};
 export const tuple = <T extends Lit[]>(...args: T) => args;
 
 export function enumerableSymbol(key: string): any {
-  return `__${key}${Math.floor(Math.random() * Date.now())}__`;
+  return intern(`__${key}${Math.floor(Math.random() * Date.now())}__`);
 }
 
 export const symbol = HAS_NATIVE_SYMBOL ? Symbol : enumerableSymbol;


### PR DESCRIPTION
Currently, the custom tag system relies on an enumerable "symbol"-like
key, which is then placed on the objects that need to use it. This is an
expensive system, since it means we need to do a brand check to see if
the function exists, which means crawling the prototype chain every time
we look up a tag for a property on an object.

This PR instead places the functions in a WeakMap. This means that in
general, we can check to see if the WeakMap has the value, and if so
then we can use the function directly. WeakMap lookup is generally
faster, as it means we don't have to walk the entire prototype chain of
a megamorphic object, so this should generally be more performant.

It does mean that the functions in question need to be bound to the
instance, which could impact performance, but the functions should still
be inline-able when called (since they are called independent of the
object), and given that usage of tag lookup with non-proxies likely
dominates over usage with proxies, it should matter less than the
savings from using a WeakMap.

Finally, this means that CUSTOM_TAG_FOR is not exposed at all, so there
cannot be any observable side-effects such as the ones causing the bug
in: https://github.com/hjdivad/ember-m3/issues/957

### Unrelated Changes

In addition, I did a quick refactor of the proxy handlers to extract
them as classes. This is important for performance (POJOs with methods
on the instance do not inline, even as proxy handlers), I just never got
around to it before.