### PR TITLE
[FEATURE] Adds dynamic modifiers

### DIFF
--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
@@ -45,6 +45,11 @@ export const CALL_KEYWORDS = keywords('Call')
     assert: assertValidCurryUsage('(helper)', 'helper', false),
 
     translate: translateCallCurryUsage(CurriedType.Helper),
+  })
+  .kw('modifier', {
+    assert: assertValidCurryUsage('(modifier)', 'modifier', false),
+
+    translate: translateCallCurryUsage(CurriedType.Modifier),
   });
 
 function translateCallCurryUsage(curriedType: CurriedType) {

--- a/packages/@glimmer/debug/lib/stack-check.ts
+++ b/packages/@glimmer/debug/lib/stack-check.ts
@@ -234,7 +234,7 @@ class ObjectChecker implements Checker<unknown> {
   type!: object;
 
   validate(obj: unknown): obj is object {
-    return typeof obj === 'object' && obj !== null;
+    return typeof obj === 'function' || (typeof obj === 'object' && obj !== null);
   }
 
   expected(): string {

--- a/packages/@glimmer/integration-tests/test/modifiers/dynamic-modifiers-test.ts
+++ b/packages/@glimmer/integration-tests/test/modifiers/dynamic-modifiers-test.ts
@@ -1,0 +1,136 @@
+import {
+  RenderTest,
+  test,
+  jitSuite,
+  defineSimpleModifier,
+  syntaxErrorFor,
+  GlimmerishComponent,
+} from '../..';
+
+class DynamicModifiersResolutionModeTest extends RenderTest {
+  static suiteName = 'dynamic modifiers in resolution mode';
+
+  @test
+  'Can use a dynamic modifier'() {
+    const foo = defineSimpleModifier((element: Element) => (element.innerHTML = 'Hello, world!'));
+
+    this.registerComponent(
+      'Glimmer',
+      'Bar',
+      '<div {{this.foo}}></div>',
+      class extends GlimmerishComponent {
+        foo = foo;
+      }
+    );
+
+    this.render('<Bar/>');
+    this.assertHTML('<div>Hello, world!</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use a nested argument as a modifier'() {
+    const foo = defineSimpleModifier((element: Element) => (element.innerHTML = 'Hello, world!'));
+    this.registerComponent('TemplateOnly', 'Foo', '<div {{@x.foo}}></div>');
+
+    this.render('<Foo @x={{this.x}}/>', { x: { foo } });
+    this.assertHTML('<div>Hello, world!</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can pass curried modifier as argument and invoke dynamically'() {
+    const foo = defineSimpleModifier(
+      (element: Element, [value]: string[]) => (element.innerHTML = value)
+    );
+    this.registerComponent('TemplateOnly', 'Foo', '<div {{@value}}></div>');
+
+    this.render('<Foo @value={{modifier this.foo "Hello, world!"}}/>', { foo });
+    this.assertHTML('<div>Hello, world!</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can pass curried modifier as argument and invoke dynamically (with args, multi-layer)'() {
+    const foo = defineSimpleModifier(
+      (element: Element, values: string[]) => (element.innerHTML = values.join(' '))
+    );
+    this.registerComponent('TemplateOnly', 'Foo', '<div {{@value "three"}}></div>');
+    this.registerComponent('TemplateOnly', 'Bar', '<Foo @value={{modifier @value "two"}}/>');
+
+    this.render('<Bar @value={{modifier this.foo "one"}}/>', { foo });
+    this.assertHTML('<div>one two three</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can pass curried modifier as argument and invoke dynamically (with args)'() {
+    const foo = defineSimpleModifier(
+      (element: Element, [first, second]: string[]) => (element.innerHTML = `${first} ${second}`)
+    );
+    this.registerComponent('TemplateOnly', 'Foo', '<div {{@value "world!"}}></div>');
+
+    this.render('<Foo @value={{modifier this.foo "Hello,"}}/>', { foo });
+    this.assertHTML('<div>Hello, world!</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can pass curried modifier as argument and invoke dynamically (with named args)'() {
+    const foo = defineSimpleModifier(
+      (element: Element, _: unknown, { greeting }: { greeting: string }) =>
+        (element.innerHTML = greeting)
+    );
+    this.registerComponent(
+      'TemplateOnly',
+      'Foo',
+      '<div {{@value greeting="Hello, Nebula!"}}></div>'
+    );
+
+    this.render('<Foo @value={{modifier this.foo greeting="Hello, world!"}}/>', { foo });
+    this.assertHTML('<div>Hello, Nebula!</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can pass curried modifier as argument and invoke dynamically (with named args, multi-layer)'() {
+    const foo = defineSimpleModifier(
+      (element: Element, _: unknown, { greeting, name }: { greeting: string; name: string }) =>
+        (element.innerHTML = `${greeting} ${name}`)
+    );
+
+    this.registerComponent('TemplateOnly', 'Foo', '<div {{@value name="Nebula!"}}></div>');
+    this.registerComponent(
+      'TemplateOnly',
+      'Bar',
+      '<Foo @value={{modifier @value greeting="Hello," name="world!"}}/>'
+    );
+
+    this.render('<Bar @value={{modifier this.foo greeting="Hola,"}}/>', { foo });
+    this.assertHTML('<div>Hello, Nebula!</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can invoke a yielded nested modifier'() {
+    const foo = defineSimpleModifier((element: Element) => (element.innerHTML = 'Hello, world!'));
+    this.registerComponent(
+      'TemplateOnly',
+      'Bar',
+      '{{#let @x as |x|}}<div {{x.foo}}></div>{{/let}}'
+    );
+
+    this.render('<Bar @x={{this.x}} />', { x: { foo } });
+    this.assertHTML('<div>Hello, world!</div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Cannot invoke a modifier definition based on this fallback lookup in resolution mode'() {
+    this.assert.throws(() => {
+      this.registerComponent('TemplateOnly', 'Bar', '<div {{x.foo}}></div>');
+    }, syntaxErrorFor('You attempted to invoke a path (`{{#x.foo}}`) as a modifier, but x was not in scope. Try adding `this` to the beginning of the path', '{{x.foo}}', 'an unknown module', 1, 5));
+  }
+}
+
+jitSuite(DynamicModifiersResolutionModeTest);

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -102,6 +102,11 @@ export interface ResolutionTimeConstants {
   ): number | null;
   helper(definitionState: HelperDefinitionState, resolvedName?: string | null): number;
 
+  modifier(
+    definitionState: ModifierDefinitionState,
+    resolvedName: string | null,
+    isOptional: true
+  ): number | null;
   modifier(definitionState: ModifierDefinitionState, resolvedName?: string | null): number;
 
   component(definitionState: ComponentDefinitionState): ComponentDefinition;

--- a/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
+++ b/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
@@ -104,4 +104,5 @@ export const enum Op {
   StaticComponentAttr = 105,
   DynamicContentType = 106,
   DynamicHelper = 107,
+  DynamicModifier = 108,
 }

--- a/packages/@glimmer/manager/lib/internal/index.ts
+++ b/packages/@glimmer/manager/lib/internal/index.ts
@@ -76,7 +76,15 @@ export function setInternalModifierManager<T extends object>(
   return setManager(MODIFIER_MANAGERS, manager, definition);
 }
 
-export function getInternalModifierManager(definition: object): InternalModifierManager {
+export function getInternalModifierManager(definition: object): InternalModifierManager;
+export function getInternalModifierManager(
+  definition: object,
+  isOptional: true | undefined
+): InternalModifierManager | null;
+export function getInternalModifierManager(
+  definition: object,
+  isOptional?: true | undefined
+): InternalModifierManager | null {
   if (
     DEBUG &&
     typeof definition !== 'function' &&
@@ -89,12 +97,16 @@ export function getInternalModifierManager(definition: object): InternalModifier
 
   const manager = getManager(MODIFIER_MANAGERS, definition)!;
 
-  if (DEBUG && manager === undefined) {
-    throw new Error(
-      `Attempted to load a modifier, but there wasn't a modifier manager associated with the definition. The definition was: ${debugToString!(
-        definition
-      )}`
-    );
+  if (manager === undefined) {
+    if (isOptional === true) {
+      return null;
+    } else if (DEBUG) {
+      throw new Error(
+        `Attempted to load a modifier, but there wasn't a modifier manager associated with the definition. The definition was: ${debugToString!(
+          definition
+        )}`
+      );
+    }
   }
 
   return manager;

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -107,7 +107,7 @@ export class ConstantsImpl
 
   private helperDefinitionCache = new WeakMap<HelperDefinitionState, number | null>();
 
-  private modifierDefinitionCache = new WeakMap<ModifierDefinitionState, number>();
+  private modifierDefinitionCache = new WeakMap<ModifierDefinitionState, number | null>();
 
   private componentDefinitionCache = new WeakMap<
     ComponentDefinitionState | ResolvedComponentDefinition,
@@ -160,11 +160,26 @@ export class ConstantsImpl
     return handle;
   }
 
-  modifier(definitionState: ModifierDefinitionState, resolvedName: string | null = null): number {
+  modifier(
+    definitionState: ModifierDefinitionState,
+    resolvedName: string | null,
+    isOptional: true
+  ): number | null;
+  modifier(definitionState: ModifierDefinitionState, resolvedName?: string | null): number;
+  modifier(
+    definitionState: ModifierDefinitionState,
+    resolvedName: string | null = null,
+    isOptional?: true
+  ): number | null {
     let handle = this.modifierDefinitionCache.get(definitionState);
 
     if (handle === undefined) {
-      let manager = getInternalModifierManager(definitionState);
+      let manager = getInternalModifierManager(definitionState, isOptional);
+
+      if (manager === null) {
+        this.modifierDefinitionCache.set(definitionState, null);
+        return null;
+      }
 
       let definition = {
         resolvedName,

--- a/packages/@glimmer/syntax/lib/v2-a/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/normalize.ts
@@ -500,7 +500,7 @@ class ElementNormalizer {
 
     if (resolution.resolution === 'error') {
       throw generateSyntaxError(
-        `You attempted to invoke a path (\`{{#${resolution.path}}}\`) but ${resolution.head} was not in scope`,
+        `You attempted to invoke a path (\`{{#${resolution.path}}}\`) as a modifier, but ${resolution.head} was not in scope. Try adding \`this\` to the beginning of the path`,
         m.loc
       );
     }


### PR DESCRIPTION
Adds dynamic modifiers and the `(modifier)` keyword. Modifiers can be
invoked dynamically in general using expression syntax.

One key difference between dynamic helpers and dynamic modifiers is that
dynamic modifiers do _not_ support `this` fallback. This is because
`this` fallback is not necessary for backwards compatibility, unlike
for helpers and components. Instead, a helpful error message is given,
which lets the user know they should consider adding `this` to the path.