### PR TITLE
[FEATURE] Upstream built-in helpers and modifiers from Ember

### DIFF
--- a/packages/@glimmer/benchmark-env/src/benchmark/create-env-delegate.ts
+++ b/packages/@glimmer/benchmark-env/src/benchmark/create-env-delegate.ts
@@ -43,12 +43,35 @@ setGlobalContext({
     return (obj as Record<string, unknown>)[prop];
   },
 
-  setProp(obj: unknown, prop: string, value) {
+  setProp(obj: unknown, prop: string, value: unknown) {
     (obj as Record<string, unknown>)[prop] = value;
   },
 
   getPath(obj: unknown, path: string) {
-    return (obj as Record<string, unknown>)[path];
+    let parts = path.split('.');
+
+    let current: unknown = obj;
+
+    for (let part of parts) {
+      if (typeof current === 'function' || (typeof current === 'object' && current !== null)) {
+        current = (current as Record<string, unknown>)[part];
+      }
+    }
+
+    return current;
+  },
+
+  setPath(obj: unknown, path: string, value: unknown) {
+    let parts = path.split('.');
+
+    let current: unknown = obj;
+    let pathToSet = parts.pop()!;
+
+    for (let part of parts) {
+      current = (current as Record<string, unknown>)[part];
+    }
+
+    (current as Record<string, unknown>)[pathToSet] = value;
   },
 
   toBool(value) {

--- a/packages/@glimmer/global-context/index.ts
+++ b/packages/@glimmer/global-context/index.ts
@@ -101,6 +101,15 @@ export let setProp: (obj: object, prop: string, value: unknown) => void;
 export let getPath: (obj: object, path: string) => unknown;
 
 /**
+ * Hook for specifying how Glimmer should update paths in cases where it needs
+ * to. For instance, when updating a template reference (e.g. 2-way-binding)
+ *
+ * @param obj The object provided to get a value from
+ * @param path The path to get the value from
+ */
+export let setPath: (obj: object, path: string, value: unknown) => unknown;
+
+/**
  * Hook to warn if a style binding string or value was not marked as trusted
  * (e.g. HTMLSafe)
  */
@@ -117,6 +126,7 @@ export interface GlobalContext {
   getProp: (obj: object, path: string) => unknown;
   setProp: (obj: object, prop: string, value: unknown) => void;
   getPath: (obj: object, path: string) => unknown;
+  setPath: (obj: object, prop: string, value: unknown) => void;
   warnIfStyleNotTrusted: (value: unknown) => void;
 }
 
@@ -139,6 +149,7 @@ export default function setGlobalContext(context: GlobalContext) {
   getProp = context.getProp;
   setProp = context.setProp;
   getPath = context.getPath;
+  setPath = context.setPath;
   warnIfStyleNotTrusted = context.warnIfStyleNotTrusted;
 }
 
@@ -167,6 +178,7 @@ if (DEBUG) {
           getProp,
           setProp,
           getPath,
+          setPath,
           warnIfStyleNotTrusted,
         }
       : null;
@@ -185,6 +197,7 @@ if (DEBUG) {
     getProp = context?.getProp || getProp;
     setProp = context?.setProp || setProp;
     getPath = context?.getPath || getPath;
+    setPath = context?.setPath || setPath;
     warnIfStyleNotTrusted = context?.warnIfStyleNotTrusted || warnIfStyleNotTrusted;
 
     return originalGlobalContext;

--- a/packages/@glimmer/integration-tests/lib/modes/env.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/env.ts
@@ -48,12 +48,31 @@ setGlobalContext({
     return ((obj as Dict)[key] = value);
   },
 
-  getPath(obj: unknown, key: string): unknown {
-    if (typeof obj === 'object' && obj !== null) {
-      consumeTag(tagFor(obj as object, key));
+  getPath(obj: unknown, path: string) {
+    let parts = path.split('.');
+
+    let current: unknown = obj;
+
+    for (let part of parts) {
+      if (typeof current === 'function' || (typeof current === 'object' && current !== null)) {
+        current = (current as Record<string, unknown>)[part];
+      }
     }
 
-    return (obj as Dict)[key];
+    return current;
+  },
+
+  setPath(obj: unknown, path: string, value: unknown) {
+    let parts = path.split('.');
+
+    let current: unknown = obj;
+    let pathToSet = parts.pop()!;
+
+    for (let part of parts) {
+      current = (current as Record<string, unknown>)[part];
+    }
+
+    (current as Record<string, unknown>)[pathToSet] = value;
   },
 
   warnIfStyleNotTrusted() {},

--- a/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/modes/jit/delegate.ts
@@ -17,9 +17,15 @@ import { programCompilationContext } from '@glimmer/opcode-compiler';
 import { artifacts } from '@glimmer/program';
 import { createConstRef, Reference } from '@glimmer/reference';
 import {
+  array,
   clientBuilder,
+  concat,
   CurriedValue,
   EnvironmentDelegate,
+  fn,
+  get,
+  hash,
+  on,
   renderComponent,
   renderSync,
   runtimeContext,
@@ -84,6 +90,12 @@ export class JitRenderDelegate implements RenderDelegate {
   constructor(options?: RenderDelegateOptions) {
     this.doc = castToSimple(options?.doc ?? document);
     this.env = assign({}, options?.env ?? BaseEnv);
+    this.registry.register('modifier', 'on', on);
+    this.registry.register('helper', 'fn', fn);
+    this.registry.register('helper', 'hash', hash);
+    this.registry.register('helper', 'array', array);
+    this.registry.register('helper', 'get', get);
+    this.registry.register('helper', 'concat', concat);
   }
 
   get context(): JitTestDelegateContext {

--- a/packages/@glimmer/integration-tests/lib/test-helpers/module.ts
+++ b/packages/@glimmer/integration-tests/lib/test-helpers/module.ts
@@ -101,8 +101,9 @@ export function suite<D extends RenderDelegate>(
         } else {
           // eslint-disable-next-line no-loop-func
           QUnit.test(prop, (assert) => {
-            test.call(instance!, assert, instance!.count);
+            let result = test.call(instance!, assert, instance!.count);
             instance!.count.assert();
+            return result;
           });
         }
       }
@@ -133,7 +134,7 @@ function componentModule<D extends RenderDelegate, T extends IRenderTest>(
         QUnit.test(prop, (assert) => {
           let instance = new klass(new Delegate());
           instance.testType = type;
-          test.call(instance, assert, instance.count);
+          return test.call(instance, assert, instance.count);
         });
       }
     };

--- a/packages/@glimmer/integration-tests/test/helpers/array-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/array-test.ts
@@ -1,0 +1,314 @@
+import { jitSuite, RenderTest, strip, test, GlimmerishComponent, tracked } from '../..';
+
+class ArrayTest extends RenderTest {
+  static suiteName = 'Helpers test: {{array}}';
+
+  @test
+  'returns an array'() {
+    this.render(strip`
+    {{#with (array "Sergio") as |people|}}
+      {{#each people as |personName|}}
+        {{personName}}
+      {{/each}}
+    {{/with}}`);
+
+    this.assertHTML('Sergio');
+
+    this.assertStableRerender();
+  }
+
+  @test
+  'can have more than one value'() {
+    this.render(strip`
+    {{#with (array "Sergio" "Robert") as |people|}}
+      {{#each people as |personName|}}
+        {{personName}},
+      {{/each}}
+    {{/with}}`);
+
+    this.assertHTML('Sergio,Robert,');
+
+    this.assertStableRerender();
+  }
+
+  @test
+  'binds values when variables are used'() {
+    this.render(
+      strip`{{#with (array personOne) as |people|}}
+            {{#each people as |personName|}}
+              {{personName}}
+            {{/each}}
+          {{/with}}`,
+      {
+        personOne: 'Tom',
+      }
+    );
+
+    this.assertHTML('Tom');
+
+    this.assertStableRerender();
+
+    this.rerender({ personOne: 'Yehuda' });
+    this.assertHTML('Yehuda');
+
+    this.rerender({ personOne: 'Tom' });
+    this.assertHTML('Tom');
+  }
+
+  @test
+  'binds multiple values when variables are used'() {
+    this.render(
+      strip`{{#with (array personOne personTwo) as |people|}}
+            {{#each people as |personName|}}
+              {{personName}},
+            {{/each}}
+          {{/with}}`,
+      {
+        personOne: 'Tom',
+        personTwo: 'Yehuda',
+      }
+    );
+
+    this.assertHTML('Tom,Yehuda,');
+
+    this.assertStableRerender();
+
+    this.rerender({ personOne: 'Sergio' });
+
+    this.assertHTML('Sergio,Yehuda,');
+
+    this.rerender({ personTwo: 'Tom' });
+
+    this.assertHTML('Sergio,Tom,');
+
+    this.rerender({ personOne: 'Tom', personTwo: 'Yehuda' });
+    this.assertHTML('Tom,Yehuda,');
+  }
+
+  @test
+  'array helpers can be nested'() {
+    this.render(
+      strip`
+        {{#let (array (array personOne personTwo)) as |listOfPeople|}}
+          {{#each listOfPeople as |people|}}
+            List:
+            {{#each people as |personName|}}
+              {{personName}},
+            {{/each}}
+          {{/each}}
+        {{/let}}
+      `,
+      {
+        personOne: 'Tom',
+        personTwo: 'Yehuda',
+      }
+    );
+
+    this.assertHTML('List:Tom,Yehuda,');
+
+    this.assertStableRerender();
+
+    this.rerender({ personOne: 'Chad' });
+
+    this.assertHTML('List:Chad,Yehuda,');
+
+    this.rerender({ personTwo: 'Balint' });
+
+    this.assertHTML('List:Chad,Balint,');
+
+    this.rerender({ personOne: 'Tom', personTwo: 'Yehuda' });
+
+    this.assertHTML('List:Tom,Yehuda,');
+  }
+
+  @test
+  'should yield hash of an array of internal properties'() {
+    let fooBarInstance: FooBar;
+
+    class FooBar extends GlimmerishComponent {
+      @tracked personOne = 'Chad';
+
+      constructor(owner: object, args: Record<string, unknown>) {
+        super(owner, args);
+        fooBarInstance = this;
+      }
+    }
+
+    this.registerComponent(
+      'Glimmer',
+      'FooBar',
+      '{{yield (hash people=(array this.personOne))}}',
+      FooBar
+    );
+
+    this.render(
+      strip`
+        <FooBar as |values|>
+          {{#each values.people as |personName|}}
+            {{personName}}
+          {{/each}}
+        </FooBar>
+      `
+    );
+
+    this.assertHTML('Chad');
+
+    this.assertStableRerender();
+
+    fooBarInstance!.personOne = 'Godfrey';
+
+    this.rerender();
+    this.assertHTML('Godfrey');
+
+    fooBarInstance!.personOne = 'Chad';
+
+    this.rerender();
+    this.assertHTML('Chad');
+  }
+
+  @test
+  'should yield hash of an array of internal and external properties'() {
+    let fooBarInstance: FooBar;
+
+    class FooBar extends GlimmerishComponent {
+      @tracked personOne = 'Chad';
+
+      constructor(owner: object, args: Record<string, unknown>) {
+        super(owner, args);
+        fooBarInstance = this;
+      }
+    }
+
+    this.registerComponent(
+      'Glimmer',
+      'FooBar',
+      `{{yield (hash people=(array this.personOne @personTwo))}}`,
+      FooBar
+    );
+
+    this.render(
+      strip`
+        <FooBar @personTwo={{this.model.personTwo}} as |values|>
+          {{#each values.people as |personName|}}
+            {{personName}},
+          {{/each}}
+        </FooBar>
+      `,
+      {
+        model: { personTwo: 'Tom' },
+      }
+    );
+
+    this.assertHTML('Chad,Tom,');
+
+    this.assertStableRerender();
+
+    fooBarInstance!.personOne = 'Godfrey';
+
+    this.rerender({ model: { personTwo: 'Yehuda' } });
+    this.assertHTML('Godfrey,Yehuda,');
+
+    fooBarInstance!.personOne = 'Chad';
+
+    this.rerender({ model: { personTwo: 'Tom' } });
+    this.assertHTML('Chad,Tom,');
+  }
+
+  @test
+  'should render when passing as argument to a component invocation'() {
+    this.registerComponent(
+      'TemplateOnly',
+      'FooBar',
+      strip`
+        {{#each @people as |personName|}}
+          {{personName}},
+        {{/each}}
+      `
+    );
+
+    this.render(strip`<FooBar @people={{array "Tom" personTwo}}/>`, { personTwo: 'Chad' });
+
+    this.assertHTML('Tom,Chad,');
+
+    this.assertStableRerender();
+
+    this.rerender({ personTwo: 'Godfrey' });
+
+    this.assertHTML('Tom,Godfrey,');
+
+    this.rerender({ personTwo: 'Chad' });
+
+    this.assertHTML('Tom,Chad,');
+  }
+
+  @test
+  'should return an entirely new array when any argument change'() {
+    let fooBarInstance: FooBar;
+
+    class FooBar extends GlimmerishComponent {
+      @tracked personOne = 'Chad';
+
+      constructor(owner: object, args: Record<string, unknown>) {
+        super(owner, args);
+        fooBarInstance = this;
+      }
+    }
+
+    this.registerComponent(
+      'Glimmer',
+      'FooBar',
+      strip`
+        {{#each @people as |personName|}}
+          {{personName}},
+        {{/each}}
+      `,
+      FooBar
+    );
+
+    this.render(strip`<FooBar @people={{array "Tom" personTwo}}/>`, { personTwo: 'Chad' });
+
+    let firstArray = fooBarInstance!.args.people;
+
+    this.rerender({ personTwo: 'Godfrey' });
+
+    this.assert.ok(
+      firstArray !== fooBarInstance!.args.people,
+      'should have created an entirely new array'
+    );
+  }
+
+  @test
+  'capture array values in JS to assert deep equal'() {
+    let captured;
+
+    this.registerHelper('capture', function ([array]) {
+      captured = array;
+      return 'captured';
+    });
+
+    this.render(`{{capture (array 'Tom' personTwo)}}`, { personTwo: 'Godfrey' });
+
+    this.assert.deepEqual(captured, ['Tom', 'Godfrey']);
+
+    this.rerender({ personTwo: 'Robert' });
+
+    this.assert.deepEqual(captured, ['Tom', 'Robert']);
+
+    this.rerender({ personTwo: 'Godfrey' });
+
+    this.assert.deepEqual(captured, ['Tom', 'Godfrey']);
+  }
+
+  @test
+  'GH18693 properties in hash can be accessed from the array'() {
+    this.render(strip`
+      {{#each (array (hash some="thing")) as |item|}}
+        {{item.some}}
+      {{/each}}
+    `);
+
+    this.assertHTML('thing');
+  }
+}
+
+jitSuite(ArrayTest);

--- a/packages/@glimmer/integration-tests/test/helpers/concat-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/concat-test.ts
@@ -1,0 +1,104 @@
+import { jitSuite, RenderTest, test } from '../..';
+
+class ConcatTest extends RenderTest {
+  static suiteName = 'Helpers test: {{concat}}';
+
+  @test
+  'it concats static arguments'() {
+    this.render(`{{concat "foo" " " "bar" " " "baz"}}`);
+    this.assertHTML('foo bar baz');
+  }
+
+  @test
+  'it updates for bound arguments'() {
+    this.render(`{{concat this.model.first this.model.second}}`, {
+      model: { first: 'one', second: 'two' },
+    });
+
+    this.assertHTML('onetwo');
+    this.assertStableRerender();
+
+    this.rerender({ model: { first: 'three', second: 'two' } });
+    this.assertHTML('threetwo');
+
+    this.rerender({ model: { first: 'three', second: 'four' } });
+    this.assertHTML('threefour');
+
+    this.rerender({ model: { first: 'one', second: 'two' } });
+    this.assertHTML('onetwo');
+  }
+
+  @test
+  'it can be used as a sub-expression'() {
+    this.render(
+      `{{concat (concat this.model.first this.model.second) (concat this.model.third this.model.fourth)}}`,
+      {
+        model: {
+          first: 'one',
+          second: 'two',
+          third: 'three',
+          fourth: 'four',
+        },
+      }
+    );
+
+    this.assertHTML('onetwothreefour');
+    this.assertStableRerender();
+
+    this.rerender({
+      model: {
+        first: 'five',
+        second: 'two',
+        third: 'three',
+        fourth: 'four',
+      },
+    });
+    this.assertHTML('fivetwothreefour');
+
+    this.rerender({
+      model: {
+        first: 'five',
+        second: 'six',
+        third: 'seven',
+        fourth: 'four',
+      },
+    });
+    this.assertHTML('fivesixsevenfour');
+
+    this.rerender({
+      model: {
+        first: 'one',
+        second: 'two',
+        third: 'three',
+        fourth: 'four',
+      },
+    });
+    this.assertHTML('onetwothreefour');
+  }
+
+  @test
+  'it can be used as input for other helpers'() {
+    this.registerHelper('x-eq', ([actual, expected]) => actual === expected);
+
+    this.render(
+      `{{#if (x-eq (concat this.model.first this.model.second) "onetwo")}}Truthy!{{else}}False{{/if}}`,
+      {
+        model: {
+          first: 'one',
+          second: 'two',
+        },
+      }
+    );
+
+    this.assertHTML('Truthy!');
+    this.assertStableRerender();
+
+    this.rerender({ model: { first: 'three', second: 'two' } });
+    this.assertHTML('False');
+
+    this.rerender({ model: { first: 'one', second: 'two' } });
+    this.assertHTML('Truthy!');
+  }
+}
+
+jitSuite(ConcatTest);

--- a/packages/@glimmer/integration-tests/test/helpers/fn-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/fn-test.ts
@@ -1,0 +1,280 @@
+import { VMArguments } from '@glimmer/interfaces';
+import { createInvokableRef } from '@glimmer/reference';
+import { HAS_NATIVE_PROXY } from '@glimmer/util';
+
+import { jitSuite, RenderTest, test, GlimmerishComponent } from '../..';
+
+class FnTest extends RenderTest {
+  static suiteName = 'Helpers test: {{fn}}';
+
+  stashedFn?: () => unknown;
+
+  beforeEach() {
+    this.registerHelper('invoke', ([fn]) => {
+      return (fn as () => unknown)();
+    });
+
+    let testContext = this;
+
+    this.registerComponent(
+      'Glimmer',
+      'Stash',
+      '',
+      class extends GlimmerishComponent {
+        constructor(owner: object, args: Record<string, unknown>) {
+          super(owner, args);
+          testContext.stashedFn = args.stashedFn as () => unknown;
+        }
+      }
+    );
+  }
+
+  @test
+  'updates when arguments change'() {
+    this.render(`{{invoke (fn this.myFunc this.arg1 this.arg2)}}`, {
+      myFunc(arg1: string, arg2: string) {
+        return `arg1: ${arg1}, arg2: ${arg2}`;
+      },
+
+      arg1: 'foo',
+      arg2: 'bar',
+    });
+
+    this.assertHTML('arg1: foo, arg2: bar');
+
+    this.assertStableRerender();
+
+    this.rerender({ arg1: 'qux' });
+    this.assertHTML('arg1: qux, arg2: bar');
+
+    this.rerender({ arg2: 'derp' });
+    this.assertHTML('arg1: qux, arg2: derp');
+
+    this.rerender({ arg1: 'foo', arg2: 'bar' });
+    this.assertHTML('arg1: foo, arg2: bar');
+  }
+
+  @test
+  'updates when the function changes'() {
+    let func1 = (arg1: string, arg2: string) => `arg1: ${arg1}, arg2: ${arg2}`;
+    let func2 = (arg1: string, arg2: string) => `arg2: ${arg2}, arg1: ${arg1}`;
+
+    this.render(`{{invoke (fn this.myFunc this.arg1 this.arg2)}}`, {
+      myFunc: func1,
+
+      arg1: 'foo',
+      arg2: 'bar',
+    });
+
+    this.assertHTML('arg1: foo, arg2: bar');
+    this.assertStableRerender();
+
+    this.rerender({ myFunc: func2 });
+    this.assertHTML('arg2: bar, arg1: foo');
+
+    this.rerender({ myFunc: func1 });
+    this.assertHTML('arg1: foo, arg2: bar');
+  }
+
+  @test
+  'a stashed fn result update arguments when invoked'(assert: Assert) {
+    this.render(`<Stash @stashedFn={{fn this.myFunc this.arg1 this.arg2}}/>`, {
+      myFunc(arg1: string, arg2: string) {
+        return `arg1: ${arg1}, arg2: ${arg2}`;
+      },
+
+      arg1: 'foo',
+      arg2: 'bar',
+    });
+
+    assert.equal(this.stashedFn?.(), 'arg1: foo, arg2: bar');
+
+    this.rerender({ arg1: 'qux' });
+    assert.equal(this.stashedFn?.(), 'arg1: qux, arg2: bar');
+
+    this.rerender({ arg2: 'derp' });
+    assert.equal(this.stashedFn?.(), 'arg1: qux, arg2: derp');
+
+    this.rerender({ arg1: 'foo', arg2: 'bar' });
+    assert.equal(this.stashedFn?.(), 'arg1: foo, arg2: bar');
+  }
+
+  @test
+  'a stashed fn result invokes the correct function when the bound function changes'(
+    assert: Assert
+  ) {
+    let func1 = (arg1: string, arg2: string) => `arg1: ${arg1}, arg2: ${arg2}`;
+    let func2 = (arg1: string, arg2: string) => `arg2: ${arg2}, arg1: ${arg1}`;
+
+    this.render(`<Stash @stashedFn={{fn this.myFunc this.arg1 this.arg2}}/>`, {
+      myFunc: func1,
+
+      arg1: 'foo',
+      arg2: 'bar',
+    });
+
+    assert.equal(this.stashedFn?.(), 'arg1: foo, arg2: bar');
+
+    this.rerender({ myFunc: func2 });
+    assert.equal(this.stashedFn?.(), 'arg2: bar, arg1: foo');
+
+    this.rerender({ myFunc: func1 });
+    assert.equal(this.stashedFn?.(), 'arg1: foo, arg2: bar');
+  }
+
+  @test
+  'asserts if no argument given'(assert: Assert) {
+    assert.throws(() => {
+      this.render(`{{fn}}`, {
+        myFunc: null,
+        arg1: 'foo',
+        arg2: 'bar',
+      });
+    }, /You must pass a function as the `fn` helpers first argument./);
+  }
+
+  @test
+  'asserts if the first argument is undefined'(assert: Assert) {
+    assert.throws(() => {
+      this.render(`{{fn this.myFunc this.arg1 this.arg2}}`, {
+        myFunc: undefined,
+        arg1: 'foo',
+        arg2: 'bar',
+      });
+    }, /You must pass a function as the `fn` helpers first argument, you passed undefined. While rendering:\n\nthis.myFunc/);
+  }
+
+  @test
+  'asserts if the first argument is null'(assert: Assert) {
+    assert.throws(() => {
+      this.render(`{{fn this.myFunc this.arg1 this.arg2}}`, {
+        myFunc: null,
+        arg1: 'foo',
+        arg2: 'bar',
+      });
+    }, /You must pass a function as the `fn` helpers first argument, you passed null. While rendering:\n\nthis.myFunc/);
+  }
+
+  @test
+  'asserts if the provided function accesses `this` without being bound prior to passing to fn'(
+    assert: Assert
+  ) {
+    if (!HAS_NATIVE_PROXY) {
+      return;
+    }
+
+    this.render(`<Stash @stashedFn={{fn this.myFunc this.arg1}}/>`, {
+      myFunc(arg1: string) {
+        return `arg1: ${arg1}, arg2: ${this.arg2}`;
+      },
+
+      arg1: 'foo',
+      arg2: 'bar',
+    });
+
+    assert.throws(() => {
+      this.stashedFn?.();
+    }, /You accessed `this.arg2` from a function passed to the `fn` helper, but the function itself was not bound to a valid `this` context. Consider updating to use a bound function./);
+  }
+
+  @test
+  'there is no `this` context within the callback'(assert: Assert) {
+    if (HAS_NATIVE_PROXY) {
+      return;
+    }
+
+    this.render(`<Stash @stashedFn={{fn this.myFunc this.arg1}}/>`, {
+      myFunc() {
+        assert.strictEqual(this, null, 'this is bound to null in production builds');
+      },
+    });
+
+    this.stashedFn?.();
+  }
+
+  @test
+  'can use `this` if bound prior to passing to fn'(assert: Assert) {
+    let context = {
+      myFunc(arg1: string) {
+        return `arg1: ${arg1}, arg2: ${this.arg2}`;
+      },
+
+      arg1: 'foo',
+      arg2: 'bar',
+    };
+
+    context.myFunc = context.myFunc.bind(context);
+
+    this.render(`<Stash @stashedFn={{fn this.myFunc this.arg1}}/>`, context);
+
+    assert.equal(this.stashedFn?.(), 'arg1: foo, arg2: bar');
+  }
+
+  @test
+  'partially applies each layer when nested [GH#17959]'() {
+    this.render(`{{invoke (fn (fn (fn this.myFunc this.arg1) this.arg2) this.arg3)}}`, {
+      myFunc(arg1: string, arg2: string, arg3: string) {
+        return `arg1: ${arg1}, arg2: ${arg2}, arg3: ${arg3}`;
+      },
+
+      arg1: 'foo',
+      arg2: 'bar',
+      arg3: 'qux',
+    });
+
+    this.assertHTML('arg1: foo, arg2: bar, arg3: qux');
+    this.assertStableRerender();
+
+    this.rerender({ arg1: 'qux' });
+    this.assertHTML('arg1: qux, arg2: bar, arg3: qux');
+
+    this.rerender({ arg2: 'derp' });
+    this.assertHTML('arg1: qux, arg2: derp, arg3: qux');
+
+    this.rerender({ arg3: 'huzzah' });
+    this.assertHTML('arg1: qux, arg2: derp, arg3: huzzah');
+
+    this.rerender({ arg1: 'foo', arg2: 'bar', arg3: 'qux' });
+    this.assertHTML('arg1: foo, arg2: bar, arg3: qux');
+  }
+
+  @test
+  'can be used on the result of `mut`'() {
+    this.registerInternalHelper('mut', (args: VMArguments) => {
+      return createInvokableRef(args.positional.at(0));
+    });
+
+    this.render(`{{this.arg1}}<Stash @stashedFn={{fn (mut this.arg1) this.arg2}}/>`, {
+      arg1: 'foo',
+      arg2: 'bar',
+    });
+
+    this.assertHTML('foo<!---->');
+
+    this.stashedFn?.();
+    this.rerender();
+
+    this.assertHTML('bar<!---->');
+  }
+
+  @test
+  'can be used on the result of `mut` with a falsy value'() {
+    this.registerInternalHelper('mut', (args: VMArguments) => {
+      return createInvokableRef(args.positional.at(0));
+    });
+
+    this.render(`{{this.arg1}}<Stash @stashedFn={{fn (mut this.arg1) this.arg2}}/>`, {
+      arg1: 'foo',
+      arg2: false,
+    });
+
+    this.assertHTML('foo<!---->');
+
+    this.stashedFn?.();
+    this.rerender();
+
+    this.assertHTML('false<!---->');
+  }
+}
+
+jitSuite(FnTest);

--- a/packages/@glimmer/integration-tests/test/helpers/get-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/get-test.ts
@@ -1,0 +1,411 @@
+import { jitSuite, RenderTest, test, GlimmerishComponent, tracked } from '../..';
+
+class GetTest extends RenderTest {
+  static suiteName = 'Helpers test: {{get}}';
+  @test
+  'should be able to get an object value with a static key'() {
+    this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
+      colors: { apple: 'red' },
+    });
+
+    this.assertHTML('[red] [red]');
+    this.assertStableRerender();
+
+    this.rerender({ colors: { apple: 'green' } });
+    this.assertHTML('[green] [green]');
+
+    this.rerender({ colors: { apple: 'red' } });
+    this.assertHTML('[red] [red]');
+  }
+
+  @test
+  'should be able to get an object value with nested static key'() {
+    this.render(`[{{get colors "apple.gala"}}] [{{if true (get colors "apple.gala")}}]`, {
+      colors: {
+        apple: {
+          gala: 'red and yellow',
+        },
+      },
+    });
+
+    this.assertHTML('[red and yellow] [red and yellow]');
+    this.assertStableRerender();
+
+    this.rerender({
+      colors: {
+        apple: {
+          gala: 'yellow and red striped',
+        },
+      },
+    });
+    this.assertHTML('[yellow and red striped] [yellow and red striped]');
+
+    this.rerender({
+      colors: {
+        apple: {
+          gala: 'red and yellow',
+        },
+      },
+    });
+    this.assertHTML('[red and yellow] [red and yellow]');
+  }
+
+  @test
+  'should be able to get an object value with a number'() {
+    this.render(`[{{get items 1}}][{{get items 2}}][{{get items 3}}]`, {
+      items: {
+        1: 'First',
+        2: 'Second',
+        3: 'Third',
+      },
+    });
+
+    this.assertHTML('[First][Second][Third]');
+    this.assertStableRerender();
+
+    this.rerender({ items: { 1: 'Qux', 2: 'Second', 3: 'Third' } });
+    this.assertHTML('[Qux][Second][Third]');
+
+    this.rerender({ items: { 1: 'First', 2: 'Second', 3: 'Third' } });
+    this.assertHTML('[First][Second][Third]');
+  }
+
+  @test
+  'should be able to get an array value with a number'() {
+    this.render(`[{{get numbers 0}}][{{get numbers 1}}][{{get numbers 2}}]`, {
+      numbers: [1, 2, 3],
+    });
+
+    this.assertHTML('[1][2][3]');
+    this.assertStableRerender();
+
+    this.rerender({ numbers: [3, 2, 1] });
+    this.assertHTML('[3][2][1]');
+
+    this.rerender({ numbers: [1, 2, 3] });
+    this.assertHTML('[1][2][3]');
+  }
+
+  @test
+  'should be able to get an object value with a path evaluating to a number'() {
+    this.render(`{{#each indexes as |index|}}[{{get items index}}]{{/each}}`, {
+      indexes: [1, 2, 3],
+      items: {
+        1: 'First',
+        2: 'Second',
+        3: 'Third',
+      },
+    });
+
+    this.assertHTML('[First][Second][Third]');
+    this.assertStableRerender();
+
+    this.rerender({ items: { 1: 'Qux', 2: 'Second', 3: 'Third' } });
+    this.assertHTML('[Qux][Second][Third]');
+
+    this.rerender({ items: { 1: 'First', 2: 'Second', 3: 'Third' } });
+    this.assertHTML('[First][Second][Third]');
+  }
+
+  @test
+  'should be able to get an array value with a path evaluating to a number'() {
+    this.render(`{{#each numbers as |num index|}}[{{get numbers index}}]{{/each}}`, {
+      numbers: [1, 2, 3],
+    });
+
+    this.assertHTML('[1][2][3]');
+    this.assertStableRerender();
+
+    this.rerender({ numbers: [3, 2, 1] });
+    this.assertHTML('[3][2][1]');
+  }
+
+  @test
+  'should be able to get an object value with a bound/dynamic key'() {
+    this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+      colors: { apple: 'red', banana: 'yellow' },
+      key: 'apple',
+    });
+
+    this.assertHTML('[red] [red]');
+    this.assertStableRerender();
+
+    this.rerender({ key: 'banana' });
+    this.assertHTML('[yellow] [yellow]');
+
+    this.rerender({ colors: { apple: 'green', banana: 'purple' } });
+    this.assertHTML('[purple] [purple]');
+
+    this.rerender({ key: 'apple' });
+    this.assertHTML('[green] [green]');
+  }
+
+  @test
+  'should be able to get an object value with nested dynamic key'() {
+    this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+      colors: {
+        apple: {
+          gala: 'red and yellow',
+          mcintosh: 'red',
+        },
+        banana: 'yellow',
+      },
+      key: 'apple.gala',
+    });
+
+    this.assertHTML('[red and yellow] [red and yellow]');
+    this.assertStableRerender();
+
+    this.rerender({ key: 'apple.mcintosh' });
+    this.assertHTML('[red] [red]');
+
+    this.rerender({ key: 'banana' });
+    this.assertHTML('[yellow] [yellow]');
+
+    this.rerender({ key: 'apple.gala' });
+    this.assertHTML('[red and yellow] [red and yellow]');
+  }
+
+  @test
+  'should be able to get an object value with subexpression returning nested key'() {
+    this.render(
+      `[{{get colors (concat 'apple' '.' 'gala')}}] [{{if true (get colors (concat 'apple' '.' 'gala'))}}]`,
+      {
+        colors: {
+          apple: {
+            gala: 'red and yellow',
+            mcintosh: 'red',
+          },
+        },
+        key: 'apple.gala',
+      }
+    );
+
+    this.assertHTML('[red and yellow] [red and yellow]');
+    this.assertStableRerender();
+
+    this.rerender({
+      colors: {
+        apple: {
+          gala: 'yellow and red striped',
+        },
+      },
+    });
+    this.assertHTML('[yellow and red striped] [yellow and red striped]');
+
+    this.rerender({
+      colors: {
+        apple: {
+          gala: 'yellow-redish',
+        },
+      },
+    });
+    this.assertHTML('[yellow-redish] [yellow-redish]');
+  }
+
+  @test
+  'should be able to get an object value with a get helper as the key'() {
+    this.render(
+      `[{{get colors (get possibleKeys key)}}] [{{if true (get colors (get possibleKeys key))}}]`,
+      {
+        colors: { apple: 'red', banana: 'yellow' },
+        key: 'key1',
+        possibleKeys: { key1: 'apple', key2: 'banana' },
+      }
+    );
+
+    this.assertHTML('[red] [red]');
+    this.assertStableRerender();
+
+    this.rerender({ key: 'key2' });
+    this.assertHTML('[yellow] [yellow]');
+
+    this.rerender({ colors: { apple: 'green', banana: 'purple' } });
+    this.assertHTML('[purple] [purple]');
+
+    this.rerender({ key: 'key1' });
+    this.assertHTML('[green] [green]');
+
+    this.rerender({ colors: { apple: 'red', banana: 'yellow' } });
+    this.assertHTML('[red] [red]');
+  }
+
+  @test
+  'should be able to get an object value with a get helper value as a bound/dynamic key'() {
+    this.render(
+      `[{{get (get possibleValues objectKey) key}}] [{{if true (get (get possibleValues objectKey) key)}}]`,
+      {
+        possibleValues: {
+          colors1: { apple: 'red', banana: 'yellow' },
+          colors2: { apple: 'green', banana: 'purple' },
+        },
+        objectKey: 'colors1',
+        key: 'apple',
+      }
+    );
+
+    this.assertHTML('[red] [red]');
+    this.assertStableRerender();
+
+    this.rerender({ objectKey: 'colors2' });
+    this.assertHTML('[green] [green]');
+
+    this.rerender({ objectKey: 'colors1' });
+    this.assertHTML('[red] [red]');
+
+    this.rerender({ key: 'banana' });
+    this.assertHTML('[yellow] [yellow]');
+
+    this.rerender({ objectKey: 'colors2' });
+    this.assertHTML('[purple] [purple]');
+
+    this.rerender({ objectKey: 'colors1' });
+    this.assertHTML('[yellow] [yellow]');
+  }
+
+  @test
+  'should be able to get an object value with a get helper as the value and a get helper as the key'() {
+    this.render(
+      `[{{get (get possibleValues objectKey) (get possibleKeys key)}}] [{{if true (get (get possibleValues objectKey) (get possibleKeys key))}}]`,
+      {
+        possibleValues: {
+          colors1: { apple: 'red', banana: 'yellow' },
+          colors2: { apple: 'green', banana: 'purple' },
+        },
+        objectKey: 'colors1',
+        possibleKeys: {
+          key1: 'apple',
+          key2: 'banana',
+        },
+        key: 'key1',
+      }
+    );
+
+    this.assertHTML('[red] [red]');
+    this.assertStableRerender();
+
+    this.rerender({ objectKey: 'colors2' });
+    this.assertHTML('[green] [green]');
+
+    this.rerender({ objectKey: 'colors1' });
+    this.assertHTML('[red] [red]');
+
+    this.rerender({ key: 'key2' });
+    this.assertHTML('[yellow] [yellow]');
+
+    this.rerender({ objectKey: 'colors2' });
+    this.assertHTML('[purple] [purple]');
+
+    this.rerender({ objectKey: 'colors1', key: 'key1' });
+    this.assertHTML('[red] [red]');
+  }
+
+  @test
+  'the result of a get helper can be yielded'() {
+    let fooBarInstance: FooBar;
+
+    class FooBar extends GlimmerishComponent {
+      @tracked mcintosh = 'red';
+
+      constructor(owner: object, args: Record<string, unknown>) {
+        super(owner, args);
+        fooBarInstance = this;
+      }
+    }
+
+    this.registerComponent('Glimmer', 'FooBar', '{{yield (get @colors this.mcintosh)}}', FooBar);
+
+    this.render(`<FooBar @colors={{this.colors}} as |value|>{{value}}</FooBar>`, {
+      colors: {
+        red: 'banana',
+      },
+    });
+
+    this.assertHTML('banana');
+    this.assertStableRerender();
+
+    fooBarInstance!.mcintosh = 'yellow';
+    this.rerender({ colors: { yellow: 'bus' } });
+    this.assertHTML('bus');
+
+    fooBarInstance!.mcintosh = 'red';
+    this.rerender({ colors: { red: 'banana' } });
+    this.assertHTML('banana');
+  }
+
+  @test
+  'should handle object values as nulls'() {
+    this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
+      colors: null,
+    });
+
+    this.assertHTML('[] []');
+
+    this.assertStableRerender();
+
+    this.assertHTML('[] []');
+
+    this.rerender({ colors: { apple: 'green', banana: 'purple' } });
+    this.assertHTML('[green] [green]');
+
+    this.rerender({ colors: null });
+    this.assertHTML('[] []');
+  }
+
+  @test
+  'should handle object keys as nulls'() {
+    this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+      colors: {
+        apple: 'red',
+        banana: 'yellow',
+      },
+      key: null,
+    });
+
+    this.assertHTML('[] []');
+    this.assertStableRerender();
+
+    this.rerender({ key: 'banana' });
+    this.assertHTML('[yellow] [yellow]');
+
+    this.rerender({ key: null });
+    this.assertHTML('[] []');
+  }
+
+  @test
+  'should handle object values and keys as nulls'() {
+    this.render(`[{{get colors 'apple'}}] [{{if true (get colors key)}}]`, {
+      colors: null,
+      key: null,
+    });
+
+    this.assertHTML('[] []');
+  }
+
+  @test
+  'should be able to get an object value with a path from this.args in a glimmer component'() {
+    class PersonComponent extends GlimmerishComponent {
+      options = ['first', 'last', 'age'];
+    }
+
+    this.registerComponent(
+      'Glimmer',
+      'PersonWrapper',
+      '{{#each this.options as |option|}}{{get this.args option}}{{/each}}',
+      PersonComponent
+    );
+
+    this.render('<PersonWrapper @first={{first}} @last={{last}} @age={{age}}/>', {
+      first: 'miguel',
+      last: 'andrade',
+    });
+
+    this.assertHTML('miguelandrade');
+    this.assertStableRerender();
+
+    this.rerender({ age: 30 });
+    this.assertHTML('miguelandrade30');
+  }
+}
+
+jitSuite(GetTest);

