### PR TITLE
[BUGFIX] Convert component names after symbol allocation

### DIFF
--- a/packages/@glimmer/syntax/lib/v1/parser-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/parser-builders.ts
@@ -249,9 +249,8 @@ class Builders {
     tail: string[];
     loc: SourceSpan;
   }): ASTv1.PathExpression {
-    let { original: originalHead, parts: headParts } = headToString(head);
-    let parts = [...headParts, ...tail];
-    let original = [...originalHead, ...parts].join('.');
+    let { original: originalHead } = headToString(head);
+    let original = [...originalHead, ...tail].join('.');
 
     return new PathExpressionImplV1(original, head, tail, loc);
   }


### PR DESCRIPTION
Currently component names are converted via the `customizeComponentName`
option prior to symbol allocation. This means that a component can end
up conflicting with an existing local variable, even though they
logically represent different things. This PR ensures that customization
happens after symbol allocation, as a final step within the symbol table
itself. This also means that the correct value is passed through the
rest of the AST and transformations, so it cannot conflict with keywords
as well as other language constructs.

Fixes: https://github.com/emberjs/ember.js/issues/19334