### PR TITLE
[BUGFIX] Fix tag classification in strict

### DIFF
--- a/packages/@glimmer/integration-tests/lib/compile.ts
+++ b/packages/@glimmer/integration-tests/lib/compile.ts
@@ -17,7 +17,7 @@ export function createTemplate(
   options: PrecompileOptions = {},
   scopeValues: Record<string, unknown> = {}
 ): TemplateFactory {
-  options.locals = Object.keys(scopeValues ?? {});
+  options.locals = options.locals ?? Object.keys(scopeValues ?? {});
   let [block, usedLocals] = precompileJSON(templateSource, options);
   let reifiedScopeValues = usedLocals.map((key) => scopeValues[key]);
 

--- a/packages/@glimmer/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer/integration-tests/test/strict-mode-test.ts
@@ -7,6 +7,7 @@ import {
   defineComponent,
   defineSimpleHelper,
   defineSimpleModifier,
+  syntaxErrorFor,
 } from '..';
 
 class GeneralStrictModeTest extends RenderTest {
@@ -369,11 +370,9 @@ class StaticStrictModeTest extends RenderTest {
 
   @test
   'Throws an error if component is not in scope'() {
-    const Bar = defineComponent({}, '<Foo/>');
-
     this.assert.throws(() => {
-      this.renderComponent(Bar);
-    }, /Attempted to resolve a component in a strict mode template, but that value was not in scope: Foo/);
+      defineComponent({}, '<Foo/>');
+    }, syntaxErrorFor('Attempted to invoke a component that was not in scope in a strict mode template, `<Foo>`. If you wanted to create an element with that name, convert it to lowercase - `<foo>`', '<Foo/>', 'an unknown module', 1, 0));
   }
 
   @test

--- a/packages/@glimmer/integration-tests/test/syntax/keyword-errors-test.ts
+++ b/packages/@glimmer/integration-tests/test/syntax/keyword-errors-test.ts
@@ -24,7 +24,7 @@ for (let keyword of KEYWORDS) {
     'keyword can be used as a value in strict mode'() {
       preprocess(`{{some-helper ${keyword}}}`, {
         strictMode: true,
-        locals: [keyword],
+        locals: ['some-helper', keyword],
         meta: { moduleName: 'test-module' },
       });
     }
@@ -49,7 +49,7 @@ for (let keyword of KEYWORDS) {
             {{some-helper ${keyword}}}
           {{/let}}
         `,
-        { strictMode: true, meta: { moduleName: 'test-module' } }
+        { strictMode: true, locals: ['some-helper'], meta: { moduleName: 'test-module' } }
       );
     }
 
@@ -73,7 +73,11 @@ for (let keyword of KEYWORDS) {
             {{some-helper ${keyword}}}
           {{/my-component}}
         `,
-        { strictMode: true, meta: { moduleName: 'test-module' } }
+        {
+          strictMode: true,
+          locals: ['my-component', 'some-helper'],
+          meta: { moduleName: 'test-module' },
+        }
       );
     }
 
@@ -97,7 +101,11 @@ for (let keyword of KEYWORDS) {
             {{some-helper ${keyword}}}
           </SomeComponent>
         `,
-        { strictMode: true, meta: { moduleName: 'test-module' } }
+        {
+          strictMode: true,
+          locals: ['SomeComponent', 'some-helper'],
+          meta: { moduleName: 'test-module' },
+        }
       );
     }
 
@@ -125,7 +133,11 @@ for (let keyword of KEYWORDS) {
             </:main>
           </SomeComponent>
         `,
-        { strictMode: true, meta: { moduleName: 'test-module' } }
+        {
+          strictMode: true,
+          locals: ['SomeComponent', 'some-helper'],
+          meta: { moduleName: 'test-module' },
+        }
       );
     }
 


### PR DESCRIPTION
In strict mode, we want to classify tags based on whether or not they
are a local value, _not_ based on the casing itself. This PR fixes that
heuristic. We also still throw an error if the tag is capitalized
(e.g. `<Div>`) because it would be very annoying to debug that value
being a normal element. This could be changed in the future if we decide
it should be a lint rule instead.