--- a/packages/@glimmer/integration-tests/test/helpers/hash-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/hash-test.ts
@@ -1,0 +1,161 @@
+import { jitSuite, RenderTest, test, GlimmerishComponent, tracked } from '../..';
+
+class HashTest extends RenderTest {
+  static suiteName = 'Helpers test: {{hash}}';
+
+  @test
+  'returns a hash with the right key-value'() {
+    this.render(`{{#let (hash name="Sergio") as |person|}}{{person.name}}{{/let}}`);
+
+    this.assertHTML('Sergio');
+    this.assertStableRerender();
+  }
+
+  @test
+  'can have more than one key-value'() {
+    this.render(
+      `{{#let (hash name="Sergio" lastName="Arbeo") as |person|}}{{person.name}} {{person.lastName}}{{/let}}`
+    );
+
+    this.assertHTML('Sergio Arbeo');
+    this.assertStableRerender();
+  }
+
+  @test
+  'binds values when variables are used'() {
+    this.render(
+      `{{#let (hash name=this.firstName lastName="Arbeo") as |person|}}{{person.name}} {{person.lastName}}{{/let}}`,
+      {
+        firstName: 'Marisa',
+      }
+    );
+
+    this.assertHTML('Marisa Arbeo');
+    this.assertStableRerender();
+
+    this.rerender({ firstName: 'Sergio' });
+    this.assertHTML('Sergio Arbeo');
+
+    this.rerender({ firstName: 'Marisa' });
+    this.assertHTML('Marisa Arbeo');
+  }
+
+  @test
+  'binds multiple values when variables are used'() {
+    this.render(
+      `{{#let (hash name=this.firstName lastName=this.lastName) as |person|}}{{person.name}} {{person.lastName}}{{/let}}`,
+      {
+        firstName: 'Marisa',
+        lastName: 'Arbeo',
+      }
+    );
+
+    this.assertHTML('Marisa Arbeo');
+    this.assertStableRerender();
+
+    this.rerender({ firstName: 'Sergio' });
+    this.assertHTML('Sergio Arbeo');
+
+    this.rerender({ lastName: 'Smith' });
+    this.assertHTML('Sergio Smith');
+
+    this.rerender({ firstName: 'Marisa', lastName: 'Arbeo' });
+    this.assertHTML('Marisa Arbeo');
+  }
+
+  @test
+  'hash helpers can be nested'() {
+    this.render(
+      `{{#let (hash person=(hash name=this.firstName)) as |ctx|}}{{ctx.person.name}}{{/let}}`,
+      {
+        firstName: 'Balint',
+      }
+    );
+
+    this.assertHTML('Balint');
+    this.assertStableRerender();
+
+    this.rerender({ firstName: 'Chad' });
+    this.assertHTML('Chad');
+
+    this.rerender({ firstName: 'Balint' });
+    this.assertHTML('Balint');
+  }
+
+  @test
+  'should yield hash of internal properties'() {
+    let fooBarInstance: FooBar;
+
+    class FooBar extends GlimmerishComponent {
+      @tracked firstName = 'Chad';
+
+      constructor(owner: object, args: Record<string, unknown>) {
+        super(owner, args);
+        fooBarInstance = this;
+      }
+    }
+
+    this.registerComponent(
+      'Glimmer',
+      'FooBar',
+      `{{yield (hash firstName=this.firstName)}}`,
+      FooBar
+    );
+
+    this.render(`<FooBar as |values|>{{values.firstName}}</FooBar>`);
+
+    this.assertHTML('Chad');
+    this.assertStableRerender();
+
+    fooBarInstance!.firstName = 'Godfrey';
+    this.rerender();
+    this.assertHTML('Godfrey');
+
+    fooBarInstance!.firstName = 'Chad';
+    this.rerender();
+    this.assertHTML('Chad');
+  }
+
+  @test
+  'should yield hash of internal and external properties'() {
+    let fooBarInstance: FooBar;
+
+    class FooBar extends GlimmerishComponent {
+      @tracked firstName = 'Chad';
+
+      constructor(owner: object, args: Record<string, unknown>) {
+        super(owner, args);
+        fooBarInstance = this;
+      }
+    }
+
+    this.registerComponent(
+      'Glimmer',
+      'FooBar',
+      `{{yield (hash firstName=this.firstName lastName=@lastName)}}`,
+      FooBar
+    );
+
+    this.render(
+      `<FooBar @lastName={{this.lastName}} as |values|>{{values.firstName}} {{values.lastName}}</FooBar>`,
+      {
+        lastName: 'Hietala',
+      }
+    );
+
+    this.assertHTML('Chad Hietala');
+    this.assertStableRerender();
+
+    fooBarInstance!.firstName = 'Godfrey';
+    this.rerender({ lastName: 'Chan' });
+
+    this.assertHTML('Godfrey Chan');
+
+    fooBarInstance!.firstName = 'Chad';
+    this.rerender({ lastName: 'Hietala' });
+
+    this.assertHTML('Chad Hietala');
+  }
+}
+
+jitSuite(HashTest);

