### PR TITLE
[BUGFIX] Ensure template locals work in nested blocks

### DIFF
--- a/packages/@glimmer/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer/integration-tests/test/strict-mode-test.ts
@@ -290,6 +290,17 @@ class StaticStrictModeTest extends RenderTest {
   }
 
   @test
+  'Can use template local in nested blocks with locals'() {
+    const place = defineSimpleHelper(() => 'world');
+    const Foo = defineComponent({}, '{{yield "Hello"}}');
+    const Bar = defineComponent({ Foo, place }, '<Foo as |hi|>{{hi}}, {{place}}!</Foo>');
+
+    this.renderComponent(Bar);
+    this.assertHTML('Hello, world!');
+    this.assertStableRerender();
+  }
+
+  @test
   'Can use component in ambiguous helper/component position (without args)'() {
     const foo = defineComponent({}, 'Hello, world!');
     const bar = defineComponent({ foo }, '{{foo}}');

--- a/packages/@glimmer/syntax/lib/v2-a/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/normalize.ts
@@ -279,9 +279,9 @@ class ExpressionNormalizer {
       }
       case 'VarHead': {
         if (block.hasBinding(head.name)) {
-          let symbol = table.get(head.name);
+          let [symbol, isRoot] = table.get(head.name);
 
-          return block.builder.localVar(head.name, symbol, table.isRoot, offsets);
+          return block.builder.localVar(head.name, symbol, isRoot, offsets);
         } else {
           let symbol = block.table.allocateFree(head.name);
           return block.builder.freeVar({


### PR DESCRIPTION
Looking up a value needs to return whether or not it is a root (e.g.
template local) value recursively, rather than relying on the current
scope.