### PR TITLE
Before 1253

### DIFF
--- a/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
@@ -15,7 +15,7 @@ module('[glimmer-compiler] Compile options', ({ test }) => {
   });
 });
 
-module('[glimmer-compiler] precompile', ({ test }) => {
+module('[glimmer-compiler] precompile', ({ test, todo }) => {
   test('returned module name correct', (assert) => {
     let wire = JSON.parse(
       precompile('Hi, {{name}}!', {
@@ -48,29 +48,32 @@ module('[glimmer-compiler] precompile', ({ test }) => {
     assert.equal(componentName, 'ooFX', 'customized component name was used');
   });
 
-  test('customizeComponentName does not cause components to conflict with existing symbols', function (assert) {
-    let wire = JSON.parse(
-      precompile('{{#let @model as |rental|}}<Rental @renter={{rental}} />{{/let}}', {
-        customizeComponentName(input: string) {
-          return input.toLowerCase();
-        },
-      })
-    );
+  todo(
+    'customizeComponentName does not cause components to conflict with existing symbols',
+    function (assert) {
+      let wire = JSON.parse(
+        precompile('{{#let @model as |rental|}}<Rental @renter={{rental}} />{{/let}}', {
+          customizeComponentName(input: string) {
+            return input.toLowerCase();
+          },
+        })
+      );
 
-    let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
+      let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
 
-    let [[, , letBlock]] = block[0] as [WireFormat.Statements.Let];
-    let [[, componentNameExpr]] = letBlock[0] as [WireFormat.Statements.Component];
+      let [[, , letBlock]] = block[0] as [WireFormat.Statements.Let];
+      let [[, componentNameExpr]] = letBlock[0] as [WireFormat.Statements.Component];
 
-    glimmerAssert(
-      Array.isArray(componentNameExpr) &&
-        componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
-      `component name is a free variable lookup`
-    );
+      glimmerAssert(
+        Array.isArray(componentNameExpr) &&
+          componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
+        `component name is a free variable lookup`
+      );
 
-    let componentName = block[3][componentNameExpr[1]];
-    assert.equal(componentName, 'rental', 'customized component name was used');
-  });
+      let componentName = block[3][componentNameExpr[1]];
+      assert.equal(componentName, 'rental', 'customized component name was used');
+    }
+  );
 
   test('customizeComponentName is not invoked on curly components', function (assert) {
     let wire = JSON.parse(

--- a/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
@@ -47,4 +47,95 @@ module('[glimmer-compiler] precompile', ({ test }) => {
     let componentName = block[3][componentNameExpr[1]];
     assert.equal(componentName, 'ooFX', 'customized component name was used');
   });
+
+  test('customizeComponentName does not cause components to conflict with existing symbols', function (assert) {
+    let wire = JSON.parse(
+      precompile('{{#let @model as |rental|}}<Rental @renter={{rental}} />{{/let}}', {
+        customizeComponentName(input: string) {
+          return input.toLowerCase();
+        },
+      })
+    );
+
+    let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
+
+    let [[, , letBlock]] = block[0] as [WireFormat.Statements.Let];
+    let [[, componentNameExpr]] = letBlock[0] as [WireFormat.Statements.Component];
+
+    glimmerAssert(
+      Array.isArray(componentNameExpr) &&
+        componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
+      `component name is a free variable lookup`
+    );
+
+    let componentName = block[3][componentNameExpr[1]];
+    assert.equal(componentName, 'rental', 'customized component name was used');
+  });
+
+  test('customizeComponentName is not invoked on curly components', function (assert) {
+    let wire = JSON.parse(
+      precompile('{{#my-component}}hello{{/my-component}}', {
+        customizeComponentName(input: string) {
+          return input.toUpperCase();
+        },
+      })
+    );
+
+    let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
+
+    let [[, componentNameExpr]] = block[0] as [WireFormat.Statements.Block];
+
+    glimmerAssert(
+      Array.isArray(componentNameExpr) &&
+        componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
+      `component name is a free variable lookup`
+    );
+
+    let componentName = block[3][componentNameExpr[1]];
+    assert.equal(componentName, 'my-component', 'original component name was used');
+  });
+
+  test('customizeComponentName is not invoked on angle-bracket-like name invoked with curlies', function (assert) {
+    let wire = JSON.parse(
+      precompile('{{#MyComponent}}hello{{/MyComponent}}', {
+        customizeComponentName(input: string) {
+          return input.toUpperCase();
+        },
+      })
+    );
+
+    let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
+
+    let [[, componentNameExpr]] = block[0] as [WireFormat.Statements.Block];
+
+    glimmerAssert(
+      Array.isArray(componentNameExpr) &&
+        componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
+      `component name is a free variable lookup`
+    );
+
+    let componentName = block[3][componentNameExpr[1]];
+    assert.equal(componentName, 'MyComponent', 'original component name was used');
+  });
+
+  test('lowercased names are not resolved or customized in resolution mode', (assert) => {
+    let wire = JSON.parse(
+      precompile('<rental />', {
+        customizeComponentName(input: string) {
+          return input.split('').reverse().join('');
+        },
+      })
+    );
+
+    let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
+    let [openElementExpr] = block[0] as [WireFormat.Statements.OpenElement];
+
+    glimmerAssert(
+      Array.isArray(openElementExpr) && openElementExpr[0] === SexpOpcodes.OpenElement,
+      `expr is open element`
+    );
+
+    let elementName = openElementExpr[1];
+    assert.equal(elementName, 'rental', 'element name is correct');
+  });
 });

--- a/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
@@ -47,49 +47,4 @@ module('[glimmer-compiler] precompile', ({ test }) => {
     let componentName = block[3][componentNameExpr[1]];
     assert.equal(componentName, 'ooFX', 'customized component name was used');
   });
-
-  test('customizeComponentName does not cause components to conflict with existing symbols', function (assert) {
-    let wire = JSON.parse(
-      precompile('{{#let @model as |rental|}}<Rental @renter={{rental}} />{{/let}}', {
-        customizeComponentName(input: string) {
-          return input.toLowerCase();
-        },
-      })
-    );
-
-    let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
-
-    let [[, , letBlock]] = block[0] as [WireFormat.Statements.Let];
-    let [[, componentNameExpr]] = letBlock[0] as [WireFormat.Statements.Component];
-
-    glimmerAssert(
-      Array.isArray(componentNameExpr) &&
-        componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
-      `component name is a free variable lookup`
-    );
-
-    let componentName = block[3][componentNameExpr[1]];
-    assert.equal(componentName, 'rental', 'customized component name was used');
-  });
-
-  test('lowercased names are not resolved or customized in resolution mode', (assert) => {
-    let wire = JSON.parse(
-      precompile('<rental />', {
-        customizeComponentName(input: string) {
-          return input.split('').reverse().join('');
-        },
-      })
-    );
-
-    let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
-    let [openElementExpr] = block[0] as [WireFormat.Statements.OpenElement];
-
-    glimmerAssert(
-      Array.isArray(openElementExpr) && openElementExpr[0] === SexpOpcodes.OpenElement,
-      `expr is open element`
-    );
-
-    let elementName = openElementExpr[1];
-    assert.equal(elementName, 'rental', 'element name is correct');
-  });
 });

--- a/packages/@glimmer/integration-tests/test/support.ts
+++ b/packages/@glimmer/integration-tests/test/support.ts
@@ -3,6 +3,8 @@ import { assign } from '@glimmer/util';
 interface NestedHooks {
   test(name: string, callback: (assert: Assert) => void): void;
 
+  todo(name: string, callback: (assert: Assert) => void): void;
+
   /**
    * Runs after the last test. If additional tests are defined after the
    * module's queue has emptied, it will not run this hook again.
@@ -46,7 +48,7 @@ export function module(name: string, second?: any, third?: any) {
   }
 
   return QUnit.module(`integration - ${name}`, setup, (supplied) => {
-    nested(assign({}, supplied, { test: QUnit.test }));
+    nested(assign({}, supplied, { test: QUnit.test, todo: QUnit.todo }));
   });
 }
 

--- a/packages/@glimmer/syntax/lib/symbol-table.ts
+++ b/packages/@glimmer/syntax/lib/symbol-table.ts
@@ -1,14 +1,9 @@
-import { Core, Dict, SexpOpcodes } from '@glimmer/interfaces';
+import { Core, Dict } from '@glimmer/interfaces';
 import { dict } from '@glimmer/util';
 
-import { ASTv2 } from '..';
-
 export abstract class SymbolTable {
-  static top(
-    locals: string[],
-    customizeComponentName: (input: string) => string
-  ): ProgramSymbolTable {
-    return new ProgramSymbolTable(locals, customizeComponentName);
+  static top(locals: string[]): ProgramSymbolTable {
+    return new ProgramSymbolTable(locals);
   }
 
   abstract has(name: string): boolean;
@@ -17,7 +12,7 @@ export abstract class SymbolTable {
   abstract getLocalsMap(): Dict<number>;
   abstract getEvalInfo(): Core.EvalInfo;
 
-  abstract allocateFree(name: string, resolution: ASTv2.FreeVarResolution): number;
+  abstract allocateFree(name: string): number;
   abstract allocateNamed(name: string): number;
   abstract allocateBlock(name: string): number;
   abstract allocate(identifier: string): number;
@@ -31,10 +26,7 @@ export abstract class SymbolTable {
 }
 
 export class ProgramSymbolTable extends SymbolTable {
-  constructor(
-    private templateLocals: string[],
-    private customizeComponentName: (input: string) => string
-  ) {
+  constructor(private templateLocals: string[]) {
     super();
   }
 
@@ -85,11 +77,7 @@ export class ProgramSymbolTable extends SymbolTable {
     return Object.keys(locals).map((symbol) => locals[symbol]);
   }
 
-  allocateFree(name: string, resolution: ASTv2.FreeVarResolution): number {
-    if (resolution.resolution() === SexpOpcodes.GetFreeAsComponentHead) {
-      name = this.customizeComponentName(name);
-    }
-
+  allocateFree(name: string): number {
     let index = this.upvars.indexOf(name);
 
     if (index !== -1) {
@@ -164,8 +152,8 @@ export class BlockSymbolTable extends SymbolTable {
     this.parent.setHasEval();
   }
 
-  allocateFree(name: string, resolution: ASTv2.FreeVarResolution): number {
-    return this.parent.allocateFree(name, resolution);
+  allocateFree(name: string): number {
+    return this.parent.allocateFree(name);
   }
 
   allocateNamed(name: string): number {

--- a/packages/@glimmer/syntax/lib/v1/parser-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/parser-builders.ts
@@ -249,8 +249,9 @@ class Builders {
     tail: string[];
     loc: SourceSpan;
   }): ASTv1.PathExpression {
-    let { original: originalHead } = headToString(head);
-    let original = [...originalHead, ...tail].join('.');
+    let { original: originalHead, parts: headParts } = headToString(head);
+    let parts = [...headParts, ...tail];
+    let original = [...originalHead, ...parts].join('.');
 
     return new PathExpressionImplV1(original, head, tail, loc);
   }

--- a/packages/@glimmer/syntax/lib/v2-a/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/normalize.ts
@@ -38,11 +38,7 @@ export function normalize(
     options
   );
 
-  let top = SymbolTable.top(
-    normalizeOptions.strictMode ? normalizeOptions.locals : [],
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    options.customizeComponentName ?? ((name) => name)
-  );
+  let top = SymbolTable.top(normalizeOptions.strictMode ? normalizeOptions.locals : []);
   let block = new BlockContext(source, normalizeOptions, top);
   let normalizer = new StatementNormalizer(block);
 
@@ -287,12 +283,10 @@ class ExpressionNormalizer {
 
           return block.builder.localVar(head.name, symbol, isRoot, offsets);
         } else {
-          let context = block.strict ? ASTv2.STRICT_RESOLUTION : resolution;
-          let symbol = block.table.allocateFree(head.name, context);
-
+          let symbol = block.table.allocateFree(head.name);
           return block.builder.freeVar({
             name: head.name,
-            context,
+            context: block.strict ? ASTv2.STRICT_RESOLUTION : resolution,
             symbol,
             loc: offsets,
           });
@@ -650,6 +644,14 @@ class ElementNormalizer {
     let pathLoc = variableLoc.withEnd(pathEnd);
 
     if (isComponent) {
+      // If the component name is uppercase, the variable is not in scope,
+      // and the template is not in strict mode, run the optional
+      // `customizeComponentName` function provided as an option to the
+      // precompiler.
+      if (!this.ctx.strict && uppercase && !inScope) {
+        variable = this.ctx.customizeComponentName(variable);
+      }
+
       let path = b.path({
         head: b.head(variable, variableLoc),
         tail,


### PR DESCRIPTION
This reverts #1253, but adds back it's tests, plus the tests from #1255 and https://github.com/dfreeman/glimmer-vm/pull/1 to see what will happen. 😃 

`customizeComponentName does not cause components to conflict with existing symbols` fails (as expected since that's what #1253 was addressing) but the others pass. I've marked the failing test as a todo.