--- a/packages/@glimmer/integration-tests/test/modifiers/on-test.ts
+++ b/packages/@glimmer/integration-tests/test/modifiers/on-test.ts
@@ -1,0 +1,452 @@
+import { castToBrowser, expect, HAS_NATIVE_PROXY } from '@glimmer/util';
+import { getInternalModifierManager } from '@glimmer/manager';
+import { on } from '@glimmer/runtime';
+
+import { jitSuite, RenderTest, test } from '../..';
+
+// check if window exists and actually is the global
+const hasDom =
+  typeof self === 'object' &&
+  self !== null &&
+  (self as Window['self']).Object === Object &&
+  typeof Window !== 'undefined' &&
+  self.constructor === Window &&
+  typeof document === 'object' &&
+  document !== null &&
+  self.document === document &&
+  typeof location === 'object' &&
+  location !== null &&
+  self.location === location &&
+  typeof history === 'object' &&
+  history !== null &&
+  self.history === history &&
+  typeof navigator === 'object' &&
+  navigator !== null &&
+  self.navigator === navigator &&
+  typeof navigator.userAgent === 'string';
+
+// do this to get around type issues for these values
+let global = window as any;
+const isChrome = hasDom
+  ? typeof global.chrome === 'object' && !(typeof global.opera === 'object')
+  : false;
+const isFirefox = hasDom ? typeof global.InstallTrigger !== 'undefined' : false;
+const isIE11 = !global.ActiveXObject && 'ActiveXObject' in window;
+
+interface Counters {
+  adds: number;
+  removes: number;
+}
+
+interface OnManager {
+  counters: Counters;
+  SUPPORTS_EVENT_OPTIONS: boolean;
+}
+
+function getOnManager() {
+  return (getInternalModifierManager(on) as unknown) as OnManager;
+}
+
+if (hasDom) {
+  class OnTest extends RenderTest {
+    static suiteName = '{{on}} Modifier';
+
+    startingCounters: Counters = { adds: 0, removes: 0 };
+
+    findButton(selector = 'button'): HTMLButtonElement {
+      return expect(
+        castToBrowser(this.element, 'div').querySelector(selector) as HTMLButtonElement,
+        `BUG: expected to find ${selector}`
+      );
+    }
+
+    beforeEach() {
+      // might error if getOnManagerInstance fails
+      this.startingCounters = getOnManager().counters;
+    }
+
+    assertCounts(expected: Counters) {
+      this.assert.deepEqual(
+        getOnManager().counters,
+        {
+          adds: expected.adds + this.startingCounters.adds,
+          removes: expected.removes + this.startingCounters.removes,
+        },
+        `counters have incremented by ${JSON.stringify(expected)}`
+      );
+    }
+
+    @test
+    'SUPPORTS_EVENT_OPTIONS is correct (private API usage)'(assert: Assert) {
+      let { SUPPORTS_EVENT_OPTIONS } = getOnManager();
+
+      if (isChrome || isFirefox) {
+        assert.strictEqual(SUPPORTS_EVENT_OPTIONS, true, 'is true in chrome and firefox');
+      } else if (isIE11) {
+        assert.strictEqual(SUPPORTS_EVENT_OPTIONS, false, 'is false in IE11');
+      }
+    }
+
+    @test
+    'it adds an event listener'(assert: Assert) {
+      let count = 0;
+
+      this.render('<button {{on "click" this.callback}}>Click Me</button>', {
+        callback() {
+          count++;
+        },
+      });
+
+      assert.equal(count, 0, 'not called on initial render');
+
+      this.assertStableRerender();
+      this.assertCounts({ adds: 1, removes: 0 });
+      assert.equal(count, 0, 'not called on a rerender');
+
+      this.findButton().click();
+
+      assert.equal(count, 1, 'has been called 1 time');
+
+      this.findButton().click();
+
+      assert.equal(count, 2, 'has been called 2 times');
+
+      this.assertCounts({ adds: 1, removes: 0 });
+    }
+
+    @test
+    'passes the event to the listener'(assert: Assert) {
+      let event: UIEvent;
+
+      this.render('<button {{on "click" this.callback}}>Click Me</button>', {
+        callback(evt: UIEvent) {
+          event = evt;
+        },
+      });
+
+      let button = this.findButton();
+
+      button.click();
+
+      assert.strictEqual(event!.target, button, 'has a valid event with a target');
+
+      this.assertCounts({ adds: 1, removes: 0 });
+    }
+
+    @test
+    'the listener callback is bound'(assert: Assert) {
+      let first = 0;
+      let second = 0;
+      let firstCallback = () => first++;
+      let secondCallback = () => second++;
+
+      this.render('<button {{on "click" this.callback}}>Click Me</button>', {
+        callback: firstCallback,
+      });
+
+      let button = this.findButton();
+
+      assert.equal(first, 0, 'precond - first not called on initial render');
+      assert.equal(second, 0, 'precond - second not called on initial render');
+
+      button.click();
+
+      assert.equal(first, 1, 'first has been called 1 time');
+      assert.equal(second, 0, 'second not called on initial render');
+
+      this.rerender({ callback: secondCallback });
+
+      button.click();
+
+      assert.equal(first, 1, 'first has been called 1 time');
+      assert.equal(second, 1, 'second has been called 1 times');
+
+      this.assertCounts({ adds: 2, removes: 1 });
+    }
+
+    @test
+    'setting once named argument ensures the callback is only called once'(assert: Assert) {
+      let count = 0;
+
+      this.render('<button {{on "click" this.callback once=true}}>Click Me</button>', {
+        callback() {
+          count++;
+        },
+      });
+
+      let button = this.findButton();
+
+      assert.equal(count, 0, 'not called on initial render');
+
+      this.assertStableRerender();
+      assert.equal(count, 0, 'not called on a rerender');
+
+      button.click();
+
+      assert.equal(count, 1, 'has been called 1 time');
+
+      button.click();
+
+      assert.equal(count, 1, 'has been called 1 times');
+
+      if (isIE11) {
+        this.assertCounts({ adds: 1, removes: 1 });
+      } else {
+        this.assertCounts({ adds: 1, removes: 0 });
+      }
+    }
+
+    @test
+    'changing from `once=false` to `once=true` ensures the callback can only be called once'(
+      assert: Assert
+    ) {
+      let count = 0;
+
+      this.render('<button {{on "click" this.callback once=once}}>Click Me</button>', {
+        callback() {
+          count++;
+        },
+
+        once: false,
+      });
+
+      let button = this.findButton();
+
+      button.click();
+      assert.equal(count, 1, 'has been called 1 time');
+
+      button.click();
+      assert.equal(count, 2, 'has been called 2 times');
+
+      this.rerender({ once: true });
+
+      button.click();
+      assert.equal(count, 3, 'has been called 3 time');
+
+      button.click();
+      assert.equal(count, 3, 'is not called again');
+
+      if (isIE11) {
+        this.assertCounts({ adds: 2, removes: 2 });
+      } else {
+        this.assertCounts({ adds: 2, removes: 1 });
+      }
+    }
+
+    @test
+    'setting passive named argument prevents calling preventDefault'(assert: Assert) {
+      let matcher = /You marked this listener as 'passive', meaning that you must not call 'event.preventDefault\(\)'/;
+
+      this.render('<button {{on "click" this.callback passive=true}}>Click Me</button>', {
+        callback(event: UIEvent) {
+          assert.throws(() => {
+            event.preventDefault();
+          }, matcher);
+        },
+      });
+
+      this.findButton().click();
+    }
+
+    @test
+    'by default bubbling is used (capture: false)'(assert: Assert) {
+      this.render(
+        `
+          <button class="outer" {{on 'click' this.handleOuterClick}}>
+            <button class="inner" {{on 'click' this.handleInnerClick}}></button>
+          </button>
+        `,
+        {
+          handleOuterClick() {
+            assert.step('outer clicked');
+          },
+          handleInnerClick() {
+            assert.step('inner clicked');
+          },
+        }
+      );
+
+      this.findButton('.inner').click();
+
+      assert.verifySteps(['inner clicked', 'outer clicked'], 'uses capture: false by default');
+    }
+
+    @test
+    'specifying capture named argument uses capture semantics'(assert: Assert) {
+      this.render(
+        `
+          <button class="outer" {{on 'click' this.handleOuterClick capture=true}}>
+            <button class="inner" {{on 'click' this.handleInnerClick}}></button>
+          </button>
+        `,
+        {
+          handleOuterClick() {
+            assert.step('outer clicked');
+          },
+          handleInnerClick() {
+            assert.step('inner clicked');
+          },
+        }
+      );
+
+      this.findButton('.inner').click();
+
+      assert.verifySteps(['outer clicked', 'inner clicked'], 'capture works');
+    }
+
+    @test
+    'can use capture and once together'(assert: Assert) {
+      this.render(
+        `
+          <button class="outer" {{on 'click' this.handleOuterClick once=true capture=true}}>
+            <button class="inner" {{on 'click' this.handleInnerClick}}></button>
+          </button>
+        `,
+        {
+          handleOuterClick() {
+            assert.step('outer clicked');
+          },
+          handleInnerClick() {
+            assert.step('inner clicked');
+          },
+        }
+      );
+
+      this.findButton('.inner').click();
+
+      assert.verifySteps(['outer clicked', 'inner clicked'], 'capture works');
+
+      this.findButton('.inner').click();
+
+      assert.verifySteps(['inner clicked'], 'once works');
+    }
+
+    @test
+    'unrelated updates to `this` context does not result in removing + re-adding'(assert: Assert) {
+      let called = false;
+
+      this.render('<button {{on "click" this.callback}}>Click Me</button>', {
+        callback() {
+          called = true;
+        },
+        otherThing: 0,
+      });
+
+      this.assertCounts({ adds: 1, removes: 0 });
+
+      this.findButton().click();
+
+      assert.equal(called, 1, 'callback is being invoked');
+
+      this.rerender({ otherThing: 1 });
+      this.assertCounts({ adds: 1, removes: 0 });
+    }
+
+    @test
+    'asserts when eventName is missing'(assert: Assert) {
+      assert.throws(() => {
+        this.render(`<button {{on undefined this.callback}}>Click Me</button>`, {
+          callback() {},
+        });
+      }, /You must pass a valid DOM event name as the first argument to the `on` modifier/);
+    }
+
+    @test
+    'asserts when eventName is a bound undefined value'(assert: Assert) {
+      assert.throws(() => {
+        this.render(`<button {{on this.someUndefinedThing this.callback}}>Click Me</button>`, {
+          callback() {},
+        });
+      }, /You must pass a valid DOM event name as the first argument to the `on` modifier/);
+    }
+
+    @test
+    'asserts when eventName is a function'(assert: Assert) {
+      assert.throws(() => {
+        this.render(`<button {{on this.callback}}>Click Me</button>`, {
+          callback() {},
+        });
+      }, /You must pass a valid DOM event name as the first argument to the `on` modifier/);
+    }
+
+    @test
+    'asserts when callback is missing'(assert: Assert) {
+      assert.throws(() => {
+        this.render(`<button {{on 'click'}}>Click Me</button>`);
+      }, /You must pass a function as the second argument to the `on` modifier/);
+    }
+
+    @test
+    'asserts when callback is undefined'(assert: Assert) {
+      assert.throws(() => {
+        this.render(`<button {{on 'click' this.foo}}>Click Me</button>`);
+      }, /You must pass a function as the second argument to the `on` modifier, you passed undefined. While rendering:\n\nthis.foo/);
+    }
+
+    @test
+    'asserts when callback is null'(assert: Assert) {
+      assert.throws(() => {
+        this.render(`<button {{on 'click' this.foo}}>Click Me</button>`, { foo: null });
+      }, /You must pass a function as the second argument to the `on` modifier, you passed null. While rendering:\n\nthis.foo/);
+    }
+
+    @test
+    'asserts if the provided callback accesses `this` without being bound prior to passing to on'(
+      assert: Assert
+    ) {
+      this.render(`<button {{on 'click' this.myFunc}}>Click Me</button>`, {
+        myFunc(this: any) {
+          if (HAS_NATIVE_PROXY) {
+            assert.throws(() => {
+              // eslint-disable-next-line no-unused-expressions
+              this.arg1;
+            }, /You accessed `this.arg1` from a function passed to the `on` modifier, but the function itself was not bound to a valid `this` context. Consider updating to use a bound function/);
+          } else {
+            // IE11
+            assert.strictEqual(this, null, 'this is null on browsers without native proxy support');
+          }
+        },
+
+        arg1: 'foo',
+      });
+
+      this.findButton().click();
+    }
+
+    @test
+    'asserts if more than 2 positional parameters are provided'(assert: Assert) {
+      assert.throws(() => {
+        this.render(`<button {{on 'click' this.callback this.someArg}}>Click Me</button>`, {
+          callback() {},
+          someArg: 'foo',
+        });
+      }, /You can only pass two positional arguments \(event name and callback\) to the `on` modifier, but you provided 3. Consider using the `fn` helper to provide additional arguments to the `on` callback./);
+    }
+
+    @test
+    'it removes the modifier when the element is removed'(assert: Assert) {
+      let count = 0;
+
+      this.render(
+        '{{#if this.showButton}}<button {{on "click" this.callback}}>Click Me</button>{{/if}}',
+        {
+          callback() {
+            count++;
+          },
+          showButton: true,
+        }
+      );
+
+      this.assertCounts({ adds: 1, removes: 0 });
+
+      this.findButton().click();
+
+      assert.equal(count, 1, 'has been called 1 time');
+
+      this.rerender({ showButton: false });
+      this.assertCounts({ adds: 1, removes: 1 });
+    }
+  }
+
+  jitSuite(OnTest);
+}

