### PR TITLE
[REFACTOR] Deduplicate keyword logic

### DIFF
--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
@@ -1,3 +1,4 @@
+import { CurriedType } from '@glimmer/interfaces';
 import { ASTv2, generateSyntaxError } from '@glimmer/syntax';
 
 import { Err, Ok, Result } from '../../../shared/result';
@@ -6,7 +7,7 @@ import { NormalizationState } from '../context';
 import { VISIT_EXPRS } from '../visitors/expressions';
 import { VISIT_STMTS } from '../visitors/statements';
 import { keywords } from './impl';
-import { assertValidCurryUsage } from './utils/curry';
+import { assertCurryKeyword } from './utils/curry';
 
 export const BLOCK_KEYWORDS = keywords('Block')
   .kw('in-element', {
@@ -435,7 +436,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
     },
   })
   .kw('component', {
-    assert: assertValidCurryUsage('{{#component}}', 'component', true),
+    assert: assertCurryKeyword(CurriedType.Component),
 
     translate(
       { node, state }: { node: ASTv2.InvokeBlock; state: NormalizationState },

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
@@ -1,162 +1,19 @@
 import { CurriedType } from '@glimmer/interfaces';
-import { ASTv2, SourceSlice } from '@glimmer/syntax';
 
-import { Ok, Result } from '../../../shared/result';
-import * as mir from '../../2-encoding/mir';
-import { NormalizationState } from '../context';
-import { VISIT_EXPRS } from '../visitors/expressions';
 import { keywords } from './impl';
-import { assertValidCurryUsage } from './utils/curry';
-import { assertValidGetDynamicVar } from './utils/dynamic-vars';
-import { assertValidHasBlockUsage } from './utils/has-block';
-import { assertValidIfUnlessInlineUsage } from './utils/if-unless';
-import { assertValidLog } from './utils/log';
+import { curryKeyword } from './utils/curry';
+import { getDynamicVarKeyword } from './utils/dynamic-vars';
+import { hasBlockKeyword } from './utils/has-block';
+import { ifUnlessInlineKeyword } from './utils/if-unless';
+import { logKeyword } from './utils/log';
 
 export const CALL_KEYWORDS = keywords('Call')
-  .kw('has-block', {
-    assert(node: ASTv2.CallExpression): Result<SourceSlice> {
-      return assertValidHasBlockUsage('has-block', node);
-    },
-    translate(
-      { node, state: { scope } }: { node: ASTv2.CallExpression; state: NormalizationState },
-      target: SourceSlice
-    ): Result<mir.HasBlock> {
-      return Ok(
-        new mir.HasBlock({ loc: node.loc, target, symbol: scope.allocateBlock(target.chars) })
-      );
-    },
-  })
-  .kw('has-block-params', {
-    assert(node: ASTv2.CallExpression): Result<SourceSlice> {
-      return assertValidHasBlockUsage('has-block-params', node);
-    },
-    translate(
-      { node, state: { scope } }: { node: ASTv2.CallExpression; state: NormalizationState },
-      target: SourceSlice
-    ): Result<mir.HasBlockParams> {
-      return Ok(
-        new mir.HasBlockParams({ loc: node.loc, target, symbol: scope.allocateBlock(target.chars) })
-      );
-    },
-  })
-  .kw('-get-dynamic-var', {
-    assert: assertValidGetDynamicVar,
-
-    translate(
-      { node, state }: { node: ASTv2.CallExpression; state: NormalizationState },
-      name: ASTv2.ExpressionNode
-    ): Result<mir.GetDynamicVar> {
-      return VISIT_EXPRS.visit(name, state).mapOk(
-        (name) => new mir.GetDynamicVar({ name, loc: node.loc })
-      );
-    },
-  })
-  .kw('log', {
-    assert: assertValidLog,
-
-    translate(
-      { node, state }: { node: ASTv2.CallExpression; state: NormalizationState },
-      positional: ASTv2.PositionalArguments
-    ): Result<mir.Log> {
-      return VISIT_EXPRS.Positional(positional, state).mapOk(
-        (positional) => new mir.Log({ positional, loc: node.loc })
-      );
-    },
-  })
-  .kw('if', {
-    assert: assertValidIfUnlessInlineUsage('(if)', false),
-
-    translate(
-      { node, state }: { node: ASTv2.CallExpression; state: NormalizationState },
-      {
-        condition,
-        truthy,
-        falsy,
-      }: {
-        condition: ASTv2.ExpressionNode;
-        truthy: ASTv2.ExpressionNode;
-        falsy: ASTv2.ExpressionNode | null;
-      }
-    ): Result<mir.IfInline> {
-      let conditionResult = VISIT_EXPRS.visit(condition, state);
-      let truthyResult = VISIT_EXPRS.visit(truthy, state);
-      let falsyResult = falsy ? VISIT_EXPRS.visit(falsy, state) : Ok(null);
-
-      return Result.all(conditionResult, truthyResult, falsyResult).mapOk(
-        ([condition, truthy, falsy]) =>
-          new mir.IfInline({
-            loc: node.loc,
-            condition,
-            truthy,
-            falsy,
-          })
-      );
-    },
-  })
-  .kw('unless', {
-    assert: assertValidIfUnlessInlineUsage('(unless)', true),
-
-    translate(
-      { node, state }: { node: ASTv2.CallExpression; state: NormalizationState },
-      {
-        condition,
-        falsy,
-        truthy,
-      }: {
-        condition: ASTv2.ExpressionNode;
-        truthy: ASTv2.ExpressionNode;
-        falsy: ASTv2.ExpressionNode | null;
-      }
-    ): Result<mir.IfInline> {
-      let conditionResult = VISIT_EXPRS.visit(condition, state);
-      let truthyResult = VISIT_EXPRS.visit(truthy, state);
-      let falsyResult = falsy ? VISIT_EXPRS.visit(falsy, state) : Ok(null);
-
-      return Result.all(conditionResult, truthyResult, falsyResult).mapOk(
-        ([condition, truthy, falsy]) =>
-          new mir.IfInline({
-            loc: node.loc,
-
-            // We reverse the condition by inserting a Not
-            condition: new mir.Not({ value: condition, loc: node.loc }),
-            truthy,
-            falsy,
-          })
-      );
-    },
-  })
-  .kw('component', {
-    assert: assertValidCurryUsage('(component)', 'component', true),
-
-    translate: translateCallCurryUsage(CurriedType.Component),
-  })
-  .kw('helper', {
-    assert: assertValidCurryUsage('(helper)', 'helper', false),
-
-    translate: translateCallCurryUsage(CurriedType.Helper),
-  })
-  .kw('modifier', {
-    assert: assertValidCurryUsage('(modifier)', 'modifier', false),
-
-    translate: translateCallCurryUsage(CurriedType.Modifier),
-  });
-
-function translateCallCurryUsage(curriedType: CurriedType) {
-  return (
-    { node, state }: { node: ASTv2.CallExpression; state: NormalizationState },
-    { definition, args }: { definition: ASTv2.ExpressionNode; args: ASTv2.Args }
-  ): Result<mir.Curry> => {
-    let definitionResult = VISIT_EXPRS.visit(definition, state);
-    let argsResult = VISIT_EXPRS.Args(args, state);
-
-    return Result.all(definitionResult, argsResult).mapOk(
-      ([definition, args]) =>
-        new mir.Curry({
-          loc: node.loc,
-          curriedType,
-          definition,
-          args,
-        })
-    );
-  };
-}
+  .kw('has-block', hasBlockKeyword('has-block'))
+  .kw('has-block-params', hasBlockKeyword('has-block-params'))
+  .kw('-get-dynamic-var', getDynamicVarKeyword)
+  .kw('log', logKeyword)
+  .kw('if', ifUnlessInlineKeyword('if'))
+  .kw('unless', ifUnlessInlineKeyword('unless'))
+  .kw('component', curryKeyword(CurriedType.Component))
+  .kw('helper', curryKeyword(CurriedType.Helper))
+  .kw('modifier', curryKeyword(CurriedType.Modifier));

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/impl.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/impl.ts
@@ -10,7 +10,7 @@ import { exhausted } from '@glimmer/util';
 import { Err, Result } from '../../../shared/result';
 import { NormalizationState } from '../context';
 
-interface KeywordDelegate<Match extends KeywordMatch, V, Out> {
+export interface KeywordDelegate<Match extends KeywordMatch, V, Out> {
   assert(options: Match, state: NormalizationState): Result<V>;
   translate(options: { node: Match; state: NormalizationState }, param: V): Result<Out>;
 }

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/call-to-append.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/call-to-append.ts
@@ -1,0 +1,25 @@
+import { Result } from '../../../../shared/result';
+import * as mir from '../../../2-encoding/mir';
+import { NormalizationState } from '../../context';
+import { GenericKeywordNode, KeywordDelegate } from '../impl';
+
+export function toAppend<T>({
+  assert,
+  translate,
+}: KeywordDelegate<GenericKeywordNode, T, mir.ExpressionNode>): KeywordDelegate<
+  GenericKeywordNode,
+  T,
+  mir.AppendTextNode
+> {
+  return {
+    assert,
+    translate(
+      { node, state }: { node: GenericKeywordNode; state: NormalizationState },
+      value: T
+    ): Result<mir.AppendTextNode> {
+      let result = translate({ node, state }, value);
+
+      return result.mapOk((text) => new mir.AppendTextNode({ text, loc: node.loc }));
+    },
+  };
+}

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/has-block.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/has-block.ts
@@ -1,36 +1,70 @@
 import { ASTv2, generateSyntaxError, SourceSlice } from '@glimmer/syntax';
 
 import { Err, Ok, Result } from '../../../../shared/result';
-import { GenericKeywordNode } from '../impl';
+import * as mir from '../../../2-encoding/mir';
+import { NormalizationState } from '../../context';
+import { GenericKeywordNode, KeywordDelegate } from '../impl';
 
-export function assertValidHasBlockUsage(
-  type: string,
-  node: GenericKeywordNode
-): Result<SourceSlice> {
-  let call = node.type === 'AppendContent' ? node.value : node;
+function assertHasBlockKeyword(type: string) {
+  return (node: GenericKeywordNode): Result<SourceSlice> => {
+    let call = node.type === 'AppendContent' ? node.value : node;
 
-  let named = call.type === 'Call' ? call.args.named : null;
-  let positionals = call.type === 'Call' ? call.args.positional : null;
+    let named = call.type === 'Call' ? call.args.named : null;
+    let positionals = call.type === 'Call' ? call.args.positional : null;
 
-  if (named && !named.isEmpty()) {
-    return Err(generateSyntaxError(`(${type}) does not take any named arguments`, call.loc));
-  }
+    if (named && !named.isEmpty()) {
+      return Err(generateSyntaxError(`(${type}) does not take any named arguments`, call.loc));
+    }
 
-  if (!positionals || positionals.isEmpty()) {
-    return Ok(SourceSlice.synthetic('default'));
-  } else if (positionals.exprs.length === 1) {
-    let positional = positionals.exprs[0];
-    if (ASTv2.isLiteral(positional, 'string')) {
-      return Ok(positional.toSlice());
+    if (!positionals || positionals.isEmpty()) {
+      return Ok(SourceSlice.synthetic('default'));
+    } else if (positionals.exprs.length === 1) {
+      let positional = positionals.exprs[0];
+      if (ASTv2.isLiteral(positional, 'string')) {
+        return Ok(positional.toSlice());
+      } else {
+        return Err(
+          generateSyntaxError(
+            `(${type}) can only receive a string literal as its first argument`,
+            call.loc
+          )
+        );
+      }
     } else {
       return Err(
-        generateSyntaxError(
-          `(${type}) can only receive a string literal as its first argument`,
-          call.loc
-        )
+        generateSyntaxError(`(${type}) only takes a single positional argument`, call.loc)
       );
     }
-  } else {
-    return Err(generateSyntaxError(`(${type}) only takes a single positional argument`, call.loc));
-  }
+  };
+}
+
+function translateHasBlockKeyword(type: string) {
+  return (
+    { node, state: { scope } }: { node: ASTv2.CallExpression; state: NormalizationState },
+    target: SourceSlice
+  ): Result<mir.HasBlock | mir.HasBlockParams> => {
+    let block =
+      type === 'has-block'
+        ? new mir.HasBlock({ loc: node.loc, target, symbol: scope.allocateBlock(target.chars) })
+        : new mir.HasBlockParams({
+            loc: node.loc,
+            target,
+            symbol: scope.allocateBlock(target.chars),
+          });
+
+    return Ok(block);
+  };
+}
+
+export function hasBlockKeyword(
+  type: string
+): KeywordDelegate<
+  ASTv2.CallExpression | ASTv2.AppendContent,
+  SourceSlice,
+  mir.HasBlock | mir.HasBlockParams
+> {
+  return {
+    assert: assertHasBlockKeyword(type),
+    translate: translateHasBlockKeyword(type),
+  };
 }

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/if-unless.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/if-unless.ts
@@ -1,8 +1,12 @@
 import { ASTv2, generateSyntaxError } from '@glimmer/syntax';
 
 import { Err, Ok, Result } from '../../../../shared/result';
+import * as mir from '../../../2-encoding/mir';
+import { NormalizationState } from '../../context';
+import { VISIT_EXPRS } from '../../visitors/expressions';
+import { KeywordDelegate } from '../impl';
 
-export function assertValidIfUnlessInlineUsage(type: string, inverted: boolean) {
+function assertIfUnlessInlineKeyword(type: string) {
   return (
     originalNode: ASTv2.AppendContent | ASTv2.ExpressionNode
   ): Result<{
@@ -10,6 +14,8 @@ export function assertValidIfUnlessInlineUsage(type: string, inverted: boolean) 
     truthy: ASTv2.ExpressionNode;
     falsy: ASTv2.ExpressionNode | null;
   }> => {
+    let inverted = type === 'unless';
+
     let node = originalNode.type === 'AppendContent' ? originalNode.value : originalNode;
     let named = node.type === 'Call' ? node.args.named : null;
     let positional = node.type === 'Call' ? node.args.positional : null;
@@ -17,7 +23,7 @@ export function assertValidIfUnlessInlineUsage(type: string, inverted: boolean) 
     if (named && !named.isEmpty()) {
       return Err(
         generateSyntaxError(
-          `${type} cannot receive named parameters, received ${named.entries
+          `(${type}) cannot receive named parameters, received ${named.entries
             .map((e) => e.name.chars)
             .join(', ')}`,
           originalNode.loc
@@ -30,7 +36,7 @@ export function assertValidIfUnlessInlineUsage(type: string, inverted: boolean) 
     if (!positional || !condition) {
       return Err(
         generateSyntaxError(
-          `When used inline, ${type} requires at least two parameters 1. the condition that determines the state of the ${type}, and 2. the value to return if the condition is ${
+          `When used inline, (${type}) requires at least two parameters 1. the condition that determines the state of the (${type}), and 2. the value to return if the condition is ${
             inverted ? 'false' : 'true'
           }. Did not receive any parameters`,
           originalNode.loc
@@ -44,7 +50,7 @@ export function assertValidIfUnlessInlineUsage(type: string, inverted: boolean) 
     if (truthy === null) {
       return Err(
         generateSyntaxError(
-          `When used inline, ${type} requires at least two parameters 1. the condition that determines the state of the ${type}, and 2. the value to return if the condition is ${
+          `When used inline, (${type}) requires at least two parameters 1. the condition that determines the state of the (${type}), and 2. the value to return if the condition is ${
             inverted ? 'false' : 'true'
           }. Received only one parameter, the condition`,
           originalNode.loc
@@ -55,7 +61,7 @@ export function assertValidIfUnlessInlineUsage(type: string, inverted: boolean) 
     if (positional.size > 3) {
       return Err(
         generateSyntaxError(
-          `When used inline, ${type} can receive a maximum of three positional parameters 1. the condition that determines the state of the ${type}, 2. the value to return if the condition is ${
+          `When used inline, (${type}) can receive a maximum of three positional parameters 1. the condition that determines the state of the (${type}), 2. the value to return if the condition is ${
             inverted ? 'false' : 'true'
           }, and 3. the value to return if the condition is ${
             inverted ? 'true' : 'false'
@@ -66,5 +72,61 @@ export function assertValidIfUnlessInlineUsage(type: string, inverted: boolean) 
     }
 
     return Ok({ condition, truthy, falsy });
+  };
+}
+
+function translateIfUnlessInlineKeyword(type: string) {
+  let inverted = type === 'unless';
+
+  return (
+    {
+      node,
+      state,
+    }: { node: ASTv2.AppendContent | ASTv2.ExpressionNode; state: NormalizationState },
+    {
+      condition,
+      truthy,
+      falsy,
+    }: {
+      condition: ASTv2.ExpressionNode;
+      truthy: ASTv2.ExpressionNode;
+      falsy: ASTv2.ExpressionNode | null;
+    }
+  ): Result<mir.IfInline> => {
+    let conditionResult = VISIT_EXPRS.visit(condition, state);
+    let truthyResult = VISIT_EXPRS.visit(truthy, state);
+    let falsyResult = falsy ? VISIT_EXPRS.visit(falsy, state) : Ok(null);
+
+    return Result.all(conditionResult, truthyResult, falsyResult).mapOk(
+      ([condition, truthy, falsy]) => {
+        if (inverted) {
+          condition = new mir.Not({ value: condition, loc: node.loc });
+        }
+
+        return new mir.IfInline({
+          loc: node.loc,
+          condition,
+          truthy,
+          falsy,
+        });
+      }
+    );
+  };
+}
+
+export function ifUnlessInlineKeyword(
+  type: string
+): KeywordDelegate<
+  ASTv2.CallExpression | ASTv2.AppendContent,
+  {
+    condition: ASTv2.ExpressionNode;
+    truthy: ASTv2.ExpressionNode;
+    falsy: ASTv2.ExpressionNode | null;
+  },
+  mir.IfInline
+> {
+  return {
+    assert: assertIfUnlessInlineKeyword(type),
+    translate: translateIfUnlessInlineKeyword(type),
   };
 }

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/log.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/log.ts
@@ -1,9 +1,12 @@
 import { ASTv2, generateSyntaxError } from '@glimmer/syntax';
 
 import { Err, Ok, Result } from '../../../../shared/result';
-import { GenericKeywordNode } from '../impl';
+import * as mir from '../../../2-encoding/mir';
+import { NormalizationState } from '../../context';
+import { VISIT_EXPRS } from '../../visitors/expressions';
+import { GenericKeywordNode, KeywordDelegate } from '../impl';
 
-export function assertValidLog(node: GenericKeywordNode): Result<ASTv2.PositionalArguments> {
+function assertLogKeyword(node: GenericKeywordNode): Result<ASTv2.PositionalArguments> {
   let {
     args: { named, positional },
   } = node;
@@ -14,3 +17,21 @@ export function assertValidLog(node: GenericKeywordNode): Result<ASTv2.Positiona
 
   return Ok(positional);
 }
+
+function translateLogKeyword(
+  { node, state }: { node: ASTv2.CallExpression; state: NormalizationState },
+  positional: ASTv2.PositionalArguments
+): Result<mir.Log> {
+  return VISIT_EXPRS.Positional(positional, state).mapOk(
+    (positional) => new mir.Log({ positional, loc: node.loc })
+  );
+}
+
+export const logKeyword: KeywordDelegate<
+  ASTv2.CallExpression | ASTv2.AppendContent,
+  ASTv2.PositionalArguments,
+  mir.Log
+> = {
+  assert: assertLogKeyword,
+  translate: translateLogKeyword,
+};

--- a/packages/@glimmer/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer/integration-tests/test/strict-mode-test.ts
@@ -93,7 +93,7 @@ class GeneralStrictModeTest extends RenderTest {
   '{{component}} throws an error if a string is used in strict (append position)'() {
     this.assert.throws(() => {
       defineComponent({}, '{{component "bar"}}');
-    }, /{{component}} cannot resolve string values in strict mode templates/);
+    }, /\(component\) cannot resolve string values in strict mode templates/);
   }
 
   @test
@@ -134,7 +134,7 @@ class GeneralStrictModeTest extends RenderTest {
   '{{component}} throws an error if a string is used in strict (block position)'() {
     this.assert.throws(() => {
       defineComponent({}, '{{#component "bar"}}{{/component}}');
-    }, /{{#component}} cannot resolve string values in strict mode templates/);
+    }, /\(component\) cannot resolve string values in strict mode templates/);
   }
 
   @test

--- a/packages/@glimmer/integration-tests/test/syntax/if-unless-test.ts
+++ b/packages/@glimmer/integration-tests/test/syntax/if-unless-test.ts
@@ -35,28 +35,28 @@ for (let type of types) {
         preprocess(`{{${type} condition=true}}`, {
           meta: { moduleName: 'test-module' },
         });
-      }, syntaxErrorFor(`{{${type}}} cannot receive named parameters, received condition`, `{{${type} condition=true}}`, 'test-module', 1, 0));
+      }, syntaxErrorFor(`(${type}) cannot receive named parameters, received condition`, `{{${type} condition=true}}`, 'test-module', 1, 0));
     }
 
     @test
     [`{{${type}}} throws if it received no positional params`]() {
       this.assert.throws(() => {
         preprocess(`{{${type}}}`, { meta: { moduleName: 'test-module' } });
-      }, syntaxErrorFor(`When used inline, {{${type}}} requires at least two parameters 1. the condition that determines the state of the {{${type}}}, and 2. the value to return if the condition is ${type === 'if' ? 'true' : 'false'}. Did not receive any parameters`, `{{${type}}}`, 'test-module', 1, 0));
+      }, syntaxErrorFor(`When used inline, (${type}) requires at least two parameters 1. the condition that determines the state of the (${type}), and 2. the value to return if the condition is ${type === 'if' ? 'true' : 'false'}. Did not receive any parameters`, `{{${type}}}`, 'test-module', 1, 0));
     }
 
     @test
     [`{{${type}}} throws if it received only one positional param`]() {
       this.assert.throws(() => {
         preprocess(`{{${type} true}}`, { meta: { moduleName: 'test-module' } });
-      }, syntaxErrorFor(`When used inline, {{${type}}} requires at least two parameters 1. the condition that determines the state of the {{${type}}}, and 2. the value to return if the condition is ${type === 'if' ? 'true' : 'false'}. Received only one parameter, the condition`, `{{${type} true}}`, 'test-module', 1, 0));
+      }, syntaxErrorFor(`When used inline, (${type}) requires at least two parameters 1. the condition that determines the state of the (${type}), and 2. the value to return if the condition is ${type === 'if' ? 'true' : 'false'}. Received only one parameter, the condition`, `{{${type} true}}`, 'test-module', 1, 0));
     }
 
     @test
     [`{{${type}}} throws if it received more than 3 positional params`]() {
       this.assert.throws(() => {
         preprocess(`{{${type} true false true false}}`, { meta: { moduleName: 'test-module' } });
-      }, syntaxErrorFor(`When used inline, {{${type}}} can receive a maximum of three positional parameters 1. the condition that determines the state of the {{${type}}}, 2. the value to return if the condition is ${type === 'if' ? 'true' : 'false'}, and 3. the value to return if the condition is ${type === 'if' ? 'false' : 'true'}. Received 4 parameters`, `{{${type} true false true false}}`, 'test-module', 1, 0));
+      }, syntaxErrorFor(`When used inline, (${type}) can receive a maximum of three positional parameters 1. the condition that determines the state of the (${type}), 2. the value to return if the condition is ${type === 'if' ? 'true' : 'false'}, and 3. the value to return if the condition is ${type === 'if' ? 'false' : 'true'}. Received 4 parameters`, `{{${type} true false true false}}`, 'test-module', 1, 0));
     }
 
     @test


### PR DESCRIPTION
A number of keywords now share most of their implementation between the
Call and Append invocations, with a few minor differences. This PR
deduplicates the logic that they share into shared utility functions,
with a `toAppend` utility which wraps the Call version of the utility to
turn it into an Append version in a type-safe way.