### PR TITLE
[REFACTOR] Removes owner from managers

### DIFF
--- a/packages/@glimmer/benchmark-env/src/benchmark/create-registry.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/create-registry.ts
@@ -59,7 +59,7 @@ export default function createRegistry(): Registry {
 
   return {
     registerComponent: (name: string, component: object) => {
-      let manager = getInternalComponentManager(undefined, component);
+      let manager = getInternalComponentManager(component);
 
       components.set(name, {
         state: component,
@@ -69,11 +69,11 @@ export default function createRegistry(): Registry {
     },
     registerHelper: (name, helper) => {
       let definition = {};
-      setInternalHelperManager(() => helper, definition);
+      setInternalHelperManager(helper, definition);
       helpers.set(name, definition);
     },
     registerModifier: (name, modifier, manager) => {
-      setInternalModifierManager(() => manager, modifier);
+      setInternalModifierManager(manager, modifier);
       modifiers.set(name, modifier);
     },
     render: (entry, args, element, isIteractive) => {

--- a/packages/@glimmer/benchmark-env/src/benchmark/on-modifier.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/on-modifier.ts
@@ -1,4 +1,4 @@
-import { InternalModifierManager, VMArguments } from '@glimmer/interfaces';
+import { InternalModifierManager, Owner, VMArguments } from '@glimmer/interfaces';
 import { Reference, valueForRef } from '@glimmer/reference';
 import { castToBrowser } from '@glimmer/util';
 import { createUpdatableTag } from '@glimmer/validator';
@@ -13,7 +13,7 @@ interface OnModifierState {
 }
 
 class OnModifierManager implements InternalModifierManager<OnModifierState, object> {
-  create(element: SimpleElement, _: {}, args: VMArguments) {
+  create(_owner: Owner, element: SimpleElement, _: {}, args: VMArguments) {
     return {
       element,
       nameRef: args.positional.at(0) as Reference<string>,

--- a/packages/@glimmer/benchmark-env/src/create-benchmark.ts
+++ b/packages/@glimmer/benchmark-env/src/create-benchmark.ts
@@ -20,7 +20,7 @@ export default function createBenchmark(): Benchmark {
     },
     basicComponent: (name, template, component) => {
       setComponentTemplate(templateFactory(template), component);
-      setInternalComponentManager(() => basicComponentManager, component);
+      setInternalComponentManager(basicComponentManager, component);
 
       registry.registerComponent(name, component);
     },

--- a/packages/@glimmer/integration-tests/lib/components/emberish-curly.ts
+++ b/packages/@glimmer/integration-tests/lib/components/emberish-curly.ts
@@ -320,4 +320,4 @@ export class EmberishCurlyComponentManager
 
 const EMBERISH_CURLY_COMPONENT_MANAGER = new EmberishCurlyComponentManager();
 
-setInternalComponentManager(() => EMBERISH_CURLY_COMPONENT_MANAGER, EmberishCurlyComponent);
+setInternalComponentManager(EMBERISH_CURLY_COMPONENT_MANAGER, EmberishCurlyComponent);

--- a/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/register.ts
@@ -72,7 +72,7 @@ export function registerGlimmerishComponent(
 export function registerHelper(registry: TestJitRegistry, name: string, helper: UserHelper) {
   let state = {};
   let glimmerHelper: GlimmerHelper = (args) => createHelperRef(helper, args.capture());
-  setInternalHelperManager(() => glimmerHelper, state);
+  setInternalHelperManager(glimmerHelper, state);
   registry.register('helper', name, state);
 }
 
@@ -82,7 +82,7 @@ export function registerInternalHelper(
   helper: GlimmerHelper
 ) {
   let state = {};
-  setInternalHelperManager(() => helper, state);
+  setInternalHelperManager(helper, state);
   registry.register('helper', name, state);
 }
 
@@ -92,7 +92,7 @@ export function registerInternalModifier(
   manager: InternalModifierManager<unknown, object>,
   state: object
 ) {
-  setInternalModifierManager(() => manager, state);
+  setInternalModifierManager(manager, state);
   registry.register('modifier', name, state);
 }
 
@@ -103,7 +103,7 @@ export function registerModifier(
 ) {
   let state = new TestModifierDefinitionState(ModifierClass);
   let manager = new TestModifierManager();
-  setInternalModifierManager(() => manager, state);
+  setInternalModifierManager(manager, state);
   registry.register('modifier', name, state);
 }
 
@@ -156,7 +156,7 @@ function registerSomeComponent(
     setComponentTemplate(templateFactory, ComponentClass);
   }
 
-  let manager = getInternalComponentManager(undefined, ComponentClass);
+  let manager = getInternalComponentManager(ComponentClass);
 
   let definition = {
     name,

--- a/packages/@glimmer/integration-tests/lib/modifiers.ts
+++ b/packages/@glimmer/integration-tests/lib/modifiers.ts
@@ -8,6 +8,7 @@ import {
   DynamicScope,
   VMArguments,
   CapturedArguments,
+  Owner,
 } from '@glimmer/interfaces';
 import { UpdatableTag, createUpdatableTag } from '@glimmer/validator';
 import { registerDestructor } from '@glimmer/destroyable';
@@ -31,6 +32,7 @@ export class TestModifierDefinitionState {
 export class TestModifierManager
   implements InternalModifierManager<TestModifier, TestModifierDefinitionState> {
   create(
+    _owner: Owner,
     element: SimpleElement,
     state: TestModifierDefinitionState,
     args: VMArguments,

--- a/packages/@glimmer/interfaces/lib/managers/internal.d.ts
+++ b/packages/@glimmer/interfaces/lib/managers/internal.d.ts
@@ -1,2 +1,3 @@
 export * from './internal/component';
+export * from './internal/helper';
 export * from './internal/modifier';

--- a/packages/@glimmer/interfaces/lib/managers/internal/helper.d.ts
+++ b/packages/@glimmer/interfaces/lib/managers/internal/helper.d.ts
@@ -1,0 +1,8 @@
+import { Helper, Owner } from '../../runtime';
+import { HelperManager } from '../helper';
+
+export interface InternalHelperManager<TOwner extends Owner> {
+  getDelegateFor(owner: TOwner | undefined): HelperManager<unknown>;
+
+  helper: Helper;
+}

--- a/packages/@glimmer/interfaces/lib/managers/internal/modifier.d.ts
+++ b/packages/@glimmer/interfaces/lib/managers/internal/modifier.d.ts
@@ -2,7 +2,7 @@ import { GlimmerTreeChanges } from '../../dom/changes';
 // eslint-disable-next-line node/no-extraneous-import
 import { UpdatableTag } from '@glimmer/validator';
 import { SimpleElement } from '@simple-dom/interface';
-import { DynamicScope, VMArguments } from '../../runtime';
+import { DynamicScope, Owner, VMArguments } from '../../runtime';
 import { Destroyable } from '../../core';
 import { ModifierDefinitionState, ModifierInstanceState } from '../../runtime/modifier';
 
@@ -12,6 +12,7 @@ export interface InternalModifierManager<
 > {
   // Create is meant to only produce the state bucket
   create(
+    owner: Owner,
     element: SimpleElement,
     state: TModifierDefinitionState,
     args: VMArguments,

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -1,10 +1,10 @@
-import { STDLib, ContainingMetadata, HandleResult, Template } from './template';
-import { StdLibOperand, Encoder } from './compile';
+import { STDLib, ContainingMetadata, Template } from './template';
+import { Encoder } from './compile';
 import { Op } from './vm-opcodes';
 import { CompileTimeResolver, ResolvedComponentDefinition } from './serialize';
 import { ComponentDefinitionState, ComponentDefinition } from './components';
-import { Helper, HelperDefinitionState, Owner } from './runtime';
-import { ModifierDefinition, ModifierDefinitionState } from './runtime/modifier';
+import { HelperDefinitionState, Owner } from './runtime';
+import { ModifierDefinitionState } from './runtime/modifier';
 
 export interface RuntimeOp {
   offset: number;
@@ -96,40 +96,23 @@ export interface ResolutionTimeConstants {
   defaultTemplate: Template;
 
   helper(
-    owner: Owner | undefined,
     definitionState: HelperDefinitionState,
     resolvedName: string | null,
     isOptional: true
   ): number | null;
-  helper(
-    owner: Owner | undefined,
-    definitionState: HelperDefinitionState,
-    resolvedName?: string | null
-  ): number;
-  helper(
-    owner: Owner | undefined,
-    definitionState: HelperDefinitionState,
-    resolvedName?: string | null
-  ): number;
+  helper(definitionState: HelperDefinitionState, resolvedName?: string | null): number;
 
-  modifier(
-    owner: Owner | undefined,
-    definitionState: ModifierDefinitionState,
-    resolvedName?: string | null
-  ): number;
+  modifier(definitionState: ModifierDefinitionState, resolvedName?: string | null): number;
 
+  component(definitionState: ComponentDefinitionState): ComponentDefinition;
   component(
-    owner: Owner | undefined,
-    definitionState: ComponentDefinitionState
-  ): ComponentDefinition;
-  component(
-    owner: Owner | undefined,
     definitionState: ComponentDefinitionState,
     isOptional: true
   ): ComponentDefinition | null;
   component(
-    owner: Owner | undefined,
-    definitionState: ComponentDefinitionState
+    definitionState: ComponentDefinitionState,
+    isOptional: false,
+    owner: Owner
   ): ComponentDefinition;
 
   resolvedComponent(

--- a/packages/@glimmer/interfaces/lib/serialize.d.ts
+++ b/packages/@glimmer/interfaces/lib/serialize.d.ts
@@ -93,8 +93,8 @@ export interface CompileTimeResolver<O extends Owner = Owner> {
 
   // TODO: These are used to lookup keywords that are implemented as helpers/modifiers.
   // We should try to figure out a cleaner way to do this.
-  lookupBuiltInHelper(name: string, owner: O): Option<HelperDefinitionState>;
-  lookupBuiltInModifier(name: string, owner: O): Option<ModifierDefinitionState>;
+  lookupBuiltInHelper(name: string): Option<HelperDefinitionState>;
+  lookupBuiltInModifier(name: string): Option<ModifierDefinitionState>;
 }
 
 export interface PartialDefinition {

--- a/packages/@glimmer/manager/index.ts
+++ b/packages/@glimmer/manager/index.ts
@@ -12,7 +12,12 @@ export {
 export { setHelperManager, setModifierManager, setComponentManager } from './lib/public/index';
 export { componentCapabilities, CustomComponentManager } from './lib/public/component';
 export { modifierCapabilities, CustomModifierManager } from './lib/public/modifier';
-export { helperCapabilities, hasDestroyable, hasValue, customHelper } from './lib/public/helper';
+export {
+  helperCapabilities,
+  hasDestroyable,
+  hasValue,
+  CustomHelperManager,
+} from './lib/public/helper';
 export { getComponentTemplate, setComponentTemplate } from './lib/public/template';
 export { capabilityFlagsFrom, hasCapability, managerHasCapability } from './lib/util/capabilities';
 export { getCustomTagFor, setCustomTagFor } from './lib/util/args-proxy';

--- a/packages/@glimmer/manager/lib/public/index.ts
+++ b/packages/@glimmer/manager/lib/public/index.ts
@@ -6,9 +6,8 @@ import {
   setInternalModifierManager,
 } from '../internal/index';
 import { CustomComponentManager } from './component';
-import { DEBUG } from '@glimmer/env';
-import { FROM_CAPABILITIES } from '../util/capabilities';
 import { CustomModifierManager } from './modifier';
+import { CustomHelperManager } from './helper';
 
 type Manager = ComponentManager<unknown> | ModifierManager<unknown> | HelperManager<unknown>;
 
@@ -18,58 +17,19 @@ export function setComponentManager<O extends Owner, T extends object>(
   factory: ManagerFactory<O, ComponentManager<unknown>>,
   obj: T
 ): T {
-  return setInternalComponentManager((owner: O) => {
-    let manager = factory(owner);
-
-    if (DEBUG && !FROM_CAPABILITIES!.has(manager.capabilities)) {
-      // TODO: This error message should make sense in both Ember and Glimmer https://github.com/glimmerjs/glimmer-vm/issues/1200
-      throw new Error(
-        `Custom component managers must have a \`capabilities\` property that is the result of calling the \`capabilities('3.4' | '3.13')\` (imported via \`import { capabilities } from '@ember/component';\`). Received: \`${JSON.stringify(
-          manager.capabilities
-        )}\` for: \`${manager}\``
-      );
-    }
-
-    return new CustomComponentManager(manager);
-  }, obj);
+  return setInternalComponentManager(new CustomComponentManager(factory), obj);
 }
 
 export function setModifierManager<O extends Owner, T extends object>(
   factory: ManagerFactory<O, ModifierManager<unknown>>,
   obj: T
 ): T {
-  return setInternalModifierManager((owner: O) => {
-    let manager = factory(owner);
-
-    if (DEBUG && !FROM_CAPABILITIES!.has(manager.capabilities)) {
-      // TODO: This error message should make sense in both Ember and Glimmer https://github.com/glimmerjs/glimmer-vm/issues/1200
-      throw new Error(
-        `Custom modifier managers must have a \`capabilities\` property that is the result of calling the \`capabilities('3.13' | '3.22')\` (imported via \`import { capabilities } from '@ember/modifier';\`). Received: \`${JSON.stringify(
-          manager.capabilities
-        )}\` for: \`${manager}\``
-      );
-    }
-
-    return new CustomModifierManager(owner, manager);
-  }, obj);
+  return setInternalModifierManager(new CustomModifierManager(factory), obj);
 }
 
 export function setHelperManager<O extends Owner, T extends object>(
   factory: ManagerFactory<O | undefined, HelperManager<unknown>>,
   obj: T
 ): T {
-  return setInternalHelperManager((owner: O | undefined) => {
-    let manager = factory(owner);
-
-    if (DEBUG && !FROM_CAPABILITIES!.has(manager.capabilities)) {
-      // TODO: This error message should make sense in both Ember and Glimmer https://github.com/glimmerjs/glimmer-vm/issues/1200
-      throw new Error(
-        `Custom helper managers must have a \`capabilities\` property that is the result of calling the \`capabilities('3.23')\` (imported via \`import { capabilities } from '@ember/helper';\`). Received: \`${JSON.stringify(
-          manager.capabilities
-        )}\` for: \`${manager}\``
-      );
-    }
-
-    return manager;
-  }, obj);
+  return setInternalHelperManager(new CustomHelperManager(factory, obj), obj);
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -101,12 +101,12 @@ export function resolveComponent(
   }
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
-    then(constants.component(owner ?? undefined, definition as object));
+    then(constants.component(definition as object));
   } else {
     let { upvars, owner } = assertResolverInvariants(meta);
 
@@ -138,12 +138,12 @@ export function resolveHelper(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
-    then(constants.helper(owner ?? undefined, definition as object));
+    then(constants.helper(definition as object));
   } else if (type === SexpOpcodes.GetStrictFree) {
     then(
       lookupBuiltInHelper(expr as Expressions.GetStrictFree, resolver, meta, constants, 'helper')
@@ -160,7 +160,7 @@ export function resolveHelper(
       );
     }
 
-    then(constants.helper(owner, helper, name));
+    then(constants.helper(helper, name));
   }
 }
 
@@ -180,16 +180,16 @@ export function resolveModifier(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
-    then(constants.modifier(owner ?? undefined, definition as object));
+    then(constants.modifier(definition as object));
   } else if (type === SexpOpcodes.GetStrictFree) {
-    let { upvars, owner } = assertResolverInvariants(meta);
+    let { upvars } = assertResolverInvariants(meta);
     let name = upvars[expr[1]];
-    let modifier = resolver.lookupBuiltInModifier(name, owner)!;
+    let modifier = resolver.lookupBuiltInModifier(name);
 
     if (DEBUG && modifier === null) {
       throw new Error(
@@ -197,7 +197,7 @@ export function resolveModifier(
       );
     }
 
-    then(constants.modifier(owner, modifier, name));
+    then(constants.modifier(modifier!, name));
   } else {
     let { upvars, owner } = assertResolverInvariants(meta);
     let name = upvars[expr[1]];
@@ -209,7 +209,7 @@ export function resolveModifier(
       );
     }
 
-    then(constants.modifier(owner, modifier, name));
+    then(constants.modifier(modifier, name));
   }
 }
 
@@ -230,19 +230,19 @@ export function resolveComponentOrHelper(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
-    let component = constants.component(owner ?? undefined, definition as object, true);
+    let component = constants.component(definition as object, true);
 
     if (component !== null) {
       ifComponent(component);
       return;
     }
 
-    let helper = constants.helper(owner ?? undefined, definition as object, null, true);
+    let helper = constants.helper(definition as object, null, true);
 
     if (DEBUG && helper === null) {
       throw new Error(
@@ -280,7 +280,7 @@ export function resolveComponentOrHelper(
         );
       }
 
-      ifHelper(constants.helper(owner, helper!, name));
+      ifHelper(constants.helper(helper!, name));
     }
   }
 }
@@ -303,7 +303,7 @@ export function resolveOptionalHelper(
   if (helper === null) {
     ifFallback(name);
   } else {
-    ifHelper(constants.helper(owner, helper, name));
+    ifHelper(constants.helper(helper, name));
   }
 }
 
@@ -324,7 +324,7 @@ export function resolveOptionalComponentOrHelper(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
@@ -338,14 +338,14 @@ export function resolveOptionalComponentOrHelper(
       return;
     }
 
-    let component = constants.component(owner ?? undefined, definition, true);
+    let component = constants.component(definition, true);
 
     if (component !== null) {
       ifComponent(component);
       return;
     }
 
-    let helper = constants.helper(owner ?? undefined, definition, null, true);
+    let helper = constants.helper(definition, null, true);
 
     if (helper !== null) {
       ifHelper(helper);
@@ -371,7 +371,7 @@ export function resolveOptionalComponentOrHelper(
     let helper = resolver.lookupHelper(name, owner);
 
     if (helper !== null) {
-      ifHelper(constants.helper(owner, helper, name));
+      ifHelper(constants.helper(helper, name));
       return;
     }
 
@@ -386,10 +386,10 @@ function lookupBuiltInHelper(
   constants: ResolutionTimeConstants,
   type: string
 ): number {
-  let { upvars, owner } = assertResolverInvariants(meta);
+  let { upvars } = assertResolverInvariants(meta);
 
   let name = upvars[expr[1]];
-  let helper = resolver.lookupBuiltInHelper(name, owner);
+  let helper = resolver.lookupBuiltInHelper(name);
 
   if (DEBUG && helper === null) {
     // Keyword helper did not exist, which means that we're attempting to use a
@@ -401,5 +401,5 @@ function lookupBuiltInHelper(
     );
   }
 
-  return constants.helper(owner, helper!, name);
+  return constants.helper(helper!, name);
 }

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -3,7 +3,6 @@ import {
   ComponentDefinitionState,
   ConstantPool,
   InternalComponentCapability,
-  Owner,
   ComponentDefinition,
   ResolutionTimeConstants,
   ResolvedComponentDefinition,
@@ -15,7 +14,6 @@ import {
 import { assert, constants, expect, unwrapTemplate } from '@glimmer/util';
 import {
   capabilityFlagsFrom,
-  customHelper,
   getComponentTemplate,
   getInternalComponentManager,
   getInternalHelperManager,
@@ -117,7 +115,6 @@ export class ConstantsImpl
   >();
 
   helper(
-    owner: Owner | undefined,
     definitionState: HelperDefinitionState,
 
     // TODO: Add a way to expose resolved name for debugging
@@ -125,14 +122,12 @@ export class ConstantsImpl
     isOptional: true
   ): number | null;
   helper(
-    owner: Owner | undefined,
     definitionState: HelperDefinitionState,
 
     // TODO: Add a way to expose resolved name for debugging
     _resolvedName?: string | null
   ): number;
   helper(
-    owner: Owner | undefined,
     definitionState: HelperDefinitionState,
 
     // TODO: Add a way to expose resolved name for debugging
@@ -142,7 +137,7 @@ export class ConstantsImpl
     let handle = this.helperDefinitionCache.get(definitionState);
 
     if (handle === undefined) {
-      let managerOrHelper = getInternalHelperManager(owner, definitionState, isOptional);
+      let managerOrHelper = getInternalHelperManager(definitionState, isOptional);
 
       if (managerOrHelper === null) {
         this.helperDefinitionCache.set(definitionState, null);
@@ -151,10 +146,7 @@ export class ConstantsImpl
 
       assert(managerOrHelper, 'BUG: expected manager or helper');
 
-      let helper =
-        typeof managerOrHelper === 'function'
-          ? managerOrHelper
-          : customHelper(managerOrHelper, definitionState);
+      let helper = typeof managerOrHelper === 'function' ? managerOrHelper : managerOrHelper.helper;
 
       handle = this.value(helper);
 
@@ -165,15 +157,11 @@ export class ConstantsImpl
     return handle;
   }
 
-  modifier(
-    owner: Owner | undefined,
-    definitionState: ModifierDefinitionState,
-    resolvedName: string | null = null
-  ): number {
+  modifier(definitionState: ModifierDefinitionState, resolvedName: string | null = null): number {
     let handle = this.modifierDefinitionCache.get(definitionState);
 
     if (handle === undefined) {
-      let manager = getInternalModifierManager(owner, definitionState);
+      let manager = getInternalModifierManager(definitionState);
 
       let definition = {
         resolvedName,
@@ -190,24 +178,20 @@ export class ConstantsImpl
     return handle;
   }
 
+  component(definitionState: ComponentDefinitionState): ComponentDefinition;
   component(
-    owner: Owner | undefined,
-    definitionState: ComponentDefinitionState
-  ): ComponentDefinition;
-  component(
-    owner: Owner | undefined,
     definitionState: ComponentDefinitionState,
     isOptional: true
   ): ComponentDefinition | null;
   component(
-    owner: Owner | undefined,
     definitionState: ComponentDefinitionState,
-    isOptional?: true
+    isOptional?: true,
+    owner?: object
   ): ComponentDefinition | null {
     let definition = this.componentDefinitionCache.get(definitionState);
 
     if (definition === undefined) {
-      let manager = getInternalComponentManager(owner, definitionState, isOptional);
+      let manager = getInternalComponentManager(definitionState, isOptional);
 
       if (manager === null) {
         this.componentDefinitionCache.set(definitionState, null);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
@@ -134,7 +134,7 @@ export const CheckCompilableProgram: Checker<CompilableProgram> = CheckInterface
 });
 
 export const CheckScopeBlock: Checker<ScopeBlock> = CheckInterface({
-  0: CheckOr(CheckHandle, CheckCompilableBlock),
+  0: CheckCompilableBlock,
   1: CheckScope,
   2: CheckBlockSymbolTable,
 });

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -173,7 +173,7 @@ APPEND_OPCODES.add(Op.ResolveDynamicComponent, (vm, { op1: _isStrict }) => {
   } else if (isCurriedComponentDefinition(component)) {
     definition = component;
   } else {
-    definition = constants.component(owner, component);
+    definition = constants.component(component);
   }
 
   stack.pushJs(definition);
@@ -185,7 +185,6 @@ APPEND_OPCODES.add(Op.ResolveCurriedComponent, (vm) => {
   let value = valueForRef(ref);
   let constants = vm[CONSTANTS];
 
-  let owner = vm.getOwner();
   let definition: CurriedComponentDefinition | ComponentDefinition | null;
 
   if (DEBUG && !(typeof value === 'function' || (typeof value === 'object' && value !== null))) {
@@ -197,7 +196,7 @@ APPEND_OPCODES.add(Op.ResolveCurriedComponent, (vm) => {
   if (isCurriedComponentDefinition(value)) {
     definition = value as CurriedComponentDefinition;
   } else {
-    definition = constants.component(owner, value as object, true);
+    definition = constants.component(value as object, true);
 
     if (DEBUG && definition === null) {
       throw new Error(

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -102,6 +102,7 @@ APPEND_OPCODES.add(Op.Modifier, (vm, { op1: handle }) => {
   let dynamicScope = vm.dynamicScope();
 
   let state = manager.create(
+    vm.getOwner(),
     expect(constructing, 'BUG: ElementModifier could not find the element it applies to'),
     definition.state,
     args,

--- a/packages/@glimmer/runtime/lib/component/template-only.ts
+++ b/packages/@glimmer/runtime/lib/component/template-only.ts
@@ -51,7 +51,7 @@ export class TemplateOnlyComponentDefinition {
 }
 
 setInternalComponentManager(
-  () => TEMPLATE_ONLY_COMPONENT_MANAGER,
+  TEMPLATE_ONLY_COMPONENT_MANAGER,
   TemplateOnlyComponentDefinition.prototype
 );
 

--- a/packages/@glimmer/runtime/lib/helpers/invoke.ts
+++ b/packages/@glimmer/runtime/lib/helpers/invoke.ts
@@ -1,6 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import { Cache, createCache, getValue } from '@glimmer/validator';
-import { Arguments, HelperManager } from '@glimmer/interfaces';
+import { Arguments, InternalHelperManager } from '@glimmer/interfaces';
 import { debugToString } from '@glimmer/util';
 import { getInternalHelperManager, hasDestroyable, hasValue } from '@glimmer/manager';
 
@@ -54,7 +54,7 @@ export function invokeHelper(
   }
 
   const owner = getOwner(context);
-  const internalManager = getInternalHelperManager(owner, definition)!;
+  const internalManager = getInternalHelperManager(definition)!;
 
   // TODO: figure out why assert isn't using the TS assert thing
   if (DEBUG && !internalManager) {
@@ -71,7 +71,7 @@ export function invokeHelper(
     );
   }
 
-  const manager = internalManager as HelperManager<unknown>;
+  const manager = (internalManager as InternalHelperManager<object>).getDelegateFor(owner);
   let args = new SimpleArgsProxy(context, computeArgs);
   let bucket = manager.createHelper(definition, args);
 

--- a/packages/@glimmer/runtime/lib/references/curry-component.ts
+++ b/packages/@glimmer/runtime/lib/references/curry-component.ts
@@ -55,7 +55,7 @@ export default function createCurryComponentRef(
         args
       );
     } else if (typeof value === 'object' && value !== null) {
-      curriedDefinition = curry(constants.component(owner, value), owner, args);
+      curriedDefinition = curry(constants.component(value), owner, args);
     } else {
       curriedDefinition = null;
     }

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -80,7 +80,7 @@ function renderInvocation(
   // Prefix argument names with `@` symbol
   const argNames = argList.map(([name]) => `@${name}`);
 
-  let reified = vm[CONSTANTS].component(owner, definition);
+  let reified = vm[CONSTANTS].component(definition, false, owner);
 
   vm.pushFrame();
 


### PR DESCRIPTION
Removes `owner` from the internal manager APIs in general, making it so
we don't need to use the owner for lookups or cache based on it. This is
better for internal managers which are stateless, and makes custom
managers the only ones that have to deal with and add state. In the
future, they could also be changed.

\## Breaking Changes

- `getInternal*Manager` APIs no longer receive `owner` as the first
  argument.
- `InternalModifierManager#create` now receives the `owner` as its first
  argument.