### PR TITLE
[FEAT] Enable sub-expressions in mustache position

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "benchmark:experiment": "node benchmark/bin/experiment.js"
   },
   "dependencies": {
-    "@handlebars/parser": "^1.1.0",
+    "@handlebars/parser": "^2.0.0",
     "@simple-dom/document": "^1.4.0",
     "@simple-dom/interface": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
@@ -80,10 +80,6 @@ export class ExpressionEncoder {
     return [SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback, symbol];
   }
 
-  GetSymbol({ symbol }: mir.GetSymbol): WireFormat.Expressions.GetSymbol {
-    return [SexpOpcodes.GetSymbol, symbol];
-  }
-
   PathExpression({ head, tail }: mir.PathExpression): WireFormat.Expressions.GetPath {
     let getOp = EXPR.expr(head) as WireFormat.Expressions.GetVar;
 
@@ -95,10 +91,6 @@ export class ExpressionEncoder {
   }
 
   CallExpression({ callee, args }: mir.CallExpression): WireFormat.Expressions.Helper {
-    // let head = ctx.popValue(EXPR);
-    // let params = ctx.popValue(PARAMS);
-    // let hash = ctx.popValue(HASH);
-
     return [SexpOpcodes.Call, EXPR.expr(callee), ...EXPR.Args(args)];
   }
 

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -136,7 +136,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
       let { path, params, hash } = acceptCallNodes(
         this,
         rawMustache as HBS.MustacheStatement & {
-          path: HBS.PathExpression;
+          path: HBS.PathExpression | HBS.SubExpression;
         }
       );
       mustache = b.mustache({
@@ -464,12 +464,19 @@ function updateTokenizerLocation(tokenizer: Parser['tokenizer'], content: HBS.Co
 function acceptCallNodes(
   compiler: HandlebarsNodeVisitors,
   node: {
-    path: HBS.PathExpression;
+    path: HBS.PathExpression | HBS.SubExpression;
     params: HBS.Expression[];
     hash: HBS.Hash;
   }
-): { path: ASTv1.PathExpression; params: ASTv1.Expression[]; hash: ASTv1.Hash } {
-  let path = compiler.PathExpression(node.path);
+): {
+  path: ASTv1.PathExpression | ASTv1.SubExpression;
+  params: ASTv1.Expression[];
+  hash: ASTv1.Hash;
+} {
+  let path =
+    node.path.type === 'PathExpression'
+      ? compiler.PathExpression(node.path)
+      : compiler.SubExpression(node.path);
   let params = node.params ? node.params.map((e) => compiler.acceptNode<ASTv1.Expression>(e)) : [];
 
   // if there is no hash, position it as a collapsed node immediately after the last param (or the

--- a/packages/@glimmer/syntax/lib/v1/handlebars-ast.ts
+++ b/packages/@glimmer/syntax/lib/v1/handlebars-ast.ts
@@ -64,7 +64,7 @@ export type Statement =
   | CommentStatement;
 
 export interface CommonMustache extends CommonNode {
-  path: PathExpression | Literal;
+  path: Expression;
   params: Expression[];
   hash: Hash;
   escaped: boolean;
@@ -81,7 +81,7 @@ export interface Decorator extends CommonMustache {
 
 export interface CommonBlock extends CommonNode {
   chained: boolean;
-  path: PathExpression;
+  path: PathExpression | SubExpression;
   params: Expression[];
   hash: Hash;
   program: Program;
@@ -134,7 +134,7 @@ export type Expression = SubExpression | PathExpression | Literal;
 
 export interface SubExpression extends CommonNode {
   type: 'SubExpression';
-  path: PathExpression;
+  path: PathExpression | SubExpression;
   params: Expression[];
   hash: Hash;
 }

--- a/packages/@glimmer/syntax/lib/v1/parser-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/parser-builders.ts
@@ -101,7 +101,7 @@ class Builders {
     inverseStrip = DEFAULT_STRIP,
     closeStrip = DEFAULT_STRIP,
   }: {
-    path: ASTv1.PathExpression;
+    path: ASTv1.PathExpression | ASTv1.SubExpression;
     params: ASTv1.Expression[];
     hash: ASTv1.Hash;
     defaultBlock: ASTv1.Block;
@@ -226,7 +226,7 @@ class Builders {
     hash,
     loc,
   }: {
-    path: ASTv1.PathExpression;
+    path: ASTv1.PathExpression | ASTv1.SubExpression;
     params: ASTv1.Expression[];
     hash: ASTv1.Hash;
     loc: SourceSpan;

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@glimmer/interfaces": "0.68.1",
     "@glimmer/util": "0.68.1",
-    "@handlebars/parser": "^1.1.0",
+    "@handlebars/parser": "^2.0.0",
     "simple-html-tokenizer": "^0.5.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,10 +867,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@handlebars/parser@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
-  integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
+"@handlebars/parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
+  integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
 "@iarna/toml@2.2.5":
   version "2.2.5"


### PR DESCRIPTION
Allows users to use sub-expressions directly within mustaches, either in
append or in argument position. This is the bare-minimum needed for
strict-mode, and does not yet support using sub-expressions in call
position recursively. For that, we need to implement dynamic helpers
(coming up in the next PR).