### PR TITLE
Fix missing component error message

### DIFF
--- a/packages/@glimmer/runtime/lib/references/curry-value.ts
+++ b/packages/@glimmer/runtime/lib/references/curry-value.ts
@@ -49,7 +49,7 @@ export default function createCurryRef(
 
         if (!resolvedDefinition) {
           throw new Error(
-            `Attempted to resolve \`${name}\`, which was expected to be a component, but nothing was found.`
+            `Attempted to resolve \`${value}\`, which was expected to be a component, but nothing was found.`
           );
         }
       }


### PR DESCRIPTION
TypeScript cannot save you from [window.name](https://developer.mozilla.org/en-US/docs/Web/API/Window/name). 😭