### PR TITLE
[REFACTOR] Make Owner VM state

### DIFF
--- a/packages/@glimmer/benchmark-env/src/benchmark/basic-component-manager.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/basic-component-manager.ts
@@ -1,4 +1,4 @@
-import { WithCreateInstance, Environment, Dict, VMArguments, Template } from '@glimmer/interfaces';
+import { WithCreateInstance, Dict, VMArguments, Template, Owner } from '@glimmer/interfaces';
 import { createConstRef, Reference } from '@glimmer/reference';
 import { EMPTY_ARGS } from '@glimmer/runtime';
 import { getComponentTemplate } from '@glimmer/manager';
@@ -18,25 +18,24 @@ const BASIC_COMPONENT_CAPABILITIES = {
   createInstance: true,
   wrapped: false,
   willDestroy: false,
+  hasSubOwner: false,
 };
 
 interface BasicState {
-  env: Environment;
   self: Reference<unknown>;
   instance: object;
 }
 
 class BasicComponentManager
-  implements
-    WithCreateInstance<BasicState, Environment, new (args: Readonly<Dict<unknown>>) => object> {
+  implements WithCreateInstance<BasicState, new (args: Readonly<Dict<unknown>>) => object, Owner> {
   create(
-    env: Environment,
+    _owner: Owner,
     Component: { new (args: ComponentArgs): object },
     args: VMArguments | null
   ) {
     const instance = new Component(argsProxy(args === null ? EMPTY_ARGS : args.capture()));
     const self = createConstRef(instance, 'this');
-    return { env, instance, self };
+    return { instance, self };
   }
 
   getDebugName() {

--- a/packages/@glimmer/benchmark-env/src/benchmark/create-env-delegate.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/create-env-delegate.ts
@@ -72,7 +72,6 @@ setGlobalContext({
 
 export default function createEnvDelegate(isInteractive: boolean): EnvironmentDelegate {
   return {
-    owner: {},
     isInteractive,
     enableDebugTooling: false,
     onTransactionCommit() {

--- a/packages/@glimmer/integration-tests/lib/components/emberish-curly.ts
+++ b/packages/@glimmer/integration-tests/lib/components/emberish-curly.ts
@@ -7,7 +7,6 @@ import {
   Template,
   VMArguments,
   PreparedArguments,
-  Environment,
   DynamicScope,
   ElementOperations,
   Destroyable,
@@ -15,6 +14,8 @@ import {
   InternalComponentCapabilities,
   WithCreateInstance,
   CompilableProgram,
+  Owner,
+  Environment,
 } from '@glimmer/interfaces';
 import { setInternalComponentManager } from '@glimmer/manager';
 import {
@@ -127,6 +128,7 @@ const EMBERISH_CURLY_CAPABILITIES: InternalComponentCapabilities = {
   createInstance: true,
   wrapped: true,
   willDestroy: true,
+  hasSubOwner: false,
 };
 
 export class EmberishCurlyComponentManager
@@ -196,9 +198,10 @@ export class EmberishCurlyComponentManager
   }
 
   create(
-    _env: Environment,
+    _owner: Owner,
     definition: EmberishCurlyComponentFactory,
     _args: VMArguments,
+    _env: Environment,
     dynamicScope: DynamicScope,
     callerSelf: Reference,
     hasDefaultBlock: boolean

--- a/packages/@glimmer/integration-tests/lib/modes/env.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/env.ts
@@ -101,8 +101,6 @@ export const BaseEnv: EnvironmentDelegate = {
 
   enableDebugTooling: false,
 
-  owner: {},
-
   onTransactionCommit() {
     for (let i = 0; i < scheduledDestroyables.length; i++) {
       scheduledDestructors[i](scheduledDestroyables[i]);

--- a/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
@@ -178,5 +178,5 @@ export function componentHelper(
 
   if (definition === null) return null;
 
-  return curry(constants.resolvedComponent(definition, name), null);
+  return curry(constants.resolvedComponent(definition, name), {}, null);
 }

--- a/packages/@glimmer/integration-tests/lib/modes/jit/render.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/render.ts
@@ -15,6 +15,13 @@ export function renderTemplate(
 ): RenderResult {
   let template = preprocess(src, options);
 
-  let iterator = renderMain(runtime, program, self, builder, unwrapTemplate(template).asLayout());
+  let iterator = renderMain(
+    runtime,
+    program,
+    {},
+    self,
+    builder,
+    unwrapTemplate(template).asLayout()
+  );
   return renderSync(runtime.env, iterator);
 }

--- a/packages/@glimmer/integration-tests/test/env-test.ts
+++ b/packages/@glimmer/integration-tests/test/env-test.ts
@@ -7,7 +7,6 @@ QUnit.test('assert against nested transactions', (assert) => {
   let env = new EnvironmentImpl(
     { document: castToSimple(document) },
     {
-      owner: {},
       onTransactionCommit() {},
       isInteractive: true,
       enableDebugTooling: false,
@@ -24,7 +23,6 @@ QUnit.test('ensure commit cleans up when it can', (assert) => {
   let env = new EnvironmentImpl(
     { document: castToSimple(document) },
     {
-      owner: {},
       onTransactionCommit() {},
       isInteractive: true,
       enableDebugTooling: false,

--- a/packages/@glimmer/integration-tests/test/owner-test.ts
+++ b/packages/@glimmer/integration-tests/test/owner-test.ts
@@ -51,25 +51,31 @@ class OwnerTest extends RenderTest {
 
   @test
   'owner can be used per-template in runtime resolver'(assert: Assert) {
-    class FooBar extends EmberishCurlyComponent {
-      subcomponent = 'foo-baz';
+    this.delegate.registerComponent('TemplateOnly', 'TemplateOnly', 'FooQux', 'testing');
 
-      layout = createTemplate('{{component this.subcomponent}}')(() => {
-        assert.step('foo-bar owner called');
-      });
-    }
+    this.delegate.registerComponent(
+      'Curly',
+      'Curly',
+      'FooBaz',
+      null,
+      class FooBaz extends EmberishCurlyComponent {
+        layout = createTemplate('<FooQux/>')(() => {
+          assert.step('foo-baz owner called');
+        });
+      }
+    );
 
-    class FooBaz extends EmberishCurlyComponent {
-      subcomponent = 'foo-qux';
-
-      layout = createTemplate('{{component this.subcomponent}}')(() => {
-        assert.step('foo-baz owner called');
-      });
-    }
-
-    this.delegate.registerComponent('Curly', 'Curly', 'FooBar', null, FooBar);
-    this.delegate.registerComponent('Curly', 'Curly', 'foo-baz', null, FooBaz);
-    this.delegate.registerComponent('TemplateOnly', 'TemplateOnly', 'foo-qux', 'testing');
+    this.delegate.registerComponent(
+      'Curly',
+      'Curly',
+      'FooBar',
+      null,
+      class FooBar extends EmberishCurlyComponent {
+        layout = createTemplate('<FooBaz/>')(() => {
+          assert.step('foo-bar owner called');
+        });
+      }
+    );
 
     this.render('<FooBar/>');
 

--- a/packages/@glimmer/interfaces/lib/compile/operands.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/operands.d.ts
@@ -4,24 +4,18 @@ import { CompilableTemplate } from '../template';
 
 export const enum HighLevelOperand {
   Label = 1,
-  Owner = 2,
-  IsStrictMode = 3,
-  EvalSymbols = 4,
-  Block = 5,
-  StdLib = 6,
-  NonSmallInt = 7,
-  SymbolTable = 8,
-  Layout = 9,
+  IsStrictMode = 2,
+  EvalSymbols = 3,
+  Block = 4,
+  StdLib = 5,
+  NonSmallInt = 6,
+  SymbolTable = 7,
+  Layout = 8,
 }
 
 export interface LabelOperand {
   type: HighLevelOperand.Label;
   value: string;
-}
-
-export interface OwnerOperand {
-  type: HighLevelOperand.Owner;
-  value: undefined;
 }
 
 export interface IsStrictModeOperand {
@@ -61,7 +55,6 @@ export interface LayoutOperand {
 
 export type HighLevelBuilderOperand =
   | LabelOperand
-  | OwnerOperand
   | IsStrictModeOperand
   | EvalSymbolsOperand
   | StdLibOperand

--- a/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
@@ -24,7 +24,7 @@ export type ComponentInstanceWithCreate = ComponentInstance<
   WithCreateInstance
 >;
 
-export interface Environment<O extends Owner = Owner> {
+export interface Environment {
   [TransactionSymbol]: Option<Transaction>;
 
   didCreate(component: ComponentInstanceWithCreate): void;
@@ -41,5 +41,4 @@ export interface Environment<O extends Owner = Owner> {
 
   isInteractive: boolean;
   debugRenderTree?: DebugRenderTree;
-  owner: O;
 }

--- a/packages/@glimmer/interfaces/lib/runtime/scope.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/scope.d.ts
@@ -3,6 +3,7 @@ import { CompilableBlock } from '../template';
 import { Reference } from '@glimmer/reference';
 import { Option, Dict } from '../core';
 import { BlockSymbolTable } from '../tier1/symbol-table';
+import { Owner } from './owner';
 
 export type Block = CompilableBlock | number;
 
@@ -13,6 +14,7 @@ export type ScopeSlot = Reference | ScopeBlock | null;
 export interface Scope {
   // for debug only
   readonly slots: Array<ScopeSlot>;
+  readonly owner: Owner;
 
   getSelf(): Reference;
   getSymbol(symbol: number): Reference;

--- a/packages/@glimmer/interfaces/lib/runtime/vm.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/vm.d.ts
@@ -2,17 +2,18 @@ import { Environment } from './environment';
 // eslint-disable-next-line node/no-extraneous-import
 import { Reference } from '@glimmer/reference';
 import { Destroyable } from '../core';
-import { VMArguments } from './arguments';
 import { DynamicScope } from './scope';
+import { Owner } from './owner';
 /**
  * This is used in the Glimmer Embedding API. In particular, embeddings
  * provide helpers through the `CompileTimeLookup` interface, and the
  * helpers they provide implement the `Helper` interface, which is a
  * function that takes a `VM` as a parameter.
  */
-export interface VM {
+export interface VM<O extends Owner = Owner> {
   env: Environment;
   dynamicScope(): DynamicScope;
+  getOwner(): O;
   getSelf(): Reference;
   associateDestroyable(child: Destroyable): void;
 }

--- a/packages/@glimmer/manager/lib/public/component.ts
+++ b/packages/@glimmer/manager/lib/public/component.ts
@@ -35,6 +35,7 @@ const CAPABILITIES = {
   createInstance: true,
   wrapped: false,
   willDestroy: false,
+  hasSubOwner: false,
 };
 
 export function componentCapabilities<Version extends keyof ComponentCapabilitiesVersions>(

--- a/packages/@glimmer/manager/lib/util/capabilities.ts
+++ b/packages/@glimmer/manager/lib/util/capabilities.ts
@@ -9,6 +9,7 @@ import {
   WithCreateInstance,
   WithDynamicLayout,
   InternalComponentCapability,
+  WithSubOwner,
 } from '@glimmer/interfaces';
 import { check, CheckNumber } from '@glimmer/debug';
 
@@ -42,7 +43,8 @@ export function capabilityFlagsFrom(
     (capabilities.updateHook ? InternalComponentCapability.UpdateHook : 0) |
     (capabilities.createInstance ? InternalComponentCapability.CreateInstance : 0) |
     (capabilities.wrapped ? InternalComponentCapability.Wrapped : 0) |
-    (capabilities.willDestroy ? InternalComponentCapability.WillDestroy : 0)
+    (capabilities.willDestroy ? InternalComponentCapability.WillDestroy : 0) |
+    (capabilities.hasSubOwner ? InternalComponentCapability.HasSubOwner : 0)
   );
 }
 
@@ -59,6 +61,7 @@ export interface InternalComponentCapabilityMap {
   [InternalComponentCapability.CreateInstance]: WithCreateInstance;
   [InternalComponentCapability.Wrapped]: InternalComponentManager;
   [InternalComponentCapability.WillDestroy]: InternalComponentManager;
+  [InternalComponentCapability.HasSubOwner]: WithSubOwner;
 }
 
 export function managerHasCapability<F extends keyof InternalComponentCapabilityMap>(

--- a/packages/@glimmer/manager/test/capabilities-test.ts
+++ b/packages/@glimmer/manager/test/capabilities-test.ts
@@ -18,8 +18,9 @@ QUnit.test('encodes a capabilities object into a bitmap', (assert) => {
       createInstance: false,
       wrapped: false,
       willDestroy: false,
+      hasSubOwner: false,
     }),
-    0b000000000000,
+    0b0000000000000,
     'empty capabilities'
   );
 
@@ -37,8 +38,9 @@ QUnit.test('encodes a capabilities object into a bitmap', (assert) => {
       createInstance: true,
       wrapped: true,
       willDestroy: true,
+      hasSubOwner: true,
     }),
-    0b111111111111,
+    0b1111111111111,
     'all capabilities'
   );
 
@@ -56,8 +58,9 @@ QUnit.test('encodes a capabilities object into a bitmap', (assert) => {
       createInstance: false,
       wrapped: true,
       willDestroy: false,
+      hasSubOwner: false,
     }),
-    0b010100100101,
+    0b0010100100101,
     'random sample'
   );
 });
@@ -76,6 +79,7 @@ QUnit.test('allows querying bitmap for a capability', (assert) => {
     createInstance: false,
     wrapped: true,
     willDestroy: false,
+    hasSubOwner: false,
   });
 
   assert.strictEqual(
@@ -121,5 +125,9 @@ QUnit.test('allows querying bitmap for a capability', (assert) => {
   assert.strictEqual(
     false,
     managerHasCapability({} as any, capabilities, InternalComponentCapability.WillDestroy)
+  );
+  assert.strictEqual(
+    false,
+    managerHasCapability({} as any, capabilities, InternalComponentCapability.HasSubOwner)
   );
 });

--- a/packages/@glimmer/manager/test/managers-test.ts
+++ b/packages/@glimmer/manager/test/managers-test.ts
@@ -107,6 +107,7 @@ module('Managers', () => {
             createInstance: false,
             wrapped: false,
             willDestroy: false,
+            hasSubOwner: false,
           };
         }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/delegate.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/delegate.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CAPABILITIES: InternalComponentCapabilities = {
   createInstance: true,
   wrapped: false,
   willDestroy: false,
+  hasSubOwner: false,
 };
 
 export const MINIMAL_CAPABILITIES: InternalComponentCapabilities = {
@@ -28,6 +29,7 @@ export const MINIMAL_CAPABILITIES: InternalComponentCapabilities = {
   createInstance: false,
   wrapped: false,
   willDestroy: false,
+  hasSubOwner: false,
 };
 
 export interface ResolverDelegate<R = unknown> {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -207,9 +207,6 @@ export class EncoderImpl implements Encoder {
             this.currentLabels.target(this.heap.offset, operand.value);
             return -1;
 
-          case HighLevelOperand.Owner:
-            return encodeHandle(constants.value(this.meta.owner));
-
           case HighLevelOperand.IsStrictMode:
             return encodeHandle(constants.value(this.meta.isStrictMode));
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
@@ -15,13 +15,7 @@ import { $s0, $s1, $sp, $v0, SavedRegister } from '@glimmer/vm';
 import { EMPTY_STRING_ARRAY } from '@glimmer/util';
 import { PushExpressionOp, PushStatementOp } from '../../syntax/compilers';
 import { namedBlocks } from '../../utils';
-import {
-  labelOperand,
-  layoutOperand,
-  symbolTableOperand,
-  ownerOperand,
-  isStrictMode,
-} from '../operands';
+import { labelOperand, layoutOperand, symbolTableOperand, isStrictMode } from '../operands';
 import { InvokeStaticBlock, PushYieldableBlock, YieldBlock } from './blocks';
 import { Replayable } from './conditional';
 import { expr } from './expr';
@@ -136,9 +130,9 @@ export function InvokeDynamicComponent(
       op(Op.JumpUnless, labelOperand('ELSE'));
 
       if (curried) {
-        op(Op.ResolveCurriedComponent, ownerOperand());
+        op(Op.ResolveCurriedComponent);
       } else {
-        op(Op.ResolveDynamicComponent, ownerOperand(), isStrictMode());
+        op(Op.ResolveDynamicComponent, isStrictMode());
       }
 
       op(Op.PushDynamicComponentInstance);
@@ -469,7 +463,7 @@ export function CurryComponent(
   SimpleArgs(op, positional, named, false);
   op(Op.CaptureArgs);
   expr(op, definition);
-  op(Op.CurryComponent, ownerOperand(), isStrictMode());
+  op(Op.CurryComponent, isStrictMode());
   op(MachineOp.PopFrame);
   op(Op.Fetch, $v0);
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
@@ -1,6 +1,5 @@
 import {
   LabelOperand,
-  OwnerOperand,
   SerializedInlineBlock,
   EvalSymbolsOperand,
   HighLevelOperand,
@@ -22,10 +21,6 @@ export function labelOperand(value: string): LabelOperand {
 
 export function evalSymbolsOperand(): EvalSymbolsOperand {
   return { type: HighLevelOperand.EvalSymbols, value: undefined };
-}
-
-export function ownerOperand(): OwnerOperand {
-  return { type: HighLevelOperand.Owner, value: undefined };
 }
 
 export function isStrictMode(): IsStrictModeOperand {

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -21,12 +21,7 @@ import { Replayable, ReplayableIf } from '../opcode-builder/helpers/conditional'
 import { expr } from '../opcode-builder/helpers/expr';
 import { CompilePositional, SimpleArgs } from '../opcode-builder/helpers/shared';
 import { Call, DynamicScope, PushPrimitiveReference } from '../opcode-builder/helpers/vm';
-import {
-  evalSymbolsOperand,
-  labelOperand,
-  stdlibOperand,
-  ownerOperand,
-} from '../opcode-builder/operands';
+import { evalSymbolsOperand, labelOperand, stdlibOperand } from '../opcode-builder/operands';
 import { Compilers, PushStatementOp } from './compilers';
 import {
   isGetFreeComponent,
@@ -124,7 +119,7 @@ STATEMENTS.add(SexpOpcodes.Partial, (op, [, name, evalInfo]) => {
     },
 
     () => {
-      op(Op.InvokePartial, ownerOperand(), evalSymbolsOperand(), evalInfo);
+      op(Op.InvokePartial, evalSymbolsOperand(), evalInfo);
       op(Op.PopScope);
       op(MachineOp.PopFrame);
     }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -72,7 +72,7 @@ APPEND_OPCODES.add(Op.ResolveMaybeLocal, (vm, { op1: _name }) => {
 });
 
 APPEND_OPCODES.add(Op.RootScope, (vm, { op1: symbols }) => {
-  vm.pushRootScope(symbols);
+  vm.pushRootScope(symbols, vm.getOwner());
 });
 
 APPEND_OPCODES.add(Op.GetProperty, (vm, { op1: _key }) => {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -158,11 +158,12 @@ APPEND_OPCODES.add(Op.InvokeYield, (vm) => {
   if (table === null) {
     // To balance the pop{Frame,Scope}
     vm.pushFrame();
-    vm.pushScope(scope!); // Could be null but it doesn't matter as it is immediately popped.
+    vm.pushScope(scope ?? vm.scope());
+
     return;
   }
 
-  let invokingScope = scope!;
+  let invokingScope = expect(scope, 'BUG: expected scope');
 
   // If necessary, create a child scope
   {

--- a/packages/@glimmer/runtime/lib/component/template-only.ts
+++ b/packages/@glimmer/runtime/lib/component/template-only.ts
@@ -15,6 +15,7 @@ const CAPABILITIES: InternalComponentCapabilities = {
   createInstance: false,
   wrapped: false,
   willDestroy: false,
+  hasSubOwner: false,
 };
 
 export class TemplateOnlyComponentManager implements InternalComponentManager {

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -10,7 +10,6 @@ import {
   RuntimeResolver,
   Option,
   RuntimeArtifacts,
-  Owner,
   ComponentInstanceWithCreate,
   ModifierInstance,
   InternalModifierManager,
@@ -119,7 +118,6 @@ export class EnvironmentImpl implements Environment {
 
   // Delegate methods and values
   public isInteractive = this.delegate.isInteractive;
-  public owner = this.delegate.owner;
 
   debugRenderTree = this.delegate.enableDebugTooling ? new DebugRenderTree() : undefined;
 
@@ -203,13 +201,6 @@ export interface EnvironmentDelegate {
    * Used to enable debug tooling
    */
   enableDebugTooling: boolean;
-
-  /**
-   * Owner passed into the environment
-   *
-   * TODO: This should likely use the templating system owner instead
-   */
-  owner: Owner;
 
   /**
    * Callback to be called when an environment transaction commits

--- a/packages/@glimmer/runtime/lib/references/curry-component.ts
+++ b/packages/@glimmer/runtime/lib/references/curry-component.ts
@@ -33,7 +33,7 @@ export default function createCurryComponentRef(
     }
 
     if (isCurriedComponentDefinition(value)) {
-      curriedDefinition = args ? curry(value, args) : args;
+      curriedDefinition = args ? curry(value, owner, args) : args;
     } else if (typeof value === 'string' && value) {
       if (DEBUG && isStrict) {
         throw new Error(
@@ -49,9 +49,13 @@ export default function createCurryComponentRef(
         );
       }
 
-      curriedDefinition = curry(constants.resolvedComponent(resolvedDefinition!, value), args);
+      curriedDefinition = curry(
+        constants.resolvedComponent(resolvedDefinition!, value),
+        owner,
+        args
+      );
     } else if (typeof value === 'object' && value !== null) {
-      curriedDefinition = curry(constants.component(owner, value), args);
+      curriedDefinition = curry(constants.component(owner, value), owner, args);
     } else {
       curriedDefinition = null;
     }

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -46,6 +46,7 @@ export function renderSync(env: Environment, iterator: TemplateIterator): Render
 export function renderMain(
   runtime: RuntimeContext,
   context: CompileTimeCompilationContext,
+  owner: Owner,
   self: Reference,
   treeBuilder: ElementBuilder,
   layout: CompilableProgram,
@@ -53,7 +54,14 @@ export function renderMain(
 ): TemplateIterator {
   let handle = unwrapHandle(layout.compile(context));
   let numSymbols = layout.symbolTable.symbols.length;
-  let vm = VM.initial(runtime, context, { self, dynamicScope, treeBuilder, handle, numSymbols });
+  let vm = VM.initial(runtime, context, {
+    self,
+    dynamicScope,
+    treeBuilder,
+    handle,
+    numSymbols,
+    owner,
+  });
   return new TemplateIteratorImpl(vm);
 }
 
@@ -116,7 +124,11 @@ export function renderComponent(
   args: Record<string, unknown> = {},
   dynamicScope: DynamicScope = new DynamicScopeImpl()
 ): TemplateIterator {
-  let vm = VM.empty(runtime, { treeBuilder, handle: context.stdlib.main, dynamicScope }, context);
+  let vm = VM.empty(
+    runtime,
+    { treeBuilder, handle: context.stdlib.main, dynamicScope, owner },
+    context
+  );
   return renderInvocation(vm, context, owner, definition, recordToReference(args));
 }
 


### PR DESCRIPTION
This PR moves the owner directly onto the VM, where it is tracked as
part of the current scope. This allows us to associate the owner with a
template block, as we do currently, but without having to associate it
through the various opcodes. This is both conceptually simpler, and
also more performant - in the future we can rely more on the stdlib to
deduplicate common code segments.

## Breaking Changes

- `create` signature of component managers has changed, owner is now the
  first parameter.
- New component capability, `HasSubOwner`, which allows components to
push a new owner onto the owner stack.