--- a/packages/@glimmer/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer/integration-tests/test/strict-mode-test.ts
@@ -1,3 +1,6 @@
+import { castToBrowser } from '@glimmer/util';
+import { on, fn, hash, array, get, concat } from '@glimmer/runtime';
+
 import {
   RenderTest,
   test,
@@ -1066,6 +1069,74 @@ class DynamicStrictModeTest extends RenderTest {
   }
 }
 
+class BuiltInsStrictModeTest extends RenderTest {
+  static suiteName = 'strict mode: built in modifiers and helpers';
+
+  @test
+  'Can use hash'() {
+    let Foo = defineComponent(
+      { hash },
+      '{{#let (hash value="Hello, world!") as |hash|}}{{hash.value}}{{/let}}'
+    );
+
+    this.renderComponent(Foo);
+    this.assertHTML('Hello, world!');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use array'() {
+    let Foo = defineComponent(
+      { array },
+      '{{#each (array "Hello, world!") as |value|}}{{value}}{{/each}}'
+    );
+
+    this.renderComponent(Foo);
+    this.assertHTML('Hello, world!');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use concat'() {
+    let Foo = defineComponent({ concat }, '{{(concat "Hello" ", " "world!")}}');
+
+    this.renderComponent(Foo);
+    this.assertHTML('Hello, world!');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use get'() {
+    let Foo = defineComponent(
+      { hash, get },
+      '{{#let (hash value="Hello, world!") as |hash|}}{{(get hash "value")}}{{/let}}'
+    );
+
+    this.renderComponent(Foo);
+    this.assertHTML('Hello, world!');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use on and fn'(assert: Assert) {
+    assert.expect(3);
+
+    let handleClick = (value: number) => {
+      assert.equal(value, 123, 'handler called with correct value');
+    };
+
+    let Foo = defineComponent(
+      { on, fn, handleClick },
+      '<button {{on "click" (fn handleClick 123)}}>Click</button>'
+    );
+
+    this.renderComponent(Foo);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+  }
+}
+
 jitSuite(GeneralStrictModeTest);
 jitSuite(StaticStrictModeTest);
 jitSuite(DynamicStrictModeTest);
+jitSuite(BuiltInsStrictModeTest);

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -62,6 +62,14 @@ export {
 } from './lib/vm/rehydrate-builder';
 export { invokeHelper } from './lib/helpers/invoke';
 
+export { default as fn } from './lib/helpers/fn';
+export { default as hash } from './lib/helpers/hash';
+export { default as array } from './lib/helpers/array';
+export { default as get } from './lib/helpers/get';
+export { default as concat } from './lib/helpers/concat';
+
+export { default as on } from './lib/modifiers/on';
+
 // Currently we need to re-export these values for @glimmer/component
 // https://github.com/glimmerjs/glimmer.js/issues/319
 export { destroy, registerDestructor, isDestroying, isDestroyed } from '@glimmer/destroyable';

--- a/packages/@glimmer/runtime/lib/helpers/array.ts
+++ b/packages/@glimmer/runtime/lib/helpers/array.ts
@@ -1,0 +1,46 @@
+import { VMArguments } from '@glimmer/interfaces';
+import { createComputeRef, Reference } from '@glimmer/reference';
+import { reifyPositional } from '@glimmer/runtime';
+import { internalHelper } from './internal-helper';
+
+/**
+   Use the `{{array}}` helper to create an array to pass as an option to your
+   components.
+
+   ```handlebars
+   <MyComponent @people={{array
+     'Tom Dale'
+     'Yehuda Katz'
+     this.myOtherPerson}}
+   />
+   ```
+    or
+   ```handlebars
+   {{my-component people=(array
+     'Tom Dale'
+     'Yehuda Katz'
+     this.myOtherPerson)
+   }}
+   ```
+
+   Would result in an object such as:
+
+   ```js
+   ['Tom Dale', 'Yehuda Katz', this.get('myOtherPerson')]
+   ```
+
+   Where the 3rd item in the array is bound to updates of the `myOtherPerson` property.
+
+   @method array
+   @param {Array} options
+   @return {Array} Array
+   @public
+ */
+
+export default internalHelper(
+  (args: VMArguments): Reference<unknown[]> => {
+    let captured = args.positional.capture();
+
+    return createComputeRef(() => reifyPositional(captured), null, 'array');
+  }
+);

--- a/packages/@glimmer/runtime/lib/helpers/concat.ts
+++ b/packages/@glimmer/runtime/lib/helpers/concat.ts
@@ -1,0 +1,45 @@
+import { VMArguments } from '@glimmer/interfaces';
+import { createComputeRef } from '@glimmer/reference';
+import { reifyPositional } from '@glimmer/runtime';
+import { internalHelper } from './internal-helper';
+
+const isEmpty = (value: unknown): boolean => {
+  return value === null || value === undefined || typeof (value as object).toString !== 'function';
+};
+
+const normalizeTextValue = (value: unknown): string => {
+  if (isEmpty(value)) {
+    return '';
+  }
+  return String(value);
+};
+
+/**
+  Concatenates the given arguments into a string.
+
+  Example:
+
+  ```handlebars
+  {{some-component name=(concat firstName " " lastName)}}
+
+  {{! would pass name="<first name value> <last name value>" to the component}}
+  ```
+
+  or for angle bracket invocation, you actually don't need concat at all.
+
+  ```handlebars
+  <SomeComponent @name="{{firstName}} {{lastName}}" />
+  ```
+
+  @public
+  @method concat
+*/
+export default internalHelper((args: VMArguments) => {
+  let captured = args.positional.capture();
+
+  return createComputeRef(
+    () => reifyPositional(captured).map(normalizeTextValue).join(''),
+    null,
+    'concat'
+  );
+});

--- a/packages/@glimmer/runtime/lib/helpers/fn.ts
+++ b/packages/@glimmer/runtime/lib/helpers/fn.ts
@@ -1,0 +1,119 @@
+import { DEBUG } from '@glimmer/env';
+import { VMArguments } from '@glimmer/interfaces';
+import {
+  createComputeRef,
+  isInvokableRef,
+  Reference,
+  updateRef,
+  valueForRef,
+} from '@glimmer/reference';
+import { reifyPositional } from '@glimmer/runtime';
+import { buildUntouchableThis } from '@glimmer/util';
+import { internalHelper } from './internal-helper';
+
+const context = buildUntouchableThis('`fn` helper');
+
+/**
+  The `fn` helper allows you to ensure a function that you are passing off
+  to another component, helper, or modifier has access to arguments that are
+  available in the template.
+
+  For example, if you have an `each` helper looping over a number of items, you
+  may need to pass a function that expects to receive the item as an argument
+  to a component invoked within the loop. Here's how you could use the `fn`
+  helper to pass both the function and its arguments together:
+
+    ```app/templates/components/items-listing.hbs
+  {{#each @items as |item|}}
+    <DisplayItem @item=item @select={{fn this.handleSelected item}} />
+  {{/each}}
+  ```
+
+  ```app/components/items-list.js
+  import Component from '@glimmer/component';
+  import { action } from '@ember/object';
+
+  export default class ItemsList extends Component {
+    handleSelected = (item) => {
+      // ...snip...
+    }
+  }
+  ```
+
+  In this case the `display-item` component will receive a normal function
+  that it can invoke. When it invokes the function, the `handleSelected`
+  function will receive the `item` and any arguments passed, thanks to the
+  `fn` helper.
+
+  Let's take look at what that means in a couple circumstances:
+
+  - When invoked as `this.args.select()` the `handleSelected` function will
+    receive the `item` from the loop as its first and only argument.
+  - When invoked as `this.args.select('foo')` the `handleSelected` function
+    will receive the `item` from the loop as its first argument and the
+    string `'foo'` as its second argument.
+
+  In the example above, we used an arrow function to ensure that
+  `handleSelected` is properly bound to the `items-list`, but let's explore what
+  happens if we left out the arrow function:
+
+  ```app/components/items-list.js
+  import Component from '@glimmer/component';
+
+  export default class ItemsList extends Component {
+    handleSelected(item) {
+      // ...snip...
+    }
+  }
+  ```
+
+  In this example, when `handleSelected` is invoked inside the `display-item`
+  component, it will **not** have access to the component instance. In other
+  words, it will have no `this` context, so please make sure your functions
+  are bound (via an arrow function or other means) before passing into `fn`!
+
+  See also [partial application](https://en.wikipedia.org/wiki/Partial_application).
+
+  @method fn
+  @public
+*/
+export default internalHelper((args: VMArguments) => {
+  let positional = args.positional.capture();
+  let callbackRef = positional[0];
+
+  if (DEBUG) assertCallbackIsFn(callbackRef);
+
+  return createComputeRef(
+    () => {
+      return (...invocationArgs: unknown[]) => {
+        let [fn, ...args] = reifyPositional(positional);
+
+        if (DEBUG) assertCallbackIsFn(callbackRef);
+
+        if (isInvokableRef(callbackRef)) {
+          let value = args.length > 0 ? args[0] : invocationArgs[0];
+          return updateRef(callbackRef, value);
+        } else {
+          return (fn as Function).call(context, ...args, ...invocationArgs);
+        }
+      };
+    },
+    null,
+    'fn'
+  );
+});
+
+function assertCallbackIsFn(callbackRef: Reference) {
+  if (
+    !(
+      callbackRef &&
+      (isInvokableRef(callbackRef) || typeof valueForRef(callbackRef) === 'function')
+    )
+  ) {
+    throw new Error(
+      `You must pass a function as the \`fn\` helpers first argument, you passed ${
+        callbackRef ? valueForRef(callbackRef) : callbackRef
+      }. While rendering:\n\n${callbackRef?.debugLabel}`
+    );
+  }
+}

--- a/packages/@glimmer/runtime/lib/helpers/get.ts
+++ b/packages/@glimmer/runtime/lib/helpers/get.ts
@@ -1,0 +1,108 @@
+import { getPath, setPath } from '@glimmer/global-context';
+import { VMArguments } from '@glimmer/interfaces';
+import { createComputeRef, valueForRef } from '@glimmer/reference';
+import { internalHelper } from './internal-helper';
+
+/**
+  Dynamically look up a property on an object. The second argument to `{{get}}`
+  should have a string value, although it can be bound.
+
+  For example, these two usages are equivalent:
+
+  ```app/components/developer-detail.js
+  import Component from '@glimmer/component';
+  import { tracked } from '@glimmer/tracking';
+
+  export default class extends Component {
+    @tracked developer = {
+      name: "Sandi Metz",
+      language: "Ruby"
+    }
+  }
+  ```
+
+  ```handlebars
+  {{this.developer.name}}
+  {{get this.developer "name"}}
+  ```
+
+  If there were several facts about a person, the `{{get}}` helper can dynamically
+  pick one:
+
+  ```app/templates/application.hbs
+  <DeveloperDetail @factName="language" />
+  ```
+
+  ```handlebars
+  {{get this.developer @factName}}
+  ```
+
+  For a more complex example, this template would allow the user to switch
+  between showing the user's height and weight with a click:
+
+  ```app/components/developer-detail.js
+  import Component from '@glimmer/component';
+  import { tracked } from '@glimmer/tracking';
+
+  export default class extends Component {
+    @tracked developer = {
+      name: "Sandi Metz",
+      language: "Ruby"
+    }
+
+    @tracked currentFact = 'name'
+
+    showFact = (fact) => {
+      this.currentFact = fact;
+    }
+  }
+  ```
+
+  ```app/components/developer-detail.js
+  {{get this.developer this.currentFact}}
+
+  <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
+  <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
+  ```
+
+  The `{{get}}` helper can also respect mutable values itself. For example:
+
+  ```app/components/developer-detail.js
+  <Input @value={{mut (get this.person this.currentFact)}} />
+
+  <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
+  <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
+  ```
+
+  Would allow the user to swap what fact is being displayed, and also edit
+  that fact via a two-way mutable binding.
+
+  @public
+  @method get
+ */
+export default internalHelper((args: VMArguments) => {
+  let sourceRef = args.positional.at(0);
+  let pathRef = args.positional.at(1);
+
+  return createComputeRef(
+    () => {
+      let source = valueForRef(sourceRef);
+
+      if (isObject(source)) {
+        return getPath(source, String(valueForRef(pathRef)));
+      }
+    },
+    (value) => {
+      let source = valueForRef(sourceRef);
+
+      if (isObject(source)) {
+        return setPath(source, String(valueForRef(pathRef)), value);
+      }
+    },
+    'get'
+  );
+});
+
+function isObject(obj: unknown): obj is object {
+  return typeof obj === 'function' || (typeof obj === 'object' && obj !== null);
+}

--- a/packages/@glimmer/runtime/lib/helpers/hash.ts
+++ b/packages/@glimmer/runtime/lib/helpers/hash.ts
@@ -1,0 +1,48 @@
+import { Dict, VMArguments } from '@glimmer/interfaces';
+import { createComputeRef, Reference } from '@glimmer/reference';
+import { reifyNamed } from '@glimmer/runtime';
+import { internalHelper } from './internal-helper';
+
+/**
+   Use the `{{hash}}` helper to create a hash to pass as an option to your
+   components. This is specially useful for contextual components where you can
+   just yield a hash:
+
+   ```handlebars
+   {{yield (hash
+      name='Sarah'
+      title=office
+   )}}
+   ```
+
+   Would result in an object such as:
+
+   ```js
+   { name: 'Sarah', title: this.get('office') }
+   ```
+
+   Where the `title` is bound to updates of the `office` property.
+
+   Note that the hash is an empty object with no prototype chain, therefore
+   common methods like `toString` are not available in the resulting hash.
+   If you need to use such a method, you can use the `call` or `apply`
+   approach:
+
+   ```js
+   function toString(obj) {
+     return Object.prototype.toString.apply(obj);
+   }
+   ```
+
+   @method hash
+   @param {Object} options
+   @return {Object} Hash
+   @public
+ */
+export default internalHelper(
+  (args: VMArguments): Reference<Dict<unknown>> => {
+    let positional = args.named.capture();
+
+    return createComputeRef(() => reifyNamed(positional), null, 'hash');
+  }
+);

--- a/packages/@glimmer/runtime/lib/helpers/internal-helper.ts
+++ b/packages/@glimmer/runtime/lib/helpers/internal-helper.ts
@@ -1,0 +1,6 @@
+import { Helper, HelperDefinitionState } from '@glimmer/interfaces';
+import { setInternalHelperManager } from '@glimmer/manager';
+
+export function internalHelper(helper: Helper): HelperDefinitionState {
+  return setInternalHelperManager(helper, {});
+}

--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -1,0 +1,391 @@
+import { registerDestructor } from '@glimmer/destroyable';
+import { DEBUG } from '@glimmer/env';
+import {
+  CapturedArguments,
+  InternalModifierManager,
+  Owner,
+  VMArguments,
+} from '@glimmer/interfaces';
+import { setInternalModifierManager } from '@glimmer/manager';
+import { valueForRef } from '@glimmer/reference';
+import { reifyNamed } from '@glimmer/runtime';
+import { createUpdatableTag, UpdatableTag } from '@glimmer/validator';
+import { SimpleElement } from '@simple-dom/interface';
+import { buildUntouchableThis } from '@glimmer/util';
+
+const untouchableContext = buildUntouchableThis('`on` modifier');
+
+/*
+  Internet Explorer 11 does not support `once` and also does not support
+  passing `eventOptions`. In some situations it then throws a weird script
+  error, like:
+
+  ```
+  Could not complete the operation due to error 80020101
+  ```
+
+  This flag determines, whether `{ once: true }` and thus also event options in
+  general are supported.
+*/
+const SUPPORTS_EVENT_OPTIONS = (() => {
+  try {
+    const div = document.createElement('div');
+    let counter = 0;
+    div.addEventListener('click', () => counter++, { once: true });
+
+    let event;
+    if (typeof Event === 'function') {
+      event = new Event('click');
+    } else {
+      event = document.createEvent('Event');
+      event.initEvent('click', true, true);
+    }
+
+    div.dispatchEvent(event);
+    div.dispatchEvent(event);
+
+    return counter === 1;
+  } catch (error) {
+    return false;
+  }
+})();
+
+export class OnModifierState {
+  public tag = createUpdatableTag();
+  public element: Element;
+  public args: CapturedArguments;
+  public eventName!: string;
+  public callback!: EventListener;
+  private userProvidedCallback!: EventListener;
+  public once?: boolean;
+  public passive?: boolean;
+  public capture?: boolean;
+  public options?: AddEventListenerOptions;
+  public shouldUpdate = true;
+
+  constructor(element: Element, args: CapturedArguments) {
+    this.element = element;
+    this.args = args;
+  }
+
+  updateFromArgs(): void {
+    let { args } = this;
+
+    let { once, passive, capture }: AddEventListenerOptions = reifyNamed(args.named);
+    if (once !== this.once) {
+      this.once = once;
+      this.shouldUpdate = true;
+    }
+
+    if (passive !== this.passive) {
+      this.passive = passive;
+      this.shouldUpdate = true;
+    }
+
+    if (capture !== this.capture) {
+      this.capture = capture;
+      this.shouldUpdate = true;
+    }
+
+    let options: AddEventListenerOptions;
+    if (once || passive || capture) {
+      options = this.options = { once, passive, capture };
+    } else {
+      this.options = undefined;
+    }
+
+    if (
+      DEBUG &&
+      (args.positional[0] === undefined || typeof valueForRef(args.positional[0]) !== 'string')
+    ) {
+      throw new Error(
+        'You must pass a valid DOM event name as the first argument to the `on` modifier'
+      );
+    }
+
+    let eventName = valueForRef(args.positional[0]) as string;
+    if (eventName !== this.eventName) {
+      this.eventName = eventName;
+      this.shouldUpdate = true;
+    }
+
+    let userProvidedCallbackReference = args.positional[1];
+
+    if (DEBUG) {
+      if (args.positional[1] === undefined) {
+        throw new Error(`You must pass a function as the second argument to the \`on\` modifier.`);
+      }
+
+      let value = valueForRef(userProvidedCallbackReference);
+
+      if (typeof value !== 'function') {
+        throw new Error(
+          `You must pass a function as the second argument to the \`on\` modifier, you passed ${
+            value === null ? 'null' : typeof value
+          }. While rendering:\n\n${userProvidedCallbackReference.debugLabel}`
+        );
+      }
+    }
+
+    let userProvidedCallback = valueForRef(userProvidedCallbackReference) as EventListener;
+    if (userProvidedCallback !== this.userProvidedCallback) {
+      this.userProvidedCallback = userProvidedCallback;
+      this.shouldUpdate = true;
+    }
+
+    if (DEBUG && args.positional.length !== 2) {
+      throw new Error(
+        `You can only pass two positional arguments (event name and callback) to the \`on\` modifier, but you provided ${args.positional.length}. Consider using the \`fn\` helper to provide additional arguments to the \`on\` callback.`
+      );
+    }
+
+    let needsCustomCallback =
+      (SUPPORTS_EVENT_OPTIONS === false && once) /* needs manual once implementation */ ||
+      (DEBUG && passive); /* needs passive enforcement */
+
+    if (this.shouldUpdate) {
+      if (needsCustomCallback) {
+        let callback = (this.callback = function (this: Element, event) {
+          if (DEBUG && passive) {
+            event.preventDefault = () => {
+              throw new Error(
+                `You marked this listener as 'passive', meaning that you must not call 'event.preventDefault()': \n\n${userProvidedCallback}`
+              );
+            };
+          }
+
+          if (!SUPPORTS_EVENT_OPTIONS && once) {
+            removeEventListener(this, eventName, callback, options);
+          }
+          return userProvidedCallback.call(untouchableContext, event);
+        });
+      } else if (DEBUG) {
+        // prevent the callback from being bound to the element
+        this.callback = userProvidedCallback.bind(untouchableContext);
+      } else {
+        this.callback = userProvidedCallback;
+      }
+    }
+  }
+}
+
+let adds = 0;
+let removes = 0;
+
+function removeEventListener(
+  element: Element,
+  eventName: string,
+  callback: EventListener,
+  options?: AddEventListenerOptions
+): void {
+  removes++;
+
+  if (SUPPORTS_EVENT_OPTIONS) {
+    // when options are supported, use them across the board
+    element.removeEventListener(eventName, callback, options);
+  } else if (options !== undefined && options.capture) {
+    // used only in the following case:
+    //
+    // `{ once: true | false, passive: true | false, capture: true }
+    //
+    // `once` is handled via a custom callback that removes after first
+    // invocation so we only care about capture here as a boolean
+    element.removeEventListener(eventName, callback, true);
+  } else {
+    // used only in the following cases:
+    //
+    // * where there is no options
+    // * `{ once: true | false, passive: true | false, capture: false }
+    element.removeEventListener(eventName, callback);
+  }
+}
+
+function addEventListener(
+  element: Element,
+  eventName: string,
+  callback: EventListener,
+  options?: AddEventListenerOptions
+): void {
+  adds++;
+
+  if (SUPPORTS_EVENT_OPTIONS) {
+    // when options are supported, use them across the board
+    element.addEventListener(eventName, callback, options);
+  } else if (options !== undefined && options.capture) {
+    // used only in the following case:
+    //
+    // `{ once: true | false, passive: true | false, capture: true }
+    //
+    // `once` is handled via a custom callback that removes after first
+    // invocation so we only care about capture here as a boolean
+    element.addEventListener(eventName, callback, true);
+  } else {
+    // used only in the following cases:
+    //
+    // * where there is no options
+    // * `{ once: true | false, passive: true | false, capture: false }
+    element.addEventListener(eventName, callback);
+  }
+}
+
+/**
+  The `{{on}}` modifier lets you easily add event listeners (it uses
+  [EventTarget.addEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+  internally).
+
+  For example, if you'd like to run a function on your component when a `<button>`
+  in the components template is clicked you might do something like:
+
+  ```app/components/like-post.hbs
+  <button {{on 'click' this.saveLike}}>Like this post!</button>
+  ```
+
+  ```app/components/like-post.js
+  import Component from '@glimmer/component';
+  import { action } from '@ember/object';
+
+  export default class LikePostComponent extends Component {
+    saveLike = () => {
+      // someone likes your post!
+      // better send a request off to your server...
+    }
+  }
+  ```
+
+  ### Arguments
+
+  `{{on}}` accepts two positional arguments, and a few named arguments.
+
+  The positional arguments are:
+
+  - `event` -- the name to use when calling `addEventListener`
+  - `callback` -- the function to be passed to `addEventListener`
+
+  The named arguments are:
+
+  - capture -- a `true` value indicates that events of this type will be dispatched
+    to the registered listener before being dispatched to any EventTarget beneath it
+    in the DOM tree.
+  - once -- indicates that the listener should be invoked at most once after being
+    added. If true, the listener would be automatically removed when invoked.
+  - passive -- if `true`, indicates that the function specified by listener will never
+    call preventDefault(). If a passive listener does call preventDefault(), the user
+    agent will do nothing other than generate a console warning. See
+    [Improving scrolling performance with passive listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners)
+    to learn more.
+
+  The callback function passed to `{{on}}` will receive any arguments that are passed
+  to the event handler. Most commonly this would be the `event` itself.
+
+  If you would like to pass additional arguments to the function you should use
+  the `{{fn}}` helper.
+
+  For example, in our example case above if you'd like to pass in the post that
+  was being liked when the button is clicked you could do something like:
+
+  ```app/components/like-post.hbs
+  <button {{on 'click' (fn this.saveLike @post)}}>Like this post!</button>
+  ```
+
+  In this case, the `saveLike` function will receive two arguments: the click event
+  and the value of `@post`.
+
+  ### Function Context
+
+  In the example above, we used an arrow function to ensure that `likePost` is
+  properly bound to the `items-list`, but let's explore what happens if we
+  left out the arrow function:
+
+  ```app/components/like-post.js
+  import Component from '@glimmer/component';
+
+  export default class LikePostComponent extends Component {
+    saveLike() {
+      // ...snip...
+    }
+  }
+  ```
+
+  In this example, when the button is clicked `saveLike` will be invoked,
+  it will **not** have access to the component instance. In other
+  words, it will have no `this` context, so please make sure your functions
+  are bound (via an arrow function or other means) before passing into `on`!
+
+  @method on
+  @public
+*/
+class OnModifierManager implements InternalModifierManager<OnModifierState | null, object> {
+  public SUPPORTS_EVENT_OPTIONS: boolean = SUPPORTS_EVENT_OPTIONS;
+
+  getDebugName(): string {
+    return 'on';
+  }
+
+  get counters(): { adds: number; removes: number } {
+    return { adds, removes };
+  }
+
+  create(
+    _owner: Owner,
+    element: SimpleElement | Element,
+    _state: object,
+    args: VMArguments
+  ): OnModifierState | null {
+    const capturedArgs = args.capture();
+
+    return new OnModifierState(element as Element, capturedArgs);
+  }
+
+  getTag(state: OnModifierState | null): UpdatableTag | null {
+    if (state === null) {
+      return null;
+    }
+
+    return state.tag;
+  }
+
+  install(state: OnModifierState | null): void {
+    if (state === null) {
+      return;
+    }
+
+    state.updateFromArgs();
+
+    let { element, eventName, callback, options } = state;
+
+    addEventListener(element, eventName, callback, options);
+
+    registerDestructor(state, () => removeEventListener(element, eventName, callback, options));
+
+    state.shouldUpdate = false;
+  }
+
+  update(state: OnModifierState | null): void {
+    if (state === null) {
+      return;
+    }
+
+    // stash prior state for el.removeEventListener
+    let { element, eventName, callback, options } = state;
+
+    state.updateFromArgs();
+
+    if (!state.shouldUpdate) {
+      return;
+    }
+
+    // use prior state values for removal
+    removeEventListener(element, eventName, callback, options);
+
+    // read updated values from the state object
+    addEventListener(state.element, state.eventName, state.callback, state.options);
+
+    state.shouldUpdate = false;
+  }
+
+  getDestroyable(state: OnModifierState | null): OnModifierState | null {
+    return state;
+  }
+}
+
+export default setInternalModifierManager(new OnModifierManager(), {});

--- a/packages/@glimmer/util/index.ts
+++ b/packages/@glimmer/util/index.ts
@@ -25,6 +25,7 @@ export { castToSimple, castToBrowser, checkNode } from './lib/simple-cast';
 export * from './lib/present';
 export { default as intern } from './lib/intern';
 
+export { default as buildUntouchableThis } from './lib/untouchable-this';
 export { default as debugToString } from './lib/debug-to-string';
 export { beginTestSteps, endTestSteps, logStep, verifySteps } from './lib/debug-steps';
 

--- a/packages/@glimmer/util/lib/untouchable-this.ts
+++ b/packages/@glimmer/util/lib/untouchable-this.ts
@@ -1,0 +1,38 @@
+import { DEBUG } from '@glimmer/env';
+import { HAS_NATIVE_PROXY } from './platform-utils';
+
+export default function buildUntouchableThis(source: string): null | object {
+  let context: null | object = null;
+  if (DEBUG && HAS_NATIVE_PROXY) {
+    let assertOnProperty = (property: string | number | symbol) => {
+      throw new Error(
+        `You accessed \`this.${String(
+          property
+        )}\` from a function passed to the ${source}, but the function itself was not bound to a valid \`this\` context. Consider updating to use a bound function (for instance, use an arrow function, \`() => {}\`).`
+      );
+    };
+
+    context = new Proxy(
+      {},
+      {
+        get(_target: {}, property: string | symbol) {
+          assertOnProperty(property);
+        },
+
+        set(_target: {}, property: string | symbol) {
+          assertOnProperty(property);
+
+          return false;
+        },
+
+        has(_target: {}, property: string | symbol) {
+          assertOnProperty(property);
+
+          return false;
+        },
+      }
+    );
+  }
+
+  return context;
+}


### PR DESCRIPTION
Upstreams the built-in helpers and modifiers from Ember:

- `on`
- `fn`
- `array`
- `hash`
- `get`
- `concat`

Tests were adapted directly from the existing test suites in Ember, with omissions wherever particular test functionality did not make sense (e.g. integration testing `get` with `<Input/>`).

## Breaking Changes

- `setPath` is now required on the global context