### PR TITLE
[BUGFIX] Makes ASTPluginEnvironment generic

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -315,8 +315,8 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
   ASTPlugins can make changes to the Glimmer template AST before
   compilation begins.
 */
-export interface ASTPluginBuilder {
-  (env: ASTPluginEnvironment): ASTPlugin;
+export interface ASTPluginBuilder<TEnv extends ASTPluginEnvironment = ASTPluginEnvironment> {
+  (env: TEnv): ASTPlugin;
 }
 
 export interface ASTPlugin {


### PR DESCRIPTION
This allows us to create a wider AST plugin environment, which Ember
does, and still have everything type correctly.