### PR TITLE
Add test for usage of `{{@component.foo}}`

### DIFF
--- a/packages/@glimmer/integration-tests/test/ember-component-test.ts
+++ b/packages/@glimmer/integration-tests/test/ember-component-test.ts
@@ -1600,6 +1600,41 @@ class CurlyGlimmerComponentTest extends CurlyTest {
     assertFired(instance, 'didUpdate', 1);
     assertFired(instance, 'didRender', 2);
   }
+
+  @test
+  'Can use named argument @component (e.g. `{{@component.name}}`) emberjs/ember.js#19313'() {
+    this.registerComponent('Glimmer', 'Outer', '{{@component.name}}');
+
+    this.render('<Outer @component={{hash name="Foo"}} />');
+    this.assertHTML('Foo');
+
+    this.rerender();
+
+    this.assertHTML('Foo');
+    this.assertStableNodes();
+  }
+
+  @test
+  'Can use implicit this fallback for `component.name` emberjs/ember.js#19313'() {
+    this.registerComponent(
+      'Glimmer',
+      'Outer',
+      '{{component.name}}',
+      class extends GlimmerishComponent {
+        get component() {
+          return { name: 'Foo' };
+        }
+      }
+    );
+
+    this.render('<Outer />');
+    this.assertHTML('Foo');
+
+    this.rerender();
+
+    this.assertHTML('Foo');
+    this.assertStableNodes();
+  }
 }
 
 class CurlyTeardownTest extends CurlyTest {

--- a/packages/@glimmer/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer/integration-tests/test/strict-mode-test.ts
@@ -115,6 +115,13 @@ class GeneralStrictModeTest extends RenderTest {
   }
 
   @test
+  '{{component.foo}} throws an error (append position)'() {
+    this.assert.throws(() => {
+      defineComponent({}, '{{component.foo}}', class extends GlimmerishComponent {});
+    }, /The `component` keyword was used incorrectly. It was used as `component.foo`, but it cannot be used with additional path segments./);
+  }
+
+  @test
   '{{component}} throws an error if a string is used indirectly in strict after first render (append position)'() {
     const Bar = defineComponent({}, 'Hello, world!');
 


### PR DESCRIPTION
Initial attempts to reproduce emberjs/ember.js#19313