### PR TITLE
Remove usages of `this.property` fallback from tests

### DIFF
--- a/packages/@glimmer/integration-tests/lib/render-test.ts
+++ b/packages/@glimmer/integration-tests/lib/render-test.ts
@@ -307,9 +307,9 @@ export class RenderTest implements IRenderTest {
 
     let invocation: string | string[] = [];
     if (template) {
-      invocation.push('{{#component componentName');
+      invocation.push('{{#component this.componentName');
     } else {
-      invocation.push('{{component componentName');
+      invocation.push('{{component this.componentName');
     }
 
     let componentArgs = this.buildArgs(args);

--- a/packages/@glimmer/integration-tests/lib/suites/components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/components.ts
@@ -19,7 +19,7 @@ export class TemplateOnlyComponents extends RenderTest {
         name: 'MyComponent',
         layout: '{{yield}} - {{@color}}',
         template: 'hello!',
-        args: { color: 'color' },
+        args: { color: 'this.color' },
       },
       { color: 'red' }
     );
@@ -45,8 +45,8 @@ export class TemplateOnlyComponents extends RenderTest {
         name: 'MyComponent',
         layout: '<div><span ...attributes>{{yield}} - {{@color}}</span></div>',
         template: 'hello!',
-        args: { color: 'color' },
-        attributes: { color: '{{color}}' },
+        args: { color: 'this.color' },
+        attributes: { color: '{{this.color}}' },
       },
       { color: 'red' }
     );
@@ -223,7 +223,7 @@ export class GlimmerishComponents extends RenderTest {
     this.registerComponent(
       'Glimmer',
       'Foo',
-      '<div ...attributes>[{{localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}]</div>',
+      '<div ...attributes>[{{this.localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}]</div>',
       Foo
     );
 
@@ -232,7 +232,7 @@ export class GlimmerishComponents extends RenderTest {
         layout: stripTight`<@foo @staticNamedArg="static" data-test1={{@outerArg}} data-test2="static" @dynamicNamedArg={{@outerArg}} />`,
         args: {
           foo: 'component "Foo"',
-          outerArg: 'outer',
+          outerArg: 'this.outer',
         },
       },
       { outer: 'outer' }
@@ -345,11 +345,11 @@ export class GlimmerishComponents extends RenderTest {
     this.registerComponent(
       'Glimmer',
       'Foo',
-      '<div ...attributes>[{{localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}] - {{yield}}</div>',
+      '<div ...attributes>[{{this.localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}] - {{yield}}</div>',
       Foo
     );
     this.render(
-      `{{#with (component 'Foo') as |Other|}}<Other @staticNamedArg="static" data-test1={{outer}} data-test2="static" @dynamicNamedArg={{outer}}>template</Other>{{/with}}`,
+      `{{#with (component 'Foo') as |Other|}}<Other @staticNamedArg="static" data-test1={{this.outer}} data-test2="static" @dynamicNamedArg={{this.outer}}>template</Other>{{/with}}`,
       { outer: 'outer' }
     );
 
@@ -519,10 +519,12 @@ export class GlimmerishComponents extends RenderTest {
     this.registerComponent(
       'Glimmer',
       'Foo',
-      '<div ...attributes>[{{localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}] - {{yield}}</div>',
+      '<div ...attributes>[{{this.localProperty}} {{@staticNamedArg}} {{@dynamicNamedArg}}] - {{yield}}</div>',
       Foo
     );
-    this.render('<TestHarness @outer={{outer}} @Foo={{component "Foo"}} />', { outer: 'outer' });
+    this.render('<TestHarness @outer={{this.outer}} @Foo={{component "Foo"}} />', {
+      outer: 'outer',
+    });
 
     this.assertHTML(
       `<div data-test1="outer" data-test2="static">[local static outer] - template</div>`
@@ -625,7 +627,7 @@ export class GlimmerishComponents extends RenderTest {
     this.registerComponent(
       'Glimmer',
       'Main',
-      '<div><HelloWorld @name={{salutation}} /></div>',
+      '<div><HelloWorld @name={{this.salutation}} /></div>',
       MainComponent
     );
     this.registerComponent('Glimmer', 'HelloWorld', '<h1>Hello {{@name}}!</h1>');
@@ -666,7 +668,7 @@ export class GlimmerishComponents extends RenderTest {
     );
     this.registerComponent('Glimmer', 'HelloWorld', '{{yield (component "A" a=@a)}}');
     this.registerComponent('Glimmer', 'A', 'A {{@a}}');
-    this.render('<Main @a={{a}} />', { a: 'a' });
+    this.render('<Main @a={{this.a}} />', { a: 'a' });
     this.assertHTML('<div>A a</div>');
     this.assertStableRerender();
     this.rerender({ a: 'A' });
@@ -682,7 +684,7 @@ export class GlimmerishComponents extends RenderTest {
       'A {{#component "B" arg1=@one arg2=@two arg3=@three}}{{/component}}'
     );
     this.registerComponent('Glimmer', 'B', 'B {{@arg1}} {{@arg2}} {{@arg3}}');
-    this.render('<A @one={{first}} @two={{second}} @three={{third}} />', {
+    this.render('<A @one={{this.first}} @two={{this.second}} @three={{this.third}} />', {
       first: 1,
       second: 2,
       third: 3,
@@ -698,7 +700,7 @@ export class GlimmerishComponents extends RenderTest {
   'Static inline component helper'() {
     this.registerComponent('Glimmer', 'A', 'A {{component "B" arg1=@one arg2=@two arg3=@three}}');
     this.registerComponent('Glimmer', 'B', 'B {{@arg1}} {{@arg2}} {{@arg3}}');
-    this.render('<A @one={{first}} @two={{second}} @three={{third}} />', {
+    this.render('<A @one={{this.first}} @two={{this.second}} @three={{this.third}} />', {
       first: 1,
       second: 2,
       third: 3,
@@ -719,7 +721,7 @@ export class GlimmerishComponents extends RenderTest {
 
     this.render(
       strip`
-    {{#each components key="id" as |c|}}
+    {{#each this.components key="id" as |c|}}
       {{#in-element c.mount}}
         {{component c.name childName=c.child data=c.data}}
       {{/in-element}}
@@ -755,7 +757,7 @@ export class GlimmerishComponents extends RenderTest {
     this.registerComponent(
       'Glimmer',
       'RecursiveInvoker',
-      '{{id}}{{#if showChildren}}<RecursiveInvoker />{{/if}}',
+      '{{this.id}}{{#if this.showChildren}}<RecursiveInvoker />{{/if}}',
       RecursiveInvoker
     );
 
@@ -777,7 +779,7 @@ export class GlimmerishComponents extends RenderTest {
       }
     );
 
-    this.render('{{#if showing}}<Foo/>{{/if}}', {
+    this.render('{{#if this.showing}}<Foo/>{{/if}}', {
       showing: false,
     });
 
@@ -805,9 +807,12 @@ export class GlimmerishComponents extends RenderTest {
       }
     );
 
-    this.render('{{#if showing}}<div class="first"></div><div class="second"></div><Foo/>{{/if}}', {
-      showing: false,
-    });
+    this.render(
+      '{{#if this.showing}}<div class="first"></div><div class="second"></div><Foo/>{{/if}}',
+      {
+        showing: false,
+      }
+    );
 
     this.assert.throws(() => {
       this.rerender({ showing: true });
@@ -838,7 +843,7 @@ export class GlimmerishComponents extends RenderTest {
 
     this.registerComponent('TemplateOnly', 'Bar', '<div class="second"></div><Foo/>');
 
-    this.render('{{#if showing}}<div class="first"></div><Bar/>{{/if}}', {
+    this.render('{{#if this.showing}}<div class="first"></div><Bar/>{{/if}}', {
       showing: false,
     });
 
@@ -885,7 +890,7 @@ export class GlimmerishComponents extends RenderTest {
 
       this.registerComponent('TemplateOnly', 'Bar', '<div class="second"></div><Foo/>');
 
-      this.render('{{#if showing}}<div class="first"></div><Bar/>{{/if}}', {
+      this.render('{{#if this.showing}}<div class="first"></div><Bar/>{{/if}}', {
         showing: false,
       });
 

--- a/packages/@glimmer/integration-tests/lib/suites/custom-dom-helper.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/custom-dom-helper.ts
@@ -48,7 +48,7 @@ export class SerializedDOMHelperTests extends DOMHelperTests {
 
   @test
   'The compiler can handle unescaped HTML'() {
-    this.render('<div>{{{title}}}</div>', { title: '<strong>hello</strong>' });
+    this.render('<div>{{{this.title}}}</div>', { title: '<strong>hello</strong>' });
     let b = blockStack();
     this.assertHTML(strip`
       <div>

--- a/packages/@glimmer/integration-tests/lib/suites/debugger.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/debugger.ts
@@ -25,7 +25,10 @@ export class DebuggerSuite extends RenderTest {
       this.assert.equal(get('foo'), expectedContext.foo);
     });
 
-    this.render('{{#if a.b}}true{{debugger}}{{else}}false{{debugger}}{{/if}}', expectedContext);
+    this.render(
+      '{{#if this.a.b}}true{{debugger}}{{else}}false{{debugger}}{{/if}}',
+      expectedContext
+    );
     this.assert.equal(callbackExecuted, 1);
     this.assertHTML('true');
     this.assertStableRerender();
@@ -71,7 +74,7 @@ export class DebuggerSuite extends RenderTest {
     });
 
     this.render(
-      '{{#with foo as |bar|}}{{#if a.b}}true{{debugger}}{{else}}false{{debugger}}{{/if}}{{/with}}',
+      '{{#with this.foo as |bar|}}{{#if this.a.b}}true{{debugger}}{{else}}false{{debugger}}{{/if}}{{/with}}',
       expectedContext
     );
     this.assert.equal(callbackExecuted, 1);

--- a/packages/@glimmer/integration-tests/lib/suites/each.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/each.ts
@@ -23,7 +23,7 @@ export class EachSuite extends RenderTest {
   @test
   'basic #each'() {
     let list = [1, 2, 3, 4];
-    this.render('{{#each list key="@index" as |item|}}{{item}}{{else}}Empty{{/each}}', {
+    this.render('{{#each this.list key="@index" as |item|}}{{item}}{{else}}Empty{{/each}}', {
       list,
     });
     this.assertHTML('1234');
@@ -71,7 +71,7 @@ export class EachSuite extends RenderTest {
         this.arr.splice(0, this.arr.length);
       },
     };
-    this.render('{{#each list key="@index" as |item|}}{{item}}{{else}}Empty{{/each}}', {
+    this.render('{{#each this.list key="@index" as |item|}}{{item}}{{else}}Empty{{/each}}', {
       list,
     });
     this.assertHTML('1234');
@@ -96,7 +96,7 @@ export class EachSuite extends RenderTest {
   @test
   'keyed #each'() {
     let list = [{ text: 'hello' }];
-    this.render('{{#each list key="text" as |item|}}{{item.text}}{{else}}Empty{{/each}}', {
+    this.render('{{#each this.list key="text" as |item|}}{{item.text}}{{else}}Empty{{/each}}', {
       list,
     });
     this.assertHTML('hello');
@@ -122,7 +122,7 @@ export class EachSuite extends RenderTest {
   @test
   'receives the index as the second parameter'() {
     let list = [1, 2, 3, 4];
-    this.render('{{#each list key="@index" as |item i|}}{{item}}-{{i}}:{{else}}Empty{{/each}}', {
+    this.render('{{#each this.list key="@index" as |item i|}}{{item}}-{{i}}:{{else}}Empty{{/each}}', {
       list,
     });
     this.assertHTML('1-0:2-1:3-2:4-3:');
@@ -155,7 +155,7 @@ export class EachSuite extends RenderTest {
 
     let list = [v1, v2, v3, v4];
     this.render(
-      '{{#each list key="@identity" as |item i|}}{{item.val}}-{{i}}{{else}}Empty{{/each}}',
+      '{{#each this.list key="@identity" as |item i|}}{{item.val}}-{{i}}{{else}}Empty{{/each}}',
       {
         list,
       }
@@ -187,7 +187,7 @@ export class EachSuite extends RenderTest {
   @test
   'it can render duplicate primitive items'() {
     let list = ['a', 'a', 'a'];
-    this.render('{{#each list key="@index" as |item|}}{{item}}{{/each}}', {
+    this.render('{{#each this.list key="@index" as |item|}}{{item}}{{/each}}', {
       list,
     });
     this.assertHTML('aaa');
@@ -208,7 +208,7 @@ export class EachSuite extends RenderTest {
   'it can render duplicate objects'() {
     let dup = { text: 'dup' };
     let list = [dup, dup, { text: 'uniq' }];
-    this.render('{{#each list key="@index" as |item|}}{{item.text}}{{/each}}', {
+    this.render('{{#each this.list key="@index" as |item|}}{{item.text}}{{/each}}', {
       list,
     });
     this.assertHTML('dupdupuniq');
@@ -237,7 +237,7 @@ export class EachSuite extends RenderTest {
 
     let list = [new Item('Hello'), new Item('Hello'), new Item('Hello')];
 
-    this.render(`{{#each list key="text" as |item|}}{{item.text}}{{/each}}`, {
+    this.render(`{{#each this.list key="text" as |item|}}{{item.text}}{{/each}}`, {
       list,
     });
 
@@ -269,7 +269,7 @@ export class EachSuite extends RenderTest {
 
     let list = [new Item('Hello'), new Item('Hello'), new Item('Hello')];
 
-    this.render(`{{#each list key="@identity" as |item|}}{{item.text}}{{/each}}`, {
+    this.render(`{{#each this.list key="@identity" as |item|}}{{item.text}}{{/each}}`, {
       list,
     });
 
@@ -293,7 +293,7 @@ export class EachSuite extends RenderTest {
   'it does not update items if their key has not changed, and the items are not tracked'() {
     let list = [{ text: 'Hello' }, { text: 'Hello' }, { text: 'Hello' }];
 
-    this.render(`{{#each list key="@identity" as |item|}}{{item.text}}{{/each}}`, {
+    this.render(`{{#each this.list key="@identity" as |item|}}{{item.text}}{{/each}}`, {
       list,
     });
 
@@ -311,10 +311,13 @@ export class EachSuite extends RenderTest {
   'scoped variable not available outside list'() {
     let list = ['Wycats'];
 
-    this.render(`{{name}}-{{#each list key="@index" as |name|}}{{name}}{{/each}}-{{name}}`, {
-      list,
-      name: 'Stef',
-    });
+    this.render(
+      `{{this.name}}-{{#each this.list key="@index" as |name|}}{{name}}{{/each}}-{{this.name}}`,
+      {
+        list,
+        name: 'Stef',
+      }
+    );
 
     this.assertHTML('Stef-Wycats-Stef');
     this.assertStableRerender();
@@ -340,7 +343,7 @@ export class EachSuite extends RenderTest {
     let list: string[] = [];
 
     this.render(
-      `{{#each list key="@index" as |name|}}Has thing{{else}}No thing {{otherThing}}{{/each}}`,
+      `{{#each this.list key="@index" as |name|}}Has thing{{else}}No thing {{this.otherThing}}{{/each}}`,
       {
         list,
         otherThing: 'Chad',
@@ -369,7 +372,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let a = arr[1];
     let b = arr[7];
@@ -399,7 +402,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let a = arr[0];
     let b = arr[7];
@@ -429,7 +432,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let a = arr[0];
     let b = arr[6];
@@ -459,7 +462,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let a = arr[1];
     let b = arr[3];
@@ -493,7 +496,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let a = arr[1];
     let b = arr[3];
@@ -525,7 +528,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let a = arr[1];
     let b = arr[6];
@@ -558,7 +561,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     arr.shift();
     arr.splice(2, 0, 9);
@@ -587,7 +590,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let shifted = [8, 1, 2, 3, 4, 5, 6, 7];
 
@@ -614,7 +617,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     let shifted = [2, 3, 4, 5, 6, 7, 8, 1];
 
@@ -641,7 +644,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     for (let i = 0; i < 100; i++) {
       shuffleArray(arr);
@@ -666,7 +669,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     for (let i = 0; i < 100; i++) {
       let newArr = arr.slice();
@@ -693,7 +696,7 @@ export class EachSuite extends RenderTest {
     if (!LOCAL_DEBUG) return;
 
     let arr = [1, 2, 3, 4, 5, 6, 7, 8];
-    this.render(`{{#each arr as |item|}}{{item}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |item|}}{{item}}{{/each}}`, { arr });
 
     for (let i = 0; i < 100; i++) {
       let newArr = arr.slice();
@@ -722,7 +725,7 @@ export class EachSuite extends RenderTest {
       [4, 5, 6, 7, 8],
       [5, 6, 7, 8, 9],
     ];
-    this.render(`{{#each arr as |sub|}}{{#each sub as |item|}}{{item}}{{/each}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |sub|}}{{#each sub as |item|}}{{item}}{{/each}}{{/each}}`, { arr });
 
     for (let i = 0; i < 100; i++) {
       for (let sub of arr) {

--- a/packages/@glimmer/integration-tests/lib/suites/each.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/each.ts
@@ -122,9 +122,12 @@ export class EachSuite extends RenderTest {
   @test
   'receives the index as the second parameter'() {
     let list = [1, 2, 3, 4];
-    this.render('{{#each this.list key="@index" as |item i|}}{{item}}-{{i}}:{{else}}Empty{{/each}}', {
-      list,
-    });
+    this.render(
+      '{{#each this.list key="@index" as |item i|}}{{item}}-{{i}}:{{else}}Empty{{/each}}',
+      {
+        list,
+      }
+    );
     this.assertHTML('1-0:2-1:3-2:4-3:');
     this.assertStableRerender();
 
@@ -725,7 +728,9 @@ export class EachSuite extends RenderTest {
       [4, 5, 6, 7, 8],
       [5, 6, 7, 8, 9],
     ];
-    this.render(`{{#each this.arr as |sub|}}{{#each sub as |item|}}{{item}}{{/each}}{{/each}}`, { arr });
+    this.render(`{{#each this.arr as |sub|}}{{#each sub as |item|}}{{item}}{{/each}}{{/each}}`, {
+      arr,
+    });
 
     for (let i = 0; i < 100; i++) {
       for (let sub of arr) {

--- a/packages/@glimmer/integration-tests/lib/suites/emberish-components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/emberish-components.ts
@@ -33,7 +33,7 @@ export class EmberishComponentTests extends RenderTest {
       }
     );
 
-    this.render('{{#if ok}}<div data-ok=true {{foo bar}}></div>{{/if}}', {
+    this.render('{{#if this.ok}}<div data-ok=true {{foo this.bar}}></div>{{/if}}', {
       bar: 'bar',
       ok: true,
     });
@@ -69,7 +69,7 @@ export class EmberishComponentTests extends RenderTest {
       {
         layout: 'In layout -- {{#if @predicate}}{{yield}}{{/if}}',
         template: 'In template',
-        args: { predicate: 'predicate' },
+        args: { predicate: 'this.predicate' },
       },
       { predicate: true }
     );

--- a/packages/@glimmer/integration-tests/lib/suites/in-element.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/in-element.ts
@@ -30,7 +30,7 @@ export class InElementSuite extends RenderTest {
     }));
 
     let externalElement = this.delegate.createElement('div');
-    this.render('{{#maybe-in-element externalElement}}[{{foo}}]{{/maybe-in-element}}', {
+    this.render('{{#maybe-in-element this.externalElement}}[{{this.foo}}]{{/maybe-in-element}}', {
       externalElement,
       foo: 'Yippie!',
     });
@@ -50,7 +50,7 @@ export class InElementSuite extends RenderTest {
   @test
   'Renders curlies into external element'() {
     let externalElement = this.delegate.createElement('div');
-    this.render('{{#in-element externalElement}}[{{foo}}]{{/in-element}}', {
+    this.render('{{#in-element this.externalElement}}[{{this.foo}}]{{/in-element}}', {
       externalElement,
       foo: 'Yippie!',
     });
@@ -73,7 +73,7 @@ export class InElementSuite extends RenderTest {
     let initialContent = '<p>Hello there!</p>';
     replaceHTML(externalElement, initialContent);
 
-    this.render('{{#in-element externalElement}}[{{foo}}]{{/in-element}}', {
+    this.render('{{#in-element this.externalElement}}[{{this.foo}}]{{/in-element}}', {
       externalElement,
       foo: 'Yippie!',
     });
@@ -97,9 +97,9 @@ export class InElementSuite extends RenderTest {
 
     this.render(
       stripTight`
-        |{{foo}}|
-        {{#in-element first}}[1{{foo}}]{{/in-element}}
-        {{#in-element second}}[2{{foo}}]{{/in-element}}
+        |{{this.foo}}|
+        {{#in-element this.first}}[1{{this.foo}}]{{/in-element}}
+        {{#in-element this.second}}[2{{this.foo}}]{{/in-element}}
       `,
       { first, second: null, foo: 'Yippie!' }
     );
@@ -141,7 +141,7 @@ export class InElementSuite extends RenderTest {
     replaceHTML(externalElement, initialContent);
 
     this.render(
-      stripTight`{{#in-element externalElement insertBefore=null}}[{{foo}}]{{/in-element}}`,
+      stripTight`{{#in-element this.externalElement insertBefore=null}}[{{this.foo}}]{{/in-element}}`,
       {
         externalElement,
         foo: 'Yippie!',
@@ -174,7 +174,7 @@ export class InElementSuite extends RenderTest {
     replaceHTML(externalElement, '<b>Hello</b><em>there!</em>');
 
     this.render(
-      stripTight`{{#in-element externalElement insertBefore=insertBefore}}[{{foo}}]{{/in-element}}`,
+      stripTight`{{#in-element this.externalElement insertBefore=this.insertBefore}}[{{this.foo}}]{{/in-element}}`,
       { externalElement, insertBefore: externalElement.lastChild, foo: 'Yippie!' }
     );
 
@@ -208,7 +208,7 @@ export class InElementSuite extends RenderTest {
     let first = this.delegate.createElement('div');
     let second = this.delegate.createElement('div');
 
-    this.render(stripTight`{{#in-element externalElement}}[{{foo}}]{{/in-element}}`, {
+    this.render(stripTight`{{#in-element this.externalElement}}[{{this.foo}}]{{/in-element}}`, {
       externalElement: first,
       foo: 'Yippie!',
     });
@@ -262,11 +262,11 @@ export class InElementSuite extends RenderTest {
 
     this.render(
       stripTight`
-        {{#if showFirst}}
-          {{#in-element first}}[{{foo}}]{{/in-element}}
+        {{#if this.showFirst}}
+          {{#in-element this.first}}[{{this.foo}}]{{/in-element}}
         {{/if}}
-        {{#if showSecond}}
-          {{#in-element second}}[{{foo}}]{{/in-element}}
+        {{#if this.showSecond}}
+          {{#in-element this.second}}[{{this.foo}}]{{/in-element}}
         {{/if}}
       `,
       {
@@ -349,11 +349,11 @@ export class InElementSuite extends RenderTest {
 
     this.render(
       stripTight`
-        {{#in-element firstElement}}
-          [{{foo}}]
+        {{#in-element this.firstElement}}
+          [{{this.foo}}]
         {{/in-element}}
-        {{#in-element secondElement}}
-          [{{bar}}]
+        {{#in-element this.secondElement}}
+          [{{this.bar}}]
         {{/in-element}}
         `,
       {
@@ -464,10 +464,10 @@ export class InElementSuite extends RenderTest {
 
     this.render(
       stripTight`
-        {{#in-element firstElement}}
-          [{{foo}}]
-          {{#in-element secondElement}}
-            [{{bar}}]
+        {{#in-element this.firstElement}}
+          [{{this.foo}}]
+          {{#in-element this.secondElement}}
+            [{{this.bar}}]
           {{/in-element}}
         {{/in-element}}
         `,
@@ -525,8 +525,8 @@ export class InElementSuite extends RenderTest {
 
     this.render(
       stripTight`
-        {{#if showExternal}}
-          {{#in-element externalElement}}[<DestroyMe />]{{/in-element}}
+        {{#if this.showExternal}}
+          {{#in-element this.externalElement}}[<DestroyMe />]{{/in-element}}
         {{/if}}
       `,
       {

--- a/packages/@glimmer/integration-tests/lib/suites/initial-render.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/initial-render.ts
@@ -131,7 +131,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'Custom Elements with dynamic attributes'() {
     this.render(
-      "<fake-thing><other-fake-thing data-src='extra-{{someDynamicBits}}-here' /></fake-thing>",
+      "<fake-thing><other-fake-thing data-src='extra-{{this.someDynamicBits}}-here' /></fake-thing>",
       { someDynamicBits: 'things' }
     );
     this.assertHTML("<fake-thing><other-fake-thing data-src='extra-things-here' /></fake-thing>");
@@ -140,14 +140,14 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Custom Elements with dynamic content'() {
-    this.render('<x-foo><x-bar>{{derp}}</x-bar></x-foo>', { derp: 'stuff' });
+    this.render('<x-foo><x-bar>{{this.derp}}</x-bar></x-foo>', { derp: 'stuff' });
     this.assertHTML('<x-foo><x-bar>stuff</x-bar></x-foo>');
     this.assertStableRerender();
   }
 
   @test
   'Dynamic content within single custom element'() {
-    this.render('<x-foo>{{#if derp}}Content Here{{/if}}</x-foo>', { derp: 'stuff' });
+    this.render('<x-foo>{{#if this.derp}}Content Here{{/if}}</x-foo>', { derp: 'stuff' });
     this.assertHTML('<x-foo>Content Here</x-foo>');
     this.assertStableRerender();
 
@@ -217,7 +217,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Quoted attribute null values do not disable'() {
-    this.render('<input disabled="{{isDisabled}}">', { isDisabled: null });
+    this.render('<input disabled="{{this.isDisabled}}">', { isDisabled: null });
     this.assertHTML('<input>');
     this.assertStableRerender();
 
@@ -240,7 +240,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Unquoted attribute null values do not disable'() {
-    this.render('<input disabled={{isDisabled}}>', { isDisabled: null });
+    this.render('<input disabled={{this.isDisabled}}>', { isDisabled: null });
     this.assertHTML('<input>');
     this.assertStableRerender();
 
@@ -262,7 +262,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Quoted attribute string values'() {
-    this.render("<img src='{{src}}'>", { src: 'image.png' });
+    this.render("<img src='{{this.src}}'>", { src: 'image.png' });
     this.assertHTML("<img src='image.png'>");
     this.assertStableRerender();
 
@@ -281,7 +281,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Unquoted attribute string values'() {
-    this.render('<img src={{src}}>', { src: 'image.png' });
+    this.render('<img src={{this.src}}>', { src: 'image.png' });
     this.assertHTML("<img src='image.png'>");
     this.assertStableRerender();
 
@@ -300,7 +300,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Unquoted img src attribute is not rendered when set to `null`'() {
-    this.render("<img src='{{src}}'>", { src: null });
+    this.render("<img src='{{this.src}}'>", { src: null });
     this.assertHTML('<img>');
     this.assertStableRerender();
 
@@ -319,7 +319,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Unquoted img src attribute is not rendered when set to `undefined`'() {
-    this.render("<img src='{{src}}'>", { src: undefined });
+    this.render("<img src='{{this.src}}'>", { src: undefined });
     this.assertHTML('<img>');
     this.assertStableRerender();
 
@@ -338,7 +338,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Unquoted a href attribute is not rendered when set to `null`'() {
-    this.render('<a href={{href}}></a>', { href: null });
+    this.render('<a href={{this.href}}></a>', { href: null });
     this.assertHTML('<a></a>');
     this.assertStableRerender();
 
@@ -357,7 +357,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Unquoted a href attribute is not rendered when set to `undefined`'() {
-    this.render('<a href={{href}}></a>', { href: undefined });
+    this.render('<a href={{this.href}}></a>', { href: undefined });
     this.assertHTML('<a></a>');
     this.assertStableRerender();
 
@@ -376,7 +376,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Attribute expression can be followed by another attribute'() {
-    this.render("<div foo='{{funstuff}}' name='Alice'></div>", { funstuff: 'oh my' });
+    this.render("<div foo='{{this.funstuff}}' name='Alice'></div>", { funstuff: 'oh my' });
     this.assertHTML("<div name='Alice' foo='oh my'></div>");
     this.assertStableRerender();
 
@@ -399,7 +399,7 @@ export class InitialRenderSuite extends RenderTest {
       strip`
       <select>
         <option>1</option>
-        <option selected={{selected}}>2</option>
+        <option selected={{this.selected}}>2</option>
         <option>3</option>
       </select>
     `,
@@ -469,11 +469,11 @@ export class InitialRenderSuite extends RenderTest {
       strip`
       <select multiple>
         <option>0</option>
-        <option selected={{somethingTrue}}>1</option>
-        <option selected={{somethingTruthy}}>2</option>
-        <option selected={{somethingUndefined}}>3</option>
-        <option selected={{somethingNull}}>4</option>
-        <option selected={{somethingFalse}}>5</option>
+        <option selected={{this.somethingTrue}}>1</option>
+        <option selected={{this.somethingTruthy}}>2</option>
+        <option selected={{this.somethingUndefined}}>3</option>
+        <option selected={{this.somethingNull}}>4</option>
+        <option selected={{this.somethingFalse}}>5</option>
       </select>`,
       {
         somethingTrue: true,
@@ -531,39 +531,39 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Curlies in HTML comments'() {
-    this.render('<div><!-- {{foo}} --></div>', { foo: 'foo' });
-    this.assertHTML('<div><!-- {{foo}} --></div>');
+    this.render('<div><!-- {{this.foo}} --></div>', { foo: 'foo' });
+    this.assertHTML('<div><!-- {{this.foo}} --></div>');
     this.assertStableRerender();
 
     this.rerender({ foo: 'bar' });
-    this.assertHTML('<div><!-- {{foo}} --></div>');
+    this.assertHTML('<div><!-- {{this.foo}} --></div>');
     this.assertStableNodes();
 
     this.rerender({ foo: '' });
-    this.assertHTML('<div><!-- {{foo}} --></div>');
+    this.assertHTML('<div><!-- {{this.foo}} --></div>');
     this.assertStableNodes();
 
     this.rerender({ foo: 'foo' });
-    this.assertHTML('<div><!-- {{foo}} --></div>');
+    this.assertHTML('<div><!-- {{this.foo}} --></div>');
     this.assertStableNodes();
   }
 
   @test
   'Complex Curlies in HTML comments'() {
-    this.render('<div><!-- {{foo bar baz}} --></div>', { foo: 'foo' });
-    this.assertHTML('<div><!-- {{foo bar baz}} --></div>');
+    this.render('<div><!-- {{this.foo bar baz}} --></div>', { foo: 'foo' });
+    this.assertHTML('<div><!-- {{this.foo bar baz}} --></div>');
     this.assertStableRerender();
 
     this.rerender({ foo: 'bar' });
-    this.assertHTML('<div><!-- {{foo bar baz}} --></div>');
+    this.assertHTML('<div><!-- {{this.foo bar baz}} --></div>');
     this.assertStableNodes();
 
     this.rerender({ foo: '' });
-    this.assertHTML('<div><!-- {{foo bar baz}} --></div>');
+    this.assertHTML('<div><!-- {{this.foo bar baz}} --></div>');
     this.assertStableNodes();
 
     this.rerender({ foo: 'foo' });
-    this.assertHTML('<div><!-- {{foo bar baz}} --></div>');
+    this.assertHTML('<div><!-- {{this.foo bar baz}} --></div>');
     this.assertStableNodes();
   }
 
@@ -576,8 +576,8 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Top level comments'() {
-    this.render('<!-- {{foo}} -->');
-    this.assertHTML('<!-- {{foo}} -->');
+    this.render('<!-- {{this.foo}} -->');
+    this.assertHTML('<!-- {{this.foo}} -->');
     this.assertStableRerender();
   }
 
@@ -598,7 +598,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'svg href attribute with quotation marks'() {
     this.render(
-      `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="{{iconLink}}"></use></svg>`,
+      `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="{{this.iconLink}}"></use></svg>`,
       { iconLink: 'home' }
     );
     this.assertHTML(
@@ -616,7 +616,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'svg href attribute without quotation marks'() {
     this.render(
-      `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href={{iconLink}}></use></svg>`,
+      `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href={{this.iconLink}}></use></svg>`,
       { iconLink: 'home' }
     );
     this.assertHTML(
@@ -760,7 +760,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Text curlies'() {
-    this.render('<div>{{title}}<span>{{title}}</span></div>', { title: 'hello' });
+    this.render('<div>{{this.title}}<span>{{this.title}}</span></div>', { title: 'hello' });
     this.assertHTML('<div>hello<span>hello</span></div>');
     this.assertStableRerender();
 
@@ -779,28 +779,33 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Repaired text nodes are ensured in the right place Part 1'() {
-    this.render('{{a}} {{b}}', { a: 'A', b: 'B', c: 'C', d: 'D' });
+    this.render('{{this.a}} {{this.b}}', { a: 'A', b: 'B', c: 'C', d: 'D' });
     this.assertHTML('A B');
     this.assertStableRerender();
   }
 
   @test
   'Repaired text nodes are ensured in the right place Part 2'() {
-    this.render('<div>{{a}}{{b}}{{c}}wat{{d}}</div>', { a: 'A', b: 'B', c: 'C', d: 'D' });
+    this.render('<div>{{this.a}}{{this.b}}{{this.c}}wat{{this.d}}</div>', {
+      a: 'A',
+      b: 'B',
+      c: 'C',
+      d: 'D',
+    });
     this.assertHTML('<div>ABCwatD</div>');
     this.assertStableRerender();
   }
 
   @test
   'Repaired text nodes are ensured in the right place Part 3'() {
-    this.render('{{a}}{{b}}<img><img><img><img>', { a: 'A', b: 'B', c: 'C', d: 'D' });
+    this.render('{{this.a}}{{this.b}}<img><img><img><img>', { a: 'A', b: 'B', c: 'C', d: 'D' });
     this.assertHTML('AB<img><img><img><img>');
     this.assertStableRerender();
   }
 
   @test
   'Path expressions'() {
-    this.render('<div>{{model.foo.bar}}<span>{{model.foo.bar}}</span></div>', {
+    this.render('<div>{{this.model.foo.bar}}<span>{{this.model.foo.bar}}</span></div>', {
       model: { foo: { bar: 'hello' } },
     });
     this.assertHTML('<div>hello<span>hello</span></div>');
@@ -821,7 +826,9 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Text curlies perform escaping'() {
-    this.render('<div>{{title}}<span>{{title}}</span></div>', { title: '<strong>hello</strong>' });
+    this.render('<div>{{this.title}}<span>{{this.title}}</span></div>', {
+      title: '<strong>hello</strong>',
+    });
     this.assertHTML(
       '<div>&lt;strong&gt;hello&lt;/strong&gt;<span>&lt;strong>hello&lt;/strong&gt;</span></div>'
     );
@@ -844,7 +851,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Rerender respects whitespace'() {
-    this.render('Hello {{ foo }} ', { foo: 'bar' });
+    this.render('Hello {{ this.foo }} ', { foo: 'bar' });
     this.assertHTML('Hello bar ');
     this.assertStableRerender();
 
@@ -868,7 +875,7 @@ export class InitialRenderSuite extends RenderTest {
         return '<span>hello</span> <em>world</em>';
       },
     };
-    this.render('<div>{{title}}</div>', { title });
+    this.render('<div>{{this.title}}</div>', { title });
     this.assertHTML('<div><span>hello</span> <em>world</em></div>');
     this.assertStableRerender();
   }
@@ -876,7 +883,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'Triple curlies'() {
     let title = '<span>hello</span> <em>world</em>';
-    this.render('<div>{{{title}}}</div>', { title });
+    this.render('<div>{{{this.title}}}</div>', { title });
     this.assertHTML('<div><span>hello</span> <em>world</em></div>');
     this.assertStableRerender();
   }
@@ -893,7 +900,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'Top level triple curlies'() {
     let title = '<span>hello</span> <em>world</em>';
-    this.render('{{{title}}}', { title });
+    this.render('{{{this.title}}}', { title });
     this.assertHTML('<span>hello</span> <em>world</em>');
     this.assertStableRerender();
   }
@@ -901,14 +908,14 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'Top level unescaped tr'() {
     let title = '<tr><td>Yo</td></tr>';
-    this.render('<table>{{{title}}}</table>', { title });
+    this.render('<table>{{{this.title}}}</table>', { title });
     this.assertHTML('<table><tbody><tr><td>Yo</td></tr></tbody></table>');
     this.assertStableRerender();
   }
 
   @test
   'The compiler can handle top-level unescaped td inside tr contextualElement'() {
-    this.render('{{{html}}}', { html: '<td>Yo</td>' });
+    this.render('{{{this.html}}}', { html: '<td>Yo</td>' });
     this.assertHTML('<tr><td>Yo</td></tr>');
     this.assertStableRerender();
   }
@@ -916,7 +923,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'Extreme nesting'() {
     this.render(
-      '{{foo}}<span>{{bar}}<a>{{baz}}<em>{{boo}}{{brew}}</em>{{bat}}</a></span><span><span>{{flute}}</span></span>{{argh}}',
+      '{{this.foo}}<span>{{this.bar}}<a>{{this.baz}}<em>{{this.boo}}{{this.brew}}</em>{{this.bat}}</a></span><span><span>{{this.flute}}</span></span>{{this.argh}}',
       {
         foo: 'FOO',
         bar: 'BAR',
@@ -936,7 +943,7 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Simple blocks'() {
-    this.render('<div>{{#if admin}}<p>{{user}}</p>{{/if}}!</div>', {
+    this.render('<div>{{#if this.admin}}<p>{{this.user}}</p>{{/if}}!</div>', {
       admin: true,
       user: 'chancancode',
     });
@@ -958,11 +965,14 @@ export class InitialRenderSuite extends RenderTest {
 
   @test
   'Nested blocks'() {
-    this.render('<div>{{#if admin}}{{#if access}}<p>{{user}}</p>{{/if}}{{/if}}!</div>', {
-      admin: true,
-      access: true,
-      user: 'chancancode',
-    });
+    this.render(
+      '<div>{{#if this.admin}}{{#if this.access}}<p>{{this.user}}</p>{{/if}}{{/if}}!</div>',
+      {
+        admin: true,
+        access: true,
+        user: 'chancancode',
+      }
+    );
     this.assertHTML('<div><p>chancancode</p>!</div>');
     this.assertStableRerender();
 
@@ -988,7 +998,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   Loops() {
     this.render(
-      '<div>{{#each people key="handle" as |p|}}<span>{{p.handle}}</span> - {{p.name}}{{/each}}</div>',
+      '<div>{{#each this.people key="handle" as |p|}}<span>{{p.handle}}</span> - {{p.name}}{{/each}}</div>',
       {
         people: [
           { handle: 'tomdale', name: 'Tom Dale' },
@@ -1018,7 +1028,7 @@ export class InitialRenderSuite extends RenderTest {
   @test
   'Simple helpers'() {
     this.registerHelper('testing', ([id]) => id);
-    this.render('<div>{{testing title}}</div>', { title: 'hello' });
+    this.render('<div>{{testing this.title}}</div>', { title: 'hello' });
     this.assertHTML('<div>hello</div>');
     this.assertStableRerender();
   }
@@ -1223,11 +1233,14 @@ export class InitialRenderSuite extends RenderTest {
       return '' + params[0] + params[1];
     });
 
-    this.render('<div>{{testing (testing "hello" foo) (testing (testing bar "lol") baz)}}</div>', {
-      foo: 'FOO',
-      bar: 'BAR',
-      baz: 'BAZ',
-    });
+    this.render(
+      '<div>{{testing (testing "hello" this.foo) (testing (testing this.bar "lol") this.baz)}}</div>',
+      {
+        foo: 'FOO',
+        bar: 'BAR',
+        baz: 'BAZ',
+      }
+    );
     this.assertHTML('<div>helloFOOBARlolBAZ</div>');
     this.assertStableRerender();
   }
@@ -1249,7 +1262,7 @@ export class InitialRenderSuite extends RenderTest {
       return params[0];
     });
 
-    this.render('<a href="{{testing url}}">linky</a>', { url: 'linky.html' });
+    this.render('<a href="{{testing this.url}}">linky</a>', { url: 'linky.html' });
     this.assertHTML('<a href="linky.html">linky</a>');
     this.assertStableRerender();
   }
@@ -1260,7 +1273,7 @@ export class InitialRenderSuite extends RenderTest {
       return hash['path'];
     });
 
-    this.render('<a href="{{testing path=url}}">linky</a>', { url: 'linky.html' });
+    this.render('<a href="{{testing path=this.url}}">linky</a>', { url: 'linky.html' });
     this.assertHTML('<a href="linky.html">linky</a>');
     this.assertStableRerender();
   }
@@ -1271,7 +1284,7 @@ export class InitialRenderSuite extends RenderTest {
       return params[0];
     });
 
-    this.render('<a href="http://{{foo}}/{{testing bar}}/{{testing "baz"}}">linky</a>', {
+    this.render('<a href="http://{{this.foo}}/{{testing this.bar}}/{{testing "baz"}}">linky</a>', {
       foo: 'foo.com',
       bar: 'bar',
     });

--- a/packages/@glimmer/integration-tests/lib/suites/shadowing.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/shadowing.ts
@@ -33,7 +33,7 @@ export class ShadowingSuite extends RenderTest {
     this.render(
       {
         layout: 'In layout - someProp: {{@someProp}}',
-        args: { someProp: 'someProp' },
+        args: { someProp: 'this.someProp' },
       },
       { someProp: 'something here' }
     );
@@ -60,7 +60,7 @@ export class ShadowingSuite extends RenderTest {
       {
         layoutAttributes: { 'data-name': 'Godfrey', 'data-foo': 'foo' },
         layout: 'Hello!',
-        attributes: { 'data-name': '"{{name}}"', 'data-foo': '"{{foo}}-bar"' },
+        attributes: { 'data-name': '"{{this.name}}"', 'data-foo': '"{{this.foo}}-bar"' },
       },
       { name: 'Godhuda', foo: 'foo' }
     );
@@ -87,7 +87,7 @@ export class ShadowingSuite extends RenderTest {
       {
         layoutAttributes: { 'data-name': '{{@name}}', 'data-foo': '"{{@foo}}-bar"' },
         layout: 'Hello!',
-        args: { name: 'name', foo: 'foo' },
+        args: { name: 'this.name', foo: 'this.foo' },
         attributes: { 'data-name': '"Godhuda"', 'data-foo': '"foo-bar"' },
       },
       { name: 'Godfrey', foo: 'foo' }

--- a/packages/@glimmer/integration-tests/lib/suites/ssr.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/ssr.ts
@@ -44,19 +44,19 @@ export class ServerSideSuite extends AbstractNodeTest {
 
   @test
   'Quoted attribute expression is removed when null'() {
-    this.render('<input disabled="{{isDisabled}}">', { isDisabled: null });
+    this.render('<input disabled="{{this.isDisabled}}">', { isDisabled: null });
     this.assertHTML('<input>');
   }
 
   @test
   'Unquoted attribute expression with null value is not coerced'() {
-    this.render('<input disabled={{isDisabled}}>', { isDisabled: null });
+    this.render('<input disabled={{this.isDisabled}}>', { isDisabled: null });
     this.assertHTML('<input>');
   }
 
   @test
   'Attribute expression can be followed by another attribute'() {
-    this.render('<div foo="{{funstuff}}" name="Alice"></div>', { funstuff: 'oh my' });
+    this.render('<div foo="{{this.funstuff}}" name="Alice"></div>', { funstuff: 'oh my' });
     this.assertHTML('<div foo="oh my" name="Alice"></div>');
   }
 
@@ -111,19 +111,19 @@ export class ServerSideSuite extends AbstractNodeTest {
 
   @test
   'The compiler can handle simple handlebars'() {
-    this.render('<div>{{title}}</div>', { title: 'hello' });
+    this.render('<div>{{this.title}}</div>', { title: 'hello' });
     this.assertHTML('<div>hello</div>');
   }
 
   @test
   'The compiler can handle escaping HTML'() {
-    this.render('<div>{{title}}</div>', { title: '<strong>hello</strong>' });
+    this.render('<div>{{this.title}}</div>', { title: '<strong>hello</strong>' });
     this.assertHTML('<div>&lt;strong&gt;hello&lt;/strong&gt;</div>');
   }
 
   @test
   'The compiler can handle unescaped HTML'() {
-    this.render('<div>{{{title}}}</div>', { title: '<strong>hello</strong>' });
+    this.render('<div>{{{this.title}}}</div>', { title: '<strong>hello</strong>' });
     this.assertHTML('<div><strong>hello</strong></div>');
   }
 
@@ -146,7 +146,7 @@ export class ServerSideSuite extends AbstractNodeTest {
       return params[0];
     });
 
-    this.render('<a href="{{testing url}}">linky</a>', { url: 'linky.html' });
+    this.render('<a href="{{testing this.url}}">linky</a>', { url: 'linky.html' });
     this.assertHTML('<a href="linky.html">linky</a>');
   }
 
@@ -215,7 +215,7 @@ export class ServerSideComponentSuite extends AbstractNodeTest {
       {
         layout: '<h1>Hello {{@place}}!</h1>',
         template: 'World',
-        args: { place: 'place' },
+        args: { place: 'this.place' },
       },
       { place: 'World' }
     );
@@ -228,7 +228,7 @@ export class ServerSideComponentSuite extends AbstractNodeTest {
       {
         layout: '<h1>Hello {{yield @place}}!</h1>',
         template: '{{place}}',
-        args: { place: 'place' },
+        args: { place: 'this.place' },
         blockParams: ['place'],
       },
       { place: 'World' }

--- a/packages/@glimmer/integration-tests/lib/suites/with-dynamic-vars.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/with-dynamic-vars.ts
@@ -9,7 +9,7 @@ export class WithDynamicVarsSuite extends RenderTest {
       {
         layout: '{{#-with-dynamic-vars myKeyword=@value}}{{yield}}{{/-with-dynamic-vars}}',
         template: '{{-get-dynamic-var "myKeyword"}}',
-        args: { value: 'value' },
+        args: { value: 'this.value' },
       },
       { value: 'hello' }
     );
@@ -32,8 +32,8 @@ export class WithDynamicVarsSuite extends RenderTest {
       {
         layout:
           '{{#-with-dynamic-vars myKeyword=@value1 secondKeyword=@value2}}{{yield}}{{/-with-dynamic-vars}}',
-        template: '{{keyword}}-{{-get-dynamic-var keyword}}',
-        args: { value1: 'value1', value2: 'value2' },
+        template: '{{this.keyword}}-{{-get-dynamic-var this.keyword}}',
+        args: { value1: 'this.value1', value2: 'this.value2' },
       },
       { value1: 'hello', value2: 'goodbye', keyword: 'myKeyword' }
     );
@@ -61,7 +61,7 @@ export class WithDynamicVarsSuite extends RenderTest {
         layout:
           '{{#-with-dynamic-vars myKeyword=@outer}}<div>{{-get-dynamic-var "myKeyword"}}</div>{{#-with-dynamic-vars myKeyword=@inner}}{{yield}}{{/-with-dynamic-vars}}<div>{{-get-dynamic-var "myKeyword"}}</div>{{/-with-dynamic-vars}}',
         template: '<div>{{-get-dynamic-var "myKeyword"}}</div>',
-        args: { outer: 'outer', inner: 'inner' },
+        args: { outer: 'this.outer', inner: 'this.inner' },
       },
       { outer: 'original', inner: 'shadowed' }
     );

--- a/packages/@glimmer/integration-tests/lib/suites/yield.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/yield.ts
@@ -10,10 +10,10 @@ export class YieldSuite extends RenderTest {
       {
         layout:
           '{{#if @predicate}}Yes:{{yield @someValue}}{{else}}No:{{yield to="inverse"}}{{/if}}',
-        args: { predicate: 'activated', someValue: '42' },
+        args: { predicate: 'this.activated', someValue: '42' },
         blockParams: ['result'],
-        template: 'Hello{{result}}{{outer}}',
-        else: 'Goodbye{{outer}}',
+        template: 'Hello{{result}}{{this.outer}}',
+        else: 'Goodbye{{this.outer}}',
       },
       { activated: true, outer: 'outer' }
     );
@@ -30,10 +30,10 @@ export class YieldSuite extends RenderTest {
       {
         layout:
           '{{#if @predicate}}Yes:{{yield @someValue}}{{else}}No:{{yield to="inverse"}}{{/if}}',
-        args: { predicate: 'activated', someValue: '42' },
+        args: { predicate: 'this.activated', someValue: '42' },
         blockParams: ['result'],
-        template: 'Hello{{result}}{{outer}}',
-        else: 'Goodbye{{outer}}',
+        template: 'Hello{{result}}{{this.outer}}',
+        else: 'Goodbye{{this.outer}}',
       },
       { activated: false, outer: 'outer' }
     );
@@ -49,10 +49,10 @@ export class YieldSuite extends RenderTest {
     this.render(
       {
         layout: '{{#if @predicate}}Yes:{{yield @someValue}}{{else}}No:{{yield to="else"}}{{/if}}',
-        args: { predicate: 'activated', someValue: '42' },
+        args: { predicate: 'this.activated', someValue: '42' },
         blockParams: ['result'],
-        template: 'Hello{{result}}{{outer}}',
-        else: 'Goodbye{{outer}}',
+        template: 'Hello{{result}}{{this.outer}}',
+        else: 'Goodbye{{this.outer}}',
       },
       { activated: false, outer: 'outer' }
     );
@@ -88,7 +88,7 @@ export class YieldSuite extends RenderTest {
   })
   'use a non-existent block param'() {
     this.render({
-      layout: '{{yield someValue}}',
+      layout: '{{yield this.someValue}}',
       args: { someValue: '42' },
       blockParams: ['val1', 'val2'],
       template: '{{val1}} - {{val2}}',
@@ -199,7 +199,7 @@ export class YieldSuite extends RenderTest {
       {
         layout: 'In layout -- {{#if @predicate}}{{yield}}{{/if}}',
         template: 'In template',
-        args: { predicate: 'predicate' },
+        args: { predicate: 'this.predicate' },
       },
       { predicate: true }
     );

--- a/packages/@glimmer/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer/integration-tests/test/attributes-test.ts
@@ -50,7 +50,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'disable updates properly'() {
-    this.render('<input disabled={{enabled}} />', { enabled: true });
+    this.render('<input disabled={{this.enabled}} />', { enabled: true });
     this.assertHTML('<input disabled />');
     this.assertStableRerender();
 
@@ -81,7 +81,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'Quoted disabled is always disabled if a not-null, not-undefined value is given'() {
-    this.render('<input disabled="{{enabled}}" />', { enabled: true });
+    this.render('<input disabled="{{this.enabled}}" />', { enabled: true });
     this.assertHTML('<input disabled />');
     this.assertStableRerender();
 
@@ -122,7 +122,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'div[href] is not marked as unsafe'() {
-    this.render('<div href="{{foo}}"></div>', { foo: 'javascript:foo()' });
+    this.render('<div href="{{this.foo}}"></div>', { foo: 'javascript:foo()' });
     this.assertHTML('<div href="javascript:foo()"></div>');
     this.assertStableRerender();
 
@@ -137,7 +137,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'triple curlies in attribute position'() {
-    this.render('<div data-bar="bar" data-foo={{{rawString}}}>Hello</div>', {
+    this.render('<div data-bar="bar" data-foo={{{this.rawString}}}>Hello</div>', {
       rawString: 'TRIPLE',
     });
     this.assertHTML('<div data-foo="TRIPLE" data-bar="bar">Hello</div>');
@@ -182,7 +182,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'can set attributes on form properties'() {
-    this.render('<form id={{foo}}></form><output form={{foo}}></output>', { foo: 'bar' });
+    this.render('<form id={{this.foo}}></form><output form={{this.foo}}></output>', { foo: 'bar' });
 
     let outputElement = assertElement(this.element.lastChild);
 
@@ -195,7 +195,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'handles null input values'() {
-    this.render('<input value={{isNull}} />', { isNull: null });
+    this.render('<input value={{this.isNull}} />', { isNull: null });
     this.assert.equal(this.readDOMAttr('value'), '');
     this.assertStableRerender();
 
@@ -210,7 +210,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'handles undefined input values'() {
-    this.render('<input value={{isUndefined}} />', { isUndefined: null });
+    this.render('<input value={{this.isUndefined}} />', { isUndefined: null });
     this.assert.equal(this.readDOMAttr('value'), '');
     this.assertStableRerender();
 
@@ -226,7 +226,7 @@ export class AttributesTests extends RenderTest {
   @test
   'handles undefined `toString` input values'() {
     let obj = Object.create(null);
-    this.render('<input value={{obj}} />', { obj });
+    this.render('<input value={{this.obj}} />', { obj });
     this.assert.equal(this.readDOMAttr('value'), '');
     this.assertStableRerender();
 
@@ -249,7 +249,7 @@ export class AttributesTests extends RenderTest {
       }
     });
 
-    this.render('<input checked={{if foo true undefined}} />', { foo: true });
+    this.render('<input checked={{if this.foo true undefined}} />', { foo: true });
     this.assert.equal(this.readDOMAttr('checked'), true);
     this.assertStableRerender();
 
@@ -264,7 +264,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'input[checked] prop updates when set to null'() {
-    this.render('<input checked={{foo}} />', { foo: true });
+    this.render('<input checked={{this.foo}} />', { foo: true });
     this.assert.equal(this.readDOMAttr('checked'), true);
     this.assertStableRerender();
 
@@ -281,7 +281,7 @@ export class AttributesTests extends RenderTest {
   'select[value] prop updates when set to undefined'() {
     // setting `select[value]` only works after initial render, just use
     this.render(
-      '<select value={{foo}}><option></option><option value="us" selected>us</option></select>',
+      '<select value={{this.foo}}><option></option><option value="us" selected>us</option></select>',
       { foo: undefined }
     );
     this.assert.equal(this.readDOMAttr('value'), 'us');
@@ -299,7 +299,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'handles empty string textarea values'() {
-    this.render('<textarea value={{name}} />', { name: '' });
+    this.render('<textarea value={{this.name}} />', { name: '' });
     this.assert.equal(this.readDOMAttr('value'), '');
     this.assertStableRerender();
 
@@ -314,7 +314,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'handles empty string input placeholders'() {
-    this.render('<input type="text" placeholder={{name}} />', { name: '' });
+    this.render('<input type="text" placeholder={{this.name}} />', { name: '' });
     this.assert.equal(this.readDOMAttr('placeholder'), '');
     this.assertStableRerender();
 
@@ -338,7 +338,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'does not set undefined attributes'() {
-    this.render('<div data-foo={{isUndefined}} /><div data-foo={{isNotUndefined}} />', {
+    this.render('<div data-foo={{this.isUndefined}} /><div data-foo={{this.isNotUndefined}} />', {
       isUndefined: undefined,
       isNotUndefined: 'hello',
     });
@@ -374,7 +374,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'does not set null attributes'() {
-    this.render('<div data-foo={{isNull}} /><div data-foo={{isNotNull}} />', {
+    this.render('<div data-foo={{this.isNull}} /><div data-foo={{this.isNotNull}} />', {
       isNull: null,
       isNotNull: 'hello',
     });
@@ -414,7 +414,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'does not set undefined properties initially'() {
-    this.render('<div title={{isUndefined}} /><div title={{isNotUndefined}} />', {
+    this.render('<div title={{this.isUndefined}} /><div title={{this.isNotUndefined}} />', {
       isUndefined: undefined,
       isNotUndefined: 'hello',
     });
@@ -451,7 +451,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'does not set null properties initially'() {
-    this.render('<div title={{isNull}} /><div title={{isNotNull}} />', {
+    this.render('<div title={{this.isNull}} /><div title={{this.isNotNull}} />', {
       isNull: undefined,
       isNotNull: 'hello',
     });
@@ -488,7 +488,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'input list attribute updates properly'() {
-    this.render('<input list="{{foo}}" />', { foo: 'bar' });
+    this.render('<input list="{{this.foo}}" />', { foo: 'bar' });
     this.assertHTML('<input list="bar" />');
     this.assertStableRerender();
 
@@ -503,7 +503,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'normalizes lowercase dynamic properties correctly'() {
-    this.render('<div tiTle={{foo}} />', { foo: 'bar' });
+    this.render('<div tiTle={{this.foo}} />', { foo: 'bar' });
     this.assertHTML('<div title="bar" />');
     this.assertStableRerender();
 
@@ -518,7 +518,7 @@ export class AttributesTests extends RenderTest {
 
   @test
   'normalizes mix-case dynamic properties correctly'() {
-    this.render('<svg viewBox={{foo}} />', { foo: '0 0 100 100' });
+    this.render('<svg viewBox={{this.foo}} />', { foo: '0 0 100 100' });
     this.assertHTML('<svg viewBox="0 0 100 100" />');
     this.assertStableRerender();
 
@@ -542,7 +542,7 @@ abstract class BoundValuesToSpecialAttributeTests extends RenderTest {
 
   @test
   'marks javascript: protocol as unsafe'() {
-    this.render(this.tmplt('{{foo}}'), {
+    this.render(this.tmplt('{{this.foo}}'), {
       foo: 'javascript:foo()',
     });
     this.assertHTML(this.tmplt('unsafe:javascript:foo()'));
@@ -559,7 +559,7 @@ abstract class BoundValuesToSpecialAttributeTests extends RenderTest {
 
   @test
   'marks javascript: protocol as unsafe, http as safe'() {
-    this.render(this.tmplt('{{foo}}'), { foo: 'javascript:foo()' });
+    this.render(this.tmplt('{{this.foo}}'), { foo: 'javascript:foo()' });
     this.assertHTML(this.tmplt('unsafe:javascript:foo()'));
     this.assertStableRerender();
 
@@ -574,7 +574,7 @@ abstract class BoundValuesToSpecialAttributeTests extends RenderTest {
 
   @test
   'marks javascript: protocol as unsafe on updates'() {
-    this.render(this.tmplt('{{foo}}'), { foo: 'http://foo.bar' });
+    this.render(this.tmplt('{{this.foo}}'), { foo: 'http://foo.bar' });
     this.assertHTML(this.tmplt('http://foo.bar', true));
     this.assertStableRerender();
 
@@ -589,7 +589,7 @@ abstract class BoundValuesToSpecialAttributeTests extends RenderTest {
 
   @test
   'marks vbscript: protocol as unsafe'() {
-    this.render(this.tmplt('{{foo}}'), { foo: 'vbscript:foo()' });
+    this.render(this.tmplt('{{this.foo}}'), { foo: 'vbscript:foo()' });
     this.assertHTML(this.tmplt('unsafe:vbscript:foo()', true));
     this.assertStableRerender();
 
@@ -604,7 +604,7 @@ abstract class BoundValuesToSpecialAttributeTests extends RenderTest {
 
   @test
   'can be removed by setting to `null`'() {
-    this.render(this.tmplt('{{foo}}', false), { foo: 'http://foo.bar/derp.jpg' });
+    this.render(this.tmplt('{{this.foo}}', false), { foo: 'http://foo.bar/derp.jpg' });
     this.assertHTML(this.tmplt('http://foo.bar/derp.jpg'));
     this.assertStableRerender();
 
@@ -619,7 +619,7 @@ abstract class BoundValuesToSpecialAttributeTests extends RenderTest {
 
   @test
   'can be removed by setting to `undefined`'() {
-    this.render(this.tmplt('{{foo}}', false), { foo: 'http://foo.bar/derp.jpg' });
+    this.render(this.tmplt('{{this.foo}}', false), { foo: 'http://foo.bar/derp.jpg' });
     this.assertHTML(this.tmplt('http://foo.bar/derp.jpg'));
     this.assertStableRerender();
 

--- a/packages/@glimmer/integration-tests/test/chaos-rehydration-test.ts
+++ b/packages/@glimmer/integration-tests/test/chaos-rehydration-test.ts
@@ -203,7 +203,7 @@ class ChaosMonkeyRehydration extends AbstractChaosMonkeyTest {
 
   @test
   'adjacent text nodes'() {
-    let template = '<div>a {{b}}{{c}}{{d}}</div>';
+    let template = '<div>a {{this.b}}{{this.c}}{{this.d}}</div>';
     let context = { b: '', c: '', d: '' };
 
     this.renderServerSide(template, context);
@@ -218,7 +218,7 @@ class ChaosMonkeyRehydration extends AbstractChaosMonkeyTest {
 
   @test
   '<p> invoking a block which emits a <div>'() {
-    let template = '<p>hello {{#if show}}<div>world!</div>{{/if}}</p>';
+    let template = '<p>hello {{#if this.show}}<div>world!</div>{{/if}}</p>';
     let context = { show: true };
 
     this.renderServerSide(template, context);

--- a/packages/@glimmer/integration-tests/test/ember-component-test.ts
+++ b/packages/@glimmer/integration-tests/test/ember-component-test.ts
@@ -191,7 +191,7 @@ class CurlyCreateTest extends CurlyTest {
       tagName = 'div';
     }
 
-    this.registerComponent('Curly', 'foo-bar', `{{HAS_BLOCK}}`, FooBar);
+    this.registerComponent('Curly', 'foo-bar', `{{this.HAS_BLOCK}}`, FooBar);
 
     this.render(`{{foo-bar}}`);
 
@@ -204,7 +204,7 @@ class CurlyCreateTest extends CurlyTest {
       tagName = 'div';
     }
 
-    this.registerComponent('Curly', 'foo-bar', `{{HAS_BLOCK}}`, FooBar);
+    this.registerComponent('Curly', 'foo-bar', `{{this.HAS_BLOCK}}`, FooBar);
 
     this.render(`{{#foo-bar}}{{/foo-bar}}`);
 
@@ -222,7 +222,7 @@ class CurlyDynamicComponentTest extends CurlyTest {
     this.render(
       stripTight`
         <div>
-          {{component something arg1="hello"}}
+          {{component this.something arg1="hello"}}
         </div>
       `,
       {
@@ -245,7 +245,7 @@ class CurlyDynamicComponentTest extends CurlyTest {
     this.render(
       stripTight`
         <div>
-          {{component something}}
+          {{component this.something}}
         </div>`,
       {
         something: 'FooBar',
@@ -344,7 +344,7 @@ class CurlyArgsTest extends CurlyTest {
 
     this.registerComponent('Curly', 'foo-bar', `{{@blah}}`, FooBar);
 
-    this.render(`{{foo-bar first blah="derp"}}`);
+    this.render(`{{foo-bar this.first blah="derp"}}`);
 
     this.assertEmberishElement('div', {}, `derp`);
   }
@@ -358,18 +358,18 @@ class CurlyScopeTest extends CurlyTest {
     this.registerComponent(
       'TemplateOnly',
       'FooBar',
-      `<div>[Layout: {{zomg}}][Layout: {{lol}}][Layout: {{@foo}}]{{yield}}</div>`
+      `<div>[Layout: {{this.zomg}}][Layout: {{this.lol}}][Layout: {{@foo}}]{{yield}}</div>`
     );
 
     this.render(
       stripTight`
         <div>
-          [Outside: {{zomg}}]
-          {{#with zomg as |lol|}}
-            [Inside: {{zomg}}]
+          [Outside: {{this.zomg}}]
+          {{#with this.zomg as |lol|}}
+            [Inside: {{this.zomg}}]
             [Inside: {{lol}}]
-            <FooBar @foo={{zomg}}>
-              [Block: {{zomg}}]
+            <FooBar @foo={{this.zomg}}>
+              [Block: {{this.zomg}}]
               [Block: {{lol}}]
             </FooBar>
           {{/with}}
@@ -404,19 +404,19 @@ class CurlyScopeTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'foo-bar',
-      `[Layout: {{zomg}}][Layout: {{lol}}][Layout: {{foo}}]{{yield}}`,
+      `[Layout: {{this.zomg}}][Layout: {{this.lol}}][Layout: {{this.foo}}]{{yield}}`,
       FooBar
     );
 
     this.render(
       stripTight`
         <div>
-          [Outside: {{zomg}}]
-          {{#with zomg as |lol|}}
-            [Inside: {{zomg}}]
+          [Outside: {{this.zomg}}]
+          {{#with this.zomg as |lol|}}
+            [Inside: {{this.zomg}}]
             [Inside: {{lol}}]
-            {{#foo-bar foo=zomg}}
-              [Block: {{zomg}}]
+            {{#foo-bar foo=this.zomg}}
+              [Block: {{this.zomg}}]
               [Block: {{lol}}]
             {{/foo-bar}}
           {{/with}}
@@ -458,11 +458,11 @@ class CurlyScopeTest extends CurlyTest {
       'Curly',
       'foo-bar',
       stripTight`
-        [Name: {{name}} | Target: {{targetObject.name}}]
+        [Name: {{this.name}} | Target: {{this.targetObject.name}}]
         {{#qux-derp}}
-          [Name: {{name}} | Target: {{targetObject.name}}]
+          [Name: {{this.name}} | Target: {{this.targetObject.name}}]
         {{/qux-derp}}
-        [Name: {{name}} | Target: {{targetObject.name}}]
+        [Name: {{this.name}} | Target: {{this.targetObject.name}}]
       `,
       FooBar
     );
@@ -470,7 +470,7 @@ class CurlyScopeTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'qux-derp',
-      `[Name: {{name}} | Target: {{targetObject.name}}]{{yield}}`,
+      `[Name: {{this.name}} | Target: {{this.targetObject.name}}]{{yield}}`,
       QuxDerp
     );
 
@@ -492,25 +492,25 @@ class CurlyScopeTest extends CurlyTest {
 
   @test
   '`false` class name do not render'() {
-    this.render('<div class={{isFalse}}>FALSE</div>', { isFalse: false });
+    this.render('<div class={{this.isFalse}}>FALSE</div>', { isFalse: false });
     this.assertHTML('<div>FALSE</div>');
   }
 
   @test
   '`null` class name do not render'() {
-    this.render('<div class={{isNull}}>NULL</div>', { isNull: null });
+    this.render('<div class={{this.isNull}}>NULL</div>', { isNull: null });
     this.assertHTML('<div>NULL</div>');
   }
 
   @test
   '`undefined` class name do not render'() {
-    this.render('<div class={{isUndefined}}>UNDEFINED</div>', { isUndefined: undefined });
+    this.render('<div class={{this.isUndefined}}>UNDEFINED</div>', { isUndefined: undefined });
     this.assertHTML('<div>UNDEFINED</div>');
   }
 
   @test
   '`0` class names do render'() {
-    this.render('<div class={{isZero}}>ZERO</div>', { isZero: 0 });
+    this.render('<div class={{this.isZero}}>ZERO</div>', { isZero: 0 });
     this.assertHTML('<div class="0">ZERO</div>');
   }
 
@@ -531,7 +531,7 @@ class CurlyScopeTest extends CurlyTest {
     this.render(
       stripTight`
         <div>
-          {{#each items key="id" as |item|}}
+          {{#each this.items key="id" as |item|}}
             <SubItem @name={{item.id}} />
           {{/each}}
         </div>`,
@@ -550,8 +550,9 @@ class CurlyScopeTest extends CurlyTest {
     this.render(
       stripTight`
         <div>
-          {{#each items key="id" as |item|}}
+          {{#each this.items key="id" as |item|}}
             <SubItem @name={{this.id}} />
+            {{! Intentional property fallback to test self lookup }}
             <SubItem @name={{id}} />
             <SubItem @name={{item.id}} />
           {{/each}}
@@ -611,7 +612,7 @@ class CurlyScopeTest extends CurlyTest {
 
     this.render(
       stripTight`
-        <article>{{#each items key="id" as |item|}}
+        <article>{{#each this.items key="id" as |item|}}
           <MyItem @item={{item}} />
         {{/each}}</article>
       `,
@@ -636,7 +637,7 @@ class CurlyScopeTest extends CurlyTest {
       'item-list',
       stripTight`
         <ul>
-          {{#each items key="id" as |item|}}
+          {{#each this.items key="id" as |item|}}
             <li>{{item.id}}: {{yield item}}</li>
           {{/each}}
         </ul>
@@ -700,7 +701,7 @@ class CurlyScopeTest extends CurlyTest {
       stripTight`
         <div>
           <FooBar />
-          <FooBar @baz={{zomg}} />
+          <FooBar @baz={{this.zomg}} />
         </div>`,
       { zomg: 'zomg' }
     );
@@ -725,7 +726,7 @@ class CurlyDynamicScopeSmokeTest extends CurlyTest {
       static fromDynamicScope = ['theme'];
     }
 
-    this.registerComponent('Curly', 'sample-component', '{{theme}}', SampleComponent);
+    this.registerComponent('Curly', 'sample-component', '{{this.theme}}', SampleComponent);
 
     this.render('{{#-with-dynamic-vars theme="light"}}{{sample-component}}{{/-with-dynamic-vars}}');
 
@@ -742,7 +743,12 @@ class CurlyPositionalArgsTest extends CurlyTest {
       static positionalParams = ['person', 'age'];
     }
 
-    this.registerComponent('Curly', 'sample-component', '{{person}}{{age}}', SampleComponent);
+    this.registerComponent(
+      'Curly',
+      'sample-component',
+      '{{this.person}}{{this.age}}',
+      SampleComponent
+    );
 
     this.render('{{sample-component "Quint" 4}}');
 
@@ -755,9 +761,14 @@ class CurlyPositionalArgsTest extends CurlyTest {
       static positionalParams = ['person', 'age'];
     }
 
-    this.registerComponent('Curly', 'sample-component', '{{person}}{{age}}', SampleComponent);
+    this.registerComponent(
+      'Curly',
+      'sample-component',
+      '{{this.person}}{{this.age}}',
+      SampleComponent
+    );
 
-    this.render('{{sample-component myName myAge}}', {
+    this.render('{{sample-component this.myName this.myAge}}', {
       myName: 'Quint',
       myAge: 4,
     });
@@ -778,10 +789,10 @@ class CurlyPositionalArgsTest extends CurlyTest {
       static positionalParams = ['name'];
     }
 
-    this.registerComponent('Curly', 'sample-component', '{{name}}', SampleComponent);
+    this.registerComponent('Curly', 'sample-component', '{{this.name}}', SampleComponent);
 
     assert.throws(() => {
-      this.render('{{sample-component notMyName name=myName}}', {
+      this.render('{{sample-component this.notMyName name=this.myName}}', {
         myName: 'Quint',
         notMyName: 'Sergio',
       });
@@ -797,7 +808,7 @@ class CurlyPositionalArgsTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'sample-component',
-      '{{#each names key="@index" as |name|}}{{name}}{{/each}}',
+      '{{#each this.names key="@index" as |name|}}{{name}}{{/each}}',
       SampleComponent
     );
 
@@ -824,12 +835,12 @@ class CurlyPositionalArgsTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'sample-component',
-      '{{#each attrs.names key="@index" as |name|}}{{name}}{{/each}}',
+      '{{#each this.attrs.names key="@index" as |name|}}{{name}}{{/each}}',
       SampleComponent
     );
 
     assert.throws(() => {
-      this.render('{{sample-component "Foo" 4 "Bar" names=numbers id="args-3"}}', {
+      this.render('{{sample-component "Foo" 4 "Bar" names=this.numbers id="args-3"}}', {
         numbers: [1, 2, 3],
       });
     }, `You cannot specify positional parameters and the hash argument \`names\`.`);
@@ -844,11 +855,11 @@ class CurlyPositionalArgsTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'sample-component',
-      '{{#each names key="@index" as |name|}}{{name}}{{/each}}',
+      '{{#each this.names key="@index" as |name|}}{{name}}{{/each}}',
       SampleComponent
     );
 
-    this.render('{{sample-component names=things}}', {
+    this.render('{{sample-component names=this.things}}', {
       things: ['Foo', 4, 'Bar'],
     });
 
@@ -861,7 +872,12 @@ class CurlyPositionalArgsTest extends CurlyTest {
       static positionalParams = ['first', 'second'];
     }
 
-    this.registerComponent('Curly', 'sample-component', '{{first}} - {{second}}', SampleComponent);
+    this.registerComponent(
+      'Curly',
+      'sample-component',
+      '{{this.first}} - {{this.second}}',
+      SampleComponent
+    );
 
     this.render(
       stripTight`
@@ -892,11 +908,11 @@ class CurlyPositionalArgsTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'sample-component',
-      '{{#each attrs.n key="@index" as |name|}}{{name}}{{/each}}',
+      '{{#each this.attrs.n key="@index" as |name|}}{{name}}{{/each}}',
       SampleComponent
     );
 
-    this.render('{{sample-component user1 user2}}', {
+    this.render('{{sample-component this.user1 this.user2}}', {
       user1: 'Foo',
       user2: 4,
     });
@@ -926,11 +942,11 @@ class CurlyPositionalArgsTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'sample-component',
-      `{{attrs.name}}{{attrs.age}}`,
+      `{{this.attrs.name}}{{this.attrs.age}}`,
       SampleComponent
     );
 
-    this.render(`{{component "sample-component" myName myAge}}`, {
+    this.render(`{{component "sample-component" this.myName this.myAge}}`, {
       myName: 'Quint',
       myAge: 4,
     });
@@ -959,7 +975,7 @@ class CurlyClosureComponentsTest extends CurlyTest {
   @test
   'component helper can handle aliased block components with args'() {
     this.registerHelper('hash', (_positional, named) => named);
-    this.registerComponent('Curly', 'foo-bar', 'Hello {{arg1}} {{yield}}');
+    this.registerComponent('Curly', 'foo-bar', 'Hello {{this.arg1}} {{yield}}');
 
     this.render(
       stripTight`
@@ -991,7 +1007,7 @@ class CurlyClosureComponentsTest extends CurlyTest {
   @test
   'component helper can handle aliased inline components with args'() {
     this.registerHelper('hash', (_positional, named) => named);
-    this.registerComponent('Curly', 'foo-bar', 'Hello {{arg1}}');
+    this.registerComponent('Curly', 'foo-bar', 'Hello {{this.arg1}}');
 
     this.render(
       stripTight`
@@ -1024,7 +1040,7 @@ class CurlyClosureComponentsTest extends CurlyTest {
   'component helper can handle higher order inline components with args'() {
     this.registerHelper('hash', (_positional, named) => named);
     this.registerComponent('Curly', 'foo-bar', '{{yield (hash comp=(component "baz-bar"))}}');
-    this.registerComponent('Curly', 'baz-bar', 'Hello {{arg1}}');
+    this.registerComponent('Curly', 'baz-bar', 'Hello {{this.arg1}}');
 
     this.render(
       stripTight`
@@ -1062,7 +1078,7 @@ class CurlyClosureComponentsTest extends CurlyTest {
   'component helper can handle higher order block components with args'() {
     this.registerHelper('hash', (_positional, named) => named);
     this.registerComponent('Curly', 'foo-bar', '{{yield (hash comp=(component "baz-bar"))}}');
-    this.registerComponent('Curly', 'baz-bar', 'Hello {{arg1}} {{yield}}');
+    this.registerComponent('Curly', 'baz-bar', 'Hello {{this.arg1}} {{yield}}');
 
     this.render(
       stripTight`
@@ -1081,7 +1097,7 @@ class CurlyClosureComponentsTest extends CurlyTest {
   'component helper can handle higher order block components without args'() {
     this.registerHelper('hash', (_positional, named) => named);
     this.registerComponent('Curly', 'foo-bar', '{{yield (hash comp=(component "baz-bar"))}}');
-    this.registerComponent('Curly', 'baz-bar', 'Hello {{arg1}} {{yield}}');
+    this.registerComponent('Curly', 'baz-bar', 'Hello {{this.arg1}} {{yield}}');
 
     this.render(
       stripTight`
@@ -1141,21 +1157,21 @@ class CurlyClosureComponentsTest extends CurlyTest {
       'Curly',
       'foo-bar',
       stripTight`
-        1. [{{one}}]
-        2. [{{two}}]
-        3. [{{three}}]
-        4. [{{four}}]
-        5. [{{five}}]
-        6. [{{six}}]
+        1. [{{this.one}}]
+        2. [{{this.two}}]
+        3. [{{this.three}}]
+        4. [{{this.four}}]
+        5. [{{this.five}}]
+        6. [{{this.six}}]
 
         {{yield}}
 
-        a. [{{a}}]
-        b. [{{b}}]
-        c. [{{c}}]
-        d. [{{d}}]
-        e. [{{e}}]
-        f. [{{f}}]
+        a. [{{this.a}}]
+        b. [{{this.b}}]
+        c. [{{this.c}}]
+        d. [{{this.d}}]
+        e. [{{this.e}}]
+        f. [{{this.f}}]
       `,
       FooBarComponent
     );
@@ -1201,19 +1217,19 @@ class CurlyClosureComponentsTest extends CurlyTest {
       'Curly',
       'foo-bar',
       stripTight`
-        1. [{{one}}]
-        2. [{{two}}]
-        3. [{{three}}]
-        4. [{{four}}]
-        5. [{{five}}]
-        6. [{{six}}]
+        1. [{{this.one}}]
+        2. [{{this.two}}]
+        3. [{{this.three}}]
+        4. [{{this.four}}]
+        5. [{{this.five}}]
+        6. [{{this.six}}]
       `,
       FooBarComponent
     );
 
     this.render(
       stripTight`
-        {{component (component (component 'foo-bar' foo.first foo.second) 'inner 1') 'invocation 1' 'invocation 2'}}
+        {{component (component (component 'foo-bar' this.foo.first this.foo.second) 'inner 1') 'invocation 1' 'invocation 2'}}
       `,
       {
         foo: {
@@ -1331,7 +1347,7 @@ class CurlyGlimmerComponentTest extends CurlyTest {
       '<not-an-ember-component such="{{@stability}}" ...attributes>In layout</not-an-ember-component>'
     );
 
-    this.render('<NonBlock @stability={{stability}} />', { stability: 'stability' });
+    this.render('<NonBlock @stability={{this.stability}} />', { stability: 'stability' });
     this.assertHTML('<not-an-ember-component such="stability">In layout</not-an-ember-component>');
 
     this.rerender({
@@ -1376,7 +1392,7 @@ class CurlyGlimmerComponentTest extends CurlyTest {
       inspectHooks((NonBlock as unknown) as EmberishCurlyComponentFactory)
     );
 
-    this.render('{{non-block someProp=someProp}}', { someProp: 'wycats' });
+    this.render('{{non-block someProp=this.someProp}}', { someProp: 'wycats' });
 
     assert.ok(instance, 'instance is created');
 
@@ -1425,11 +1441,11 @@ class CurlyGlimmerComponentTest extends CurlyTest {
     this.registerComponent(
       'Curly',
       'non-block',
-      'In layout - someProp: {{someProp}}',
+      'In layout - someProp: {{this.someProp}}',
       inspectHooks(NonBlock as any)
     );
 
-    this.render('{{non-block someProp=someProp}}', { someProp: 'wycats' });
+    this.render('{{non-block someProp=this.someProp}}', { someProp: 'wycats' });
 
     assert.ok(instance, 'instance is created');
 
@@ -1484,7 +1500,7 @@ class CurlyGlimmerComponentTest extends CurlyTest {
       inspectHooks(InputComponent as any)
     );
 
-    this.render('{{input-component value=someProp}}', { someProp: null });
+    this.render('{{input-component value=this.someProp}}', { someProp: null });
 
     assert.ok(instance, 'instance is created');
 
@@ -1522,7 +1538,7 @@ class CurlyGlimmerComponentTest extends CurlyTest {
 
     this.registerComponent('Curly', 'foo-bar', 'FOO BAR', FooBarComponent);
 
-    this.render('{{foo-bar class=classes}}', { classes: 'foo bar' });
+    this.render('{{foo-bar class=this.classes}}', { classes: 'foo bar' });
 
     assert.ok(instance, 'instance is created');
 
@@ -1659,7 +1675,7 @@ class CurlyTeardownTest extends CurlyTest {
 
     this.registerComponent('Curly', 'destroy-me', 'destroy me!', DestroyMeComponent);
 
-    this.render(`{{#if cond}}{{destroy-me}}{{/if}}`, { cond: true });
+    this.render(`{{#if this.cond}}{{destroy-me}}{{/if}}`, { cond: true });
 
     assert.strictEqual(willDestroy, 0, 'destroy should not be called');
     assert.strictEqual(destroyed, 0, 'destroy should not be called');
@@ -1688,7 +1704,7 @@ class CurlyTeardownTest extends CurlyTest {
       DestroyMeComponent
     );
 
-    this.render(`{{#if cond}}<DestroyMe />{{/if}}`, { cond: true });
+    this.render(`{{#if this.cond}}<DestroyMe />{{/if}}`, { cond: true });
 
     assert.strictEqual(destroyed, 0, 'destroy should not be called');
 
@@ -1714,7 +1730,7 @@ class CurlyTeardownTest extends CurlyTest {
 
     this.registerComponent('Curly', 'another-component', 'another thing!', AnotherComponent);
 
-    this.render(`{{component componentName}}`, { componentName: 'destroy-me' });
+    this.render(`{{component this.componentName}}`, { componentName: 'destroy-me' });
 
     assert.strictEqual(destroyed, 0, 'destroy should not be called');
 
@@ -1736,7 +1752,7 @@ class CurlyTeardownTest extends CurlyTest {
 
     this.registerComponent('Curly', 'DestroyMe', '<div>destroy me!</div>', DestroyMeComponent);
 
-    this.render(`{{#each list as |item|}}<DestroyMe @item={{item}} />{{/each}}`, {
+    this.render(`{{#each this.list as |item|}}<DestroyMe @item={{item}} />{{/each}}`, {
       list: [1, 2, 3, 4, 5],
     });
 
@@ -1774,7 +1790,7 @@ class CurlyTeardownTest extends CurlyTest {
     let val4 = { val: 4 };
     let val5 = { val: 5 };
 
-    this.render(`{{#each list key='@identity' as |item|}}<DestroyMe @item={{item}} />{{/each}}`, {
+    this.render(`{{#each this.list key='@identity' as |item|}}<DestroyMe @item={{item}} />{{/each}}`, {
       list: [val1, val2, val3, val4, val5],
     });
 
@@ -1823,7 +1839,7 @@ class CurlyTeardownTest extends CurlyTest {
     );
     this.registerComponent('Curly', 'destroy-me-inner', 'inner', DestroyMe2Component);
 
-    this.render(`{{#if cond}}{{destroy-me from="root" cond=child.cond}}{{/if}}`, {
+    this.render(`{{#if this.cond}}{{destroy-me from="root" cond=this.child.cond}}{{/if}}`, {
       cond: true,
       child: { cond: true },
     });
@@ -1866,7 +1882,7 @@ class CurlyTeardownTest extends CurlyTest {
     this.registerComponent('Curly', 'destroy-me2', 'Destroy me! {{yield}}', DestroyMe2Component);
 
     this.render(
-      `{{#each list key='@identity' as |item|}}<DestroyMe1 @item={{item}}>{{#destroy-me2 from="root" item=item}}{{/destroy-me2}}</DestroyMe1>{{/each}}`,
+      `{{#each this.list key='@identity' as |item|}}<DestroyMe1 @item={{item}}>{{#destroy-me2 from="root" item=item}}{{/destroy-me2}}</DestroyMe1>{{/each}}`,
       { list: [1, 2, 3, 4, 5] }
     );
 
@@ -2010,7 +2026,7 @@ class CurlyAppendableTest extends CurlyTest {
 
     let definition = this.delegate.createCurriedComponent('foo-bar');
 
-    this.render('{{foo}}', { foo: definition });
+    this.render('{{this.foo}}', { foo: definition });
     this.assertEmberishElement('div', {}, 'foo bar');
     this.assertStableRerender();
 
@@ -2027,7 +2043,7 @@ class CurlyAppendableTest extends CurlyTest {
 
     let definition = this.delegate.createCurriedComponent('foo-bar');
 
-    this.render('{{foo.bar}}', { foo: { bar: definition } });
+    this.render('{{this.foo.bar}}', { foo: { bar: definition } });
     this.assertEmberishElement('div', {}, 'foo bar');
     this.assertStableRerender();
 
@@ -2069,7 +2085,7 @@ class CurlyAppendableTest extends CurlyTest {
 
     let definition = this.delegate.createCurriedComponent('foo-bar');
 
-    this.render('{{foo.bar}}', { foo: { bar: 'lol' } });
+    this.render('{{this.foo.bar}}', { foo: { bar: 'lol' } });
     this.assertHTML('lol');
     this.assertStableRerender();
 

--- a/packages/@glimmer/integration-tests/test/ember-component-test.ts
+++ b/packages/@glimmer/integration-tests/test/ember-component-test.ts
@@ -1790,9 +1790,12 @@ class CurlyTeardownTest extends CurlyTest {
     let val4 = { val: 4 };
     let val5 = { val: 5 };
 
-    this.render(`{{#each this.list key='@identity' as |item|}}<DestroyMe @item={{item}} />{{/each}}`, {
-      list: [val1, val2, val3, val4, val5],
-    });
+    this.render(
+      `{{#each this.list key='@identity' as |item|}}<DestroyMe @item={{item}} />{{/each}}`,
+      {
+        list: [val1, val2, val3, val4, val5],
+      }
+    );
 
     assert.strictEqual(destroyed.length, 0, 'destroy should not be called');
 

--- a/packages/@glimmer/integration-tests/test/helpers/array-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/array-test.ts
@@ -34,7 +34,7 @@ class ArrayTest extends RenderTest {
   @test
   'binds values when variables are used'() {
     this.render(
-      strip`{{#with (array personOne) as |people|}}
+      strip`{{#with (array this.personOne) as |people|}}
             {{#each people as |personName|}}
               {{personName}}
             {{/each}}
@@ -58,7 +58,7 @@ class ArrayTest extends RenderTest {
   @test
   'binds multiple values when variables are used'() {
     this.render(
-      strip`{{#with (array personOne personTwo) as |people|}}
+      strip`{{#with (array this.personOne this.personTwo) as |people|}}
             {{#each people as |personName|}}
               {{personName}},
             {{/each}}
@@ -89,7 +89,7 @@ class ArrayTest extends RenderTest {
   'array helpers can be nested'() {
     this.render(
       strip`
-        {{#let (array (array personOne personTwo)) as |listOfPeople|}}
+        {{#let (array (array this.personOne this.personTwo)) as |listOfPeople|}}
           {{#each listOfPeople as |people|}}
             List:
             {{#each people as |personName|}}
@@ -226,7 +226,7 @@ class ArrayTest extends RenderTest {
       `
     );
 
-    this.render(strip`<FooBar @people={{array "Tom" personTwo}}/>`, { personTwo: 'Chad' });
+    this.render(strip`<FooBar @people={{array "Tom" this.personTwo}}/>`, { personTwo: 'Chad' });
 
     this.assertHTML('Tom,Chad,');
 
@@ -265,7 +265,7 @@ class ArrayTest extends RenderTest {
       FooBar
     );
 
-    this.render(strip`<FooBar @people={{array "Tom" personTwo}}/>`, { personTwo: 'Chad' });
+    this.render(strip`<FooBar @people={{array "Tom" this.personTwo}}/>`, { personTwo: 'Chad' });
 
     let firstArray = fooBarInstance!.args.people;
 
@@ -286,7 +286,7 @@ class ArrayTest extends RenderTest {
       return 'captured';
     });
 
-    this.render(`{{capture (array 'Tom' personTwo)}}`, { personTwo: 'Godfrey' });
+    this.render(`{{capture (array 'Tom' this.personTwo)}}`, { personTwo: 'Godfrey' });
 
     this.assert.deepEqual(captured, ['Tom', 'Godfrey']);
 

--- a/packages/@glimmer/integration-tests/test/helpers/get-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/get-test.ts
@@ -4,7 +4,7 @@ class GetTest extends RenderTest {
   static suiteName = 'Helpers test: {{get}}';
   @test
   'should be able to get an object value with a static key'() {
-    this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
+    this.render(`[{{get this.colors 'apple'}}] [{{if true (get this.colors 'apple')}}]`, {
       colors: { apple: 'red' },
     });
 
@@ -20,7 +20,7 @@ class GetTest extends RenderTest {
 
   @test
   'should be able to get an object value with nested static key'() {
-    this.render(`[{{get colors "apple.gala"}}] [{{if true (get colors "apple.gala")}}]`, {
+    this.render(`[{{get this.colors "apple.gala"}}] [{{if true (get this.colors "apple.gala")}}]`, {
       colors: {
         apple: {
           gala: 'red and yellow',
@@ -52,7 +52,7 @@ class GetTest extends RenderTest {
 
   @test
   'should be able to get an object value with a number'() {
-    this.render(`[{{get items 1}}][{{get items 2}}][{{get items 3}}]`, {
+    this.render(`[{{get this.items 1}}][{{get this.items 2}}][{{get this.items 3}}]`, {
       items: {
         1: 'First',
         2: 'Second',
@@ -72,7 +72,7 @@ class GetTest extends RenderTest {
 
   @test
   'should be able to get an array value with a number'() {
-    this.render(`[{{get numbers 0}}][{{get numbers 1}}][{{get numbers 2}}]`, {
+    this.render(`[{{get this.numbers 0}}][{{get this.numbers 1}}][{{get this.numbers 2}}]`, {
       numbers: [1, 2, 3],
     });
 
@@ -88,7 +88,7 @@ class GetTest extends RenderTest {
 
   @test
   'should be able to get an object value with a path evaluating to a number'() {
-    this.render(`{{#each indexes as |index|}}[{{get items index}}]{{/each}}`, {
+    this.render(`{{#each this.indexes as |index|}}[{{get this.items index}}]{{/each}}`, {
       indexes: [1, 2, 3],
       items: {
         1: 'First',
@@ -109,7 +109,7 @@ class GetTest extends RenderTest {
 
   @test
   'should be able to get an array value with a path evaluating to a number'() {
-    this.render(`{{#each numbers as |num index|}}[{{get numbers index}}]{{/each}}`, {
+    this.render(`{{#each this.numbers as |num index|}}[{{get this.numbers index}}]{{/each}}`, {
       numbers: [1, 2, 3],
     });
 
@@ -122,7 +122,7 @@ class GetTest extends RenderTest {
 
   @test
   'should be able to get an object value with a bound/dynamic key'() {
-    this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+    this.render(`[{{get this.colors this.key}}] [{{if true (get this.colors this.key)}}]`, {
       colors: { apple: 'red', banana: 'yellow' },
       key: 'apple',
     });
@@ -142,7 +142,7 @@ class GetTest extends RenderTest {
 
   @test
   'should be able to get an object value with nested dynamic key'() {
-    this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+    this.render(`[{{get this.colors this.key}}] [{{if true (get this.colors this.key)}}]`, {
       colors: {
         apple: {
           gala: 'red and yellow',
@@ -169,7 +169,7 @@ class GetTest extends RenderTest {
   @test
   'should be able to get an object value with subexpression returning nested key'() {
     this.render(
-      `[{{get colors (concat 'apple' '.' 'gala')}}] [{{if true (get colors (concat 'apple' '.' 'gala'))}}]`,
+      `[{{get this.colors (concat 'apple' '.' 'gala')}}] [{{if true (get this.colors (concat 'apple' '.' 'gala'))}}]`,
       {
         colors: {
           apple: {
@@ -206,7 +206,7 @@ class GetTest extends RenderTest {
   @test
   'should be able to get an object value with a get helper as the key'() {
     this.render(
-      `[{{get colors (get possibleKeys key)}}] [{{if true (get colors (get possibleKeys key))}}]`,
+      `[{{get this.colors (get this.possibleKeys this.key)}}] [{{if true (get this.colors (get this.possibleKeys this.key))}}]`,
       {
         colors: { apple: 'red', banana: 'yellow' },
         key: 'key1',
@@ -233,7 +233,7 @@ class GetTest extends RenderTest {
   @test
   'should be able to get an object value with a get helper value as a bound/dynamic key'() {
     this.render(
-      `[{{get (get possibleValues objectKey) key}}] [{{if true (get (get possibleValues objectKey) key)}}]`,
+      `[{{get (get this.possibleValues this.objectKey) this.key}}] [{{if true (get (get this.possibleValues this.objectKey) this.key)}}]`,
       {
         possibleValues: {
           colors1: { apple: 'red', banana: 'yellow' },
@@ -266,7 +266,7 @@ class GetTest extends RenderTest {
   @test
   'should be able to get an object value with a get helper as the value and a get helper as the key'() {
     this.render(
-      `[{{get (get possibleValues objectKey) (get possibleKeys key)}}] [{{if true (get (get possibleValues objectKey) (get possibleKeys key))}}]`,
+      `[{{get (get this.possibleValues this.objectKey) (get this.possibleKeys this.key)}}] [{{if true (get (get this.possibleValues this.objectKey) (get this.possibleKeys this.key))}}]`,
       {
         possibleValues: {
           colors1: { apple: 'red', banana: 'yellow' },
@@ -335,7 +335,7 @@ class GetTest extends RenderTest {
 
   @test
   'should handle object values as nulls'() {
-    this.render(`[{{get colors 'apple'}}] [{{if true (get colors 'apple')}}]`, {
+    this.render(`[{{get this.colors 'apple'}}] [{{if true (get this.colors 'apple')}}]`, {
       colors: null,
     });
 
@@ -354,7 +354,7 @@ class GetTest extends RenderTest {
 
   @test
   'should handle object keys as nulls'() {
-    this.render(`[{{get colors key}}] [{{if true (get colors key)}}]`, {
+    this.render(`[{{get this.colors this.key}}] [{{if true (get this.colors this.key)}}]`, {
       colors: {
         apple: 'red',
         banana: 'yellow',
@@ -374,7 +374,7 @@ class GetTest extends RenderTest {
 
   @test
   'should handle object values and keys as nulls'() {
-    this.render(`[{{get colors 'apple'}}] [{{if true (get colors key)}}]`, {
+    this.render(`[{{get this.colors 'apple'}}] [{{if true (get this.colors this.key)}}]`, {
       colors: null,
       key: null,
     });
@@ -395,7 +395,7 @@ class GetTest extends RenderTest {
       PersonComponent
     );
 
-    this.render('<PersonWrapper @first={{first}} @last={{last}} @age={{age}}/>', {
+    this.render('<PersonWrapper @first={{this.first}} @last={{this.last}} @age={{this.age}}/>', {
       first: 'miguel',
       last: 'andrade',
     });

--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -307,7 +307,8 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'extra nodes at the end'() {
-    let template = '{{#if this.admin}}<div>hi admin</div>{{else}}<div>HAXOR{{this.stopHaxing}}</div>{{/if}}';
+    let template =
+      '{{#if this.admin}}<div>hi admin</div>{{else}}<div>HAXOR{{this.stopHaxing}}</div>{{/if}}';
     this.renderServerSide(template, { admin: false, stopHaxing: 'stahp' });
     this.assertServerOutput(OPEN, '<div>HAXOR', OPEN, 'stahp', CLOSE, '</div>', CLOSE);
 
@@ -723,7 +724,8 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'title tag'() {
-    let template = '<title>{{this.pageTitle}} some {{{this.other}}}{{this.thing}} <b>hey!</b></title>';
+    let template =
+      '<title>{{this.pageTitle}} some {{{this.other}}}{{this.thing}} <b>hey!</b></title>';
     this.renderServerSide(template, { pageTitle: 'kiwi', other: 'other', thing: 'thing' });
     let b = blockStack();
     this.assertHTML(strip`

--- a/packages/@glimmer/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer/integration-tests/test/initial-render-test.ts
@@ -102,7 +102,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'handles non-empty trusted content (triple-curlies)'() {
-    let template = '<div>{{{value}}}</div>';
+    let template = '<div>{{{this.value}}}</div>';
     let obj: { value: string } = { value: 'foo' };
     this.renderServerSide(template, obj);
     this.renderClientSide(template, obj);
@@ -111,7 +111,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'handles empty trusted content (triple-curlies)'() {
-    let template = '<div>{{{value}}}</div>';
+    let template = '<div>{{{this.value}}}</div>';
     let obj: { value: string } = { value: '' };
     this.renderServerSide(template, obj);
     this.renderClientSide(template, obj);
@@ -120,7 +120,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'handles empty trusted content (html safe string)'() {
-    let template = '<div>{{value}}</div>';
+    let template = '<div>{{this.value}}</div>';
 
     let safeString: SafeString = {
       toHTML() {
@@ -169,7 +169,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'mismatched text nodes'() {
-    let template = '{{content}}';
+    let template = '{{this.content}}';
     this.renderServerSide(template, { content: 'hello' });
     this.assertServerOutput(OPEN, 'hello', CLOSE);
 
@@ -182,7 +182,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'mismatched text nodes (server-render empty)'() {
-    let template = '{{content}} world';
+    let template = '{{this.content}} world';
     this.renderServerSide(template, { content: '' });
     this.assertServerOutput(OPEN, EMPTY, CLOSE, ' world');
 
@@ -198,7 +198,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'missing closing block within multiple text nodes'() {
-    let template = '<div>a {{b}}{{c}}{{d}}</div>';
+    let template = '<div>a {{this.b}}{{this.c}}{{this.d}}</div>';
     let context = { b: '', c: '', d: '' };
 
     this.renderServerSide(template, context);
@@ -227,9 +227,9 @@ class Rehydration extends AbstractRehydrationTests {
   'resumes correct block after reenabling rehydration'() {
     let template = strip`
       <div>
-        {{#if a}}
-          {{#if b}}
-            {{#if c}}
+        {{#if this.a}}
+          {{#if this.b}}
+            {{#if this.c}}
               <inside-c></inside-c>
             {{/if}}
             <after-c></after-c>
@@ -259,7 +259,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'mismatched elements'() {
-    let template = '{{#if admin}}<div>hi admin</div>{{else}}<p>HAXOR</p>{{/if}}';
+    let template = '{{#if this.admin}}<div>hi admin</div>{{else}}<p>HAXOR</p>{{/if}}';
     this.renderServerSide(template, { admin: true });
     this.assertServerOutput(OPEN, '<div>hi admin</div>', CLOSE);
 
@@ -307,7 +307,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'extra nodes at the end'() {
-    let template = '{{#if admin}}<div>hi admin</div>{{else}}<div>HAXOR{{stopHaxing}}</div>{{/if}}';
+    let template = '{{#if this.admin}}<div>hi admin</div>{{else}}<div>HAXOR{{this.stopHaxing}}</div>{{/if}}';
     this.renderServerSide(template, { admin: false, stopHaxing: 'stahp' });
     this.assertServerOutput(OPEN, '<div>HAXOR', OPEN, 'stahp', CLOSE, '</div>', CLOSE);
 
@@ -394,7 +394,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'Node curlies'() {
-    let template = '<div>{{node}}</div>';
+    let template = '<div>{{this.node}}</div>';
 
     let doc = this.delegate.serverDoc;
     let node = doc.createTextNode('hello');
@@ -423,7 +423,7 @@ class Rehydration extends AbstractRehydrationTests {
   'in-element can rehydrate'() {
     let template = strip`
       <outer><prefix></prefix>
-      {{#in-element remote}}<inner>Wat Wat</inner>{{/in-element}}
+      {{#in-element this.remote}}<inner>Wat Wat</inner>{{/in-element}}
       <suffix></suffix></outer>
       `;
     let doc = this.delegate.serverDoc;
@@ -462,7 +462,7 @@ class Rehydration extends AbstractRehydrationTests {
   'in-element with insertBefore=null can rehydrate'() {
     let template = strip`
       <outer><prefix></prefix>
-      {{#in-element remote insertBefore=null}}<inner>Wat Wat</inner>{{/in-element}}
+      {{#in-element this.remote insertBefore=null}}<inner>Wat Wat</inner>{{/in-element}}
       <suffix></suffix></outer>
       `;
     let doc = this.delegate.serverDoc;
@@ -504,7 +504,7 @@ class Rehydration extends AbstractRehydrationTests {
   'in-element with insertBefore=element can rehydrate'() {
     let template = strip`
       <outer><prefix></prefix>
-      {{#in-element remote insertBefore=prefix}}<inner>Wat Wat</inner>{{/in-element}}
+      {{#in-element this.remote insertBefore=this.prefix}}<inner>Wat Wat</inner>{{/in-element}}
       <suffix></suffix></outer>
       `;
     let doc = this.delegate.serverDoc;
@@ -549,7 +549,7 @@ class Rehydration extends AbstractRehydrationTests {
   'in-element can rehydrate into pre-existing content'() {
     let template = strip`
       <outer>
-      {{#in-element remote insertBefore=undefined}}<inner>Wat Wat</inner>{{/in-element}}
+      {{#in-element this.remote insertBefore=undefined}}<inner>Wat Wat</inner>{{/in-element}}
       </outer>
       `;
     let doc = this.delegate.serverDoc;
@@ -575,7 +575,7 @@ class Rehydration extends AbstractRehydrationTests {
   'in-element with insertBefore=null can rehydrate into pre-existing content'() {
     let template = strip`
       <outer>
-      {{#in-element remote insertBefore=null}}<inner>Wat Wat</inner>{{/in-element}}
+      {{#in-element this.remote insertBefore=null}}<inner>Wat Wat</inner>{{/in-element}}
       </outer>
       `;
     let doc = this.delegate.serverDoc;
@@ -606,7 +606,7 @@ class Rehydration extends AbstractRehydrationTests {
   'in-element with insertBefore=element can rehydrate into pre-existing content'() {
     let template = strip`
       <outer>
-      {{#in-element remote insertBefore=preexisting}}<inner>Wat Wat</inner>{{/in-element}}
+      {{#in-element this.remote insertBefore=this.preexisting}}<inner>Wat Wat</inner>{{/in-element}}
       </outer>
       `;
     let doc = this.delegate.serverDoc;
@@ -644,8 +644,8 @@ class Rehydration extends AbstractRehydrationTests {
   'nested in-element can rehydrate'() {
     let template = strip`
     <outer>
-      {{#in-element remoteParent}}
-        <inner>{{#in-element remoteChild}}Wat Wat{{/in-element}}</inner>
+      {{#in-element this.remoteParent}}
+        <inner>{{#in-element this.remoteChild}}Wat Wat{{/in-element}}</inner>
       {{/in-element}}
     </outer>
     `;
@@ -697,7 +697,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'svg elements'() {
-    let template = '<svg>{{#if isTrue}}<circle />{{/if}}</svg><p>Hello</p>';
+    let template = '<svg>{{#if this.isTrue}}<circle />{{/if}}</svg><p>Hello</p>';
     this.renderServerSide(template, { isTrue: true });
     let b = blockStack();
     this.assertHTML(strip`
@@ -723,7 +723,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'title tag'() {
-    let template = '<title>{{pageTitle}} some {{{other}}}{{thing}} <b>hey!</b></title>';
+    let template = '<title>{{this.pageTitle}} some {{{this.other}}}{{this.thing}} <b>hey!</b></title>';
     this.renderServerSide(template, { pageTitle: 'kiwi', other: 'other', thing: 'thing' });
     let b = blockStack();
     this.assertHTML(strip`
@@ -746,8 +746,8 @@ class Rehydration extends AbstractRehydrationTests {
   @test
   'script tag'() {
     let template = strip`
-      <script type="application/ld+json">{{data}}</script>
-      <script type="application/ld+json">{{otherData}}</script>
+      <script type="application/ld+json">{{this.data}}</script>
+      <script type="application/ld+json">{{this.otherData}}</script>
     `;
     this.renderServerSide(template, { data: '{ "status": "ok" }', otherData: '{ "code": 200 }' });
     let b = blockStack();
@@ -778,7 +778,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   'style tag'() {
-    let template = '<style>{{selector}} { color: #fff; }</style>';
+    let template = '<style>{{this.selector}} { color: #fff; }</style>';
     this.renderServerSide(template, { selector: 'div' });
     let b = blockStack();
     this.assertHTML(strip`
@@ -801,8 +801,8 @@ class Rehydration extends AbstractRehydrationTests {
   @test
   'clearing bounds'() {
     let template = strip`
-      {{#if isTrue}}
-        {{#each items key="id" as |item i|}}
+      {{#if this.isTrue}}
+        {{#each this.items key="id" as |item i|}}
           <p>{{item}}-{{i}}</p>
         {{/each}}
       {{/if}}
@@ -853,16 +853,16 @@ class Rehydration extends AbstractRehydrationTests {
   'top-level clearing bounds'() {
     let template = strip`
       <top>
-      {{#if isTrue}}
+      {{#if this.isTrue}}
         <inside>
-        {{#each items key="id" as |item i|}}
+        {{#each this.items key="id" as |item i|}}
           <p>{{item}}-{{i}}</p>
         {{/each}}
         </inside>
       {{/if}}
       </top>
-      {{#if isFalse}}
-        {{#each items key="id" as |item i|}}
+      {{#if this.isFalse}}
+        {{#each this.items key="id" as |item i|}}
           <p>{{item}}-{{i}}</p>
         {{/each}}
       {{/if}}
@@ -918,7 +918,7 @@ class Rehydration extends AbstractRehydrationTests {
 
   @test
   '#each rehydration'() {
-    let template = "{{#each items key='id' as |item|}}<p>{{item}}</p>{{/each}}";
+    let template = "{{#each this.items key='id' as |item|}}<p>{{item}}</p>{{/each}}";
     this.renderServerSide(template, { items: [1, 2, 3] });
     let b = blockStack();
     this.assertHTML(strip`
@@ -997,7 +997,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
   @test
   'Component invocations'() {
     let layout = 'Hello {{@name}}';
-    let args = { name: 'name' };
+    let args = { name: 'this.name' };
     this.renderServerSide(
       {
         layout,
@@ -1024,7 +1024,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
   @test
   'Mismatched Component invocations'() {
     let layout = 'Hello {{@name}}';
-    let args = { name: 'name' };
+    let args = { name: 'this.name' };
     this.renderServerSide(
       {
         layout,
@@ -1052,7 +1052,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
   '<p> invoking a block which emits a <div>'() {
     let componentToRender = {
       layout: '<p>hello {{#if @show}}<div>world!</div>{{/if}}</p>',
-      args: { show: 'show' },
+      args: { show: 'this.show' },
     };
 
     this.renderServerSide(componentToRender, { show: true });
@@ -1078,9 +1078,9 @@ class RehydratingComponents extends AbstractRehydrationTests {
   @test
   'Component invocations with block params'() {
     let layout = 'Hello {{yield @name}}';
-    let template = '{{name}}';
+    let template = '{{this.name}}';
     let blockParams = ['name'];
-    let args = { name: 'name' };
+    let args = { name: 'this.name' };
 
     this.renderServerSide(
       {
@@ -1112,9 +1112,9 @@ class RehydratingComponents extends AbstractRehydrationTests {
   @test
   'Mismatched Component invocations with block params'() {
     let layout = 'Hello {{yield @name}}';
-    let template = '{{name}}';
+    let template = '{{this.name}}';
     let blockParams = ['name'];
-    let args = { name: 'name' };
+    let args = { name: 'this.name' };
 
     this.renderServerSide(
       {
@@ -1309,7 +1309,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
     let template = '{{#if (even i)}}<FooBar @count={{i}} />{{/if}}';
     this.registerComponent('TemplateOnly', 'FooBar', '<li>{{@count}}</li>');
     let blockParams = ['i'];
-    let args = { items: 'items' };
+    let args = { items: 'this.items' };
 
     this.renderServerSide(
       {
@@ -1409,7 +1409,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
     let template = '{{#if (even i)}}<FooBar @count={{i}} />{{/if}}';
     this.registerComponent('TemplateOnly', 'FooBar', '<li>{{@count}}</li>');
     let blockParams = ['i'];
-    let args = { items: 'items' };
+    let args = { items: 'this.items' };
 
     this.renderServerSide(
       {
@@ -1518,7 +1518,7 @@ class RehydratingComponents extends AbstractRehydrationTests {
     let template = '{{#if (even i)}}<FooBar @count={{i}} />{{/if}}';
     this.registerComponent('TemplateOnly', 'FooBar', '<li>{{@count}}</li>');
     let blockParams = ['i'];
-    let args = { items: 'items', things: 'things' };
+    let args = { items: 'this.items', things: 'this.things' };
 
     this.renderServerSide(
       {

--- a/packages/@glimmer/integration-tests/test/input-range-test.ts
+++ b/packages/@glimmer/integration-tests/test/input-range-test.ts
@@ -63,9 +63,9 @@ class TemplateRangeTests extends RangeTests {
 
 jitSuite(
   class extends TemplateRangeTests {
-    static suiteName = `[emberjs/ember.js#15675] Template <input type="range" value={{value}} min={{min}} max={{max}} />`;
+    static suiteName = `[emberjs/ember.js#15675] Template <input type="range" value={{this.value}} min={{this.min}} max={{this.max}} />`;
 
-    attrs = 'type="range" value={{value}} min={{min}} max={{max}}';
+    attrs = 'type="range" value={{this.value}} min={{this.min}} max={{this.max}}';
   }
 );
 
@@ -88,7 +88,7 @@ jitSuite(
 
     renderRange(value: number): void {
       this.registerComponent('Curly', 'range-input', '', this.component());
-      this.render(`{{range-input max=max min=min value=value}}`, {
+      this.render(`{{range-input max=this.max min=this.min value=this.value}}`, {
         max: this.max,
         min: this.min,
         value,

--- a/packages/@glimmer/integration-tests/test/invocation-generation-test.ts
+++ b/packages/@glimmer/integration-tests/test/invocation-generation-test.ts
@@ -205,7 +205,7 @@ module(
         layout: 'Hello',
       });
 
-      assert.equal(invocation, '{{component componentName}}');
+      assert.equal(invocation, '{{component this.componentName}}');
     });
 
     test('Can build dynamic invocation with template', (assert) => {
@@ -215,7 +215,7 @@ module(
         template: 'World',
       });
 
-      assert.equal(invocation, '{{#component componentName}}World{{/component}}');
+      assert.equal(invocation, '{{#component this.componentName}}World{{/component}}');
     });
 
     test('Can build dynamic invocation with args', (assert) => {
@@ -228,7 +228,7 @@ module(
 
       assert.equal(
         invocation,
-        '{{#component componentName foo=bar baz=1 bar=null}}World{{/component}}'
+        '{{#component this.componentName foo=bar baz=1 bar=null}}World{{/component}}'
       );
     });
 
@@ -243,7 +243,7 @@ module(
 
       assert.equal(
         invocation,
-        `{{#component componentName foo=bar baz=1 bar=null data-foo="bar" id="wat"}}World{{/component}}`
+        `{{#component this.componentName foo=bar baz=1 bar=null data-foo="bar" id="wat"}}World{{/component}}`
       );
     });
 
@@ -259,7 +259,7 @@ module(
 
       assert.equal(
         invocation,
-        `{{#component componentName foo=bar baz=1 bar=null data-foo="bar" id="wat" as |a b c|}}World{{/component}}`
+        `{{#component this.componentName foo=bar baz=1 bar=null data-foo="bar" id="wat" as |a b c|}}World{{/component}}`
       );
     });
 
@@ -276,7 +276,7 @@ module(
 
       assert.equal(
         invocation,
-        `{{#component componentName foo=bar baz=1 bar=null data-foo="bar" id="wat" as |a b c|}}World{{else}}ELSE{{/component}}`
+        `{{#component this.componentName foo=bar baz=1 bar=null data-foo="bar" id="wat" as |a b c|}}World{{else}}ELSE{{/component}}`
       );
     });
 

--- a/packages/@glimmer/integration-tests/test/keywords/log-test.ts
+++ b/packages/@glimmer/integration-tests/test/keywords/log-test.ts
@@ -39,7 +39,7 @@ class LogTest extends RenderTest {
 
   @test
   ['correctly logs a property']() {
-    this.render(`{{log value}}`, {
+    this.render(`{{log this.value}}`, {
       value: 'one',
     });
 
@@ -48,7 +48,7 @@ class LogTest extends RenderTest {
 
   @test
   ['correctly logs multiple arguments']() {
-    this.render(`{{log "my variable:" value}}`, {
+    this.render(`{{log "my variable:" this.value}}`, {
       value: 'one',
     });
 

--- a/packages/@glimmer/integration-tests/test/modifiers-test.ts
+++ b/packages/@glimmer/integration-tests/test/modifiers-test.ts
@@ -45,7 +45,7 @@ class ModifierTests extends RenderTest {
       }
     );
 
-    this.render('{{#if ok}}<div data-ok=true {{foo bar}}></div>{{/if}}', {
+    this.render('{{#if this.ok}}<div data-ok=true {{foo this.bar}}></div>{{/if}}', {
       bar: 'bar',
       ok: true,
     });
@@ -74,7 +74,7 @@ class ModifierTests extends RenderTest {
       }
     );
 
-    this.render('{{#if ok}}<div {{foo "foo" bar="baz"}}></div>{{/if}}{{ok}}', {
+    this.render('{{#if this.ok}}<div {{foo "foo" bar="baz"}}></div>{{/if}}{{this.ok}}', {
       ok: true,
       data: 'ok',
     });
@@ -342,7 +342,7 @@ class ModifierTests extends RenderTest {
     this.registerModifier('bar', Bar);
     this.registerModifier('foo', Foo);
 
-    this.render('{{#if nuke}}<div {{foo}} {{bar}}></div>{{/if}}', { nuke: true });
+    this.render('{{#if this.nuke}}<div {{foo}} {{bar}}></div>{{/if}}', { nuke: true });
     assert.deepEqual(destructionOrder, []);
     this.rerender({ nuke: false });
     assert.deepEqual(destructionOrder, ['foo', 'bar']);
@@ -388,7 +388,7 @@ class ModifierTests extends RenderTest {
     this.registerModifier('bar', Bar);
     this.registerModifier('foo', Foo);
 
-    this.render('{{#if nuke}}<div {{foo}}><div {{bar}}></div></div>{{/if}}', { nuke: true });
+    this.render('{{#if this.nuke}}<div {{foo}}><div {{bar}}></div></div>{{/if}}', { nuke: true });
     assert.deepEqual(destructionOrder, []);
     this.rerender({ nuke: false });
     assert.deepEqual(destructionOrder, ['bar', 'foo']);
@@ -448,9 +448,12 @@ class ModifierTests extends RenderTest {
     this.registerModifier('foo', Foo);
     this.registerModifier('baz', Baz);
 
-    this.render('{{#if nuke}}<div {{foo}}><div {{bar}}></div><div {{baz}}></div></div>{{/if}}', {
-      nuke: true,
-    });
+    this.render(
+      '{{#if this.nuke}}<div {{foo}}><div {{bar}}></div><div {{baz}}></div></div>{{/if}}',
+      {
+        nuke: true,
+      }
+    );
     assert.deepEqual(destructionOrder, []);
     this.rerender({ nuke: false });
     assert.deepEqual(destructionOrder, ['bar', 'baz', 'foo']);
@@ -469,7 +472,7 @@ class ModifierTests extends RenderTest {
       }
     }
     this.registerModifier('foo', Foo);
-    this.render('<div {{foo bar}}></div>', { bar: 'bar' });
+    this.render('<div {{foo this.bar}}></div>', { bar: 'bar' });
     this.rerender({ bar: 'foo' });
   }
 
@@ -486,7 +489,7 @@ class ModifierTests extends RenderTest {
       }
     }
     this.registerModifier('foo', Foo);
-    this.render('<div {{foo bar=bar}}></div>', { bar: 'bar' });
+    this.render('<div {{foo bar=this.bar}}></div>', { bar: 'bar' });
     this.rerender({ bar: 'foo' });
   }
 
@@ -505,7 +508,7 @@ class ModifierTests extends RenderTest {
       }
     }
     this.registerModifier('foo', Foo);
-    this.render('<div {{foo baz bar=bar}}></div>', { bar: 'bar', baz: 'baz' });
+    this.render('<div {{foo this.baz bar=this.bar}}></div>', { bar: 'bar', baz: 'baz' });
     this.rerender({ bar: 'foo', baz: 'foo' });
   }
 }

--- a/packages/@glimmer/integration-tests/test/modifiers/on-test.ts
+++ b/packages/@glimmer/integration-tests/test/modifiers/on-test.ts
@@ -202,7 +202,7 @@ if (hasDom) {
     ) {
       let count = 0;
 
-      this.render('<button {{on "click" this.callback once=once}}>Click Me</button>', {
+      this.render('<button {{on "click" this.callback once=this.once}}>Click Me</button>', {
         callback() {
           count++;
         },

--- a/packages/@glimmer/integration-tests/test/partial-test.ts
+++ b/packages/@glimmer/integration-tests/test/partial-test.ts
@@ -577,10 +577,13 @@ class PartialTest extends RenderTest {
   @test
   'dynamic partial with local reference (unknown)'() {
     this.registerPartial('test', `You {{quality}}`);
-    this.render(`{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`, {
-      name: 'test',
-      qualities: ['smaht', 'loyal'],
-    });
+    this.render(
+      `{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`,
+      {
+        name: 'test',
+        qualities: ['smaht', 'loyal'],
+      }
+    );
 
     this.assertStableRerender();
 
@@ -593,10 +596,13 @@ class PartialTest extends RenderTest {
   @test
   'partial with if statement on a simple local reference works as expected'() {
     this.registerPartial('test', `{{#if quality}}You {{quality}}{{else}}No quality{{/if}}`);
-    this.render(`{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`, {
-      name: 'test',
-      qualities: ['smaht', 'loyal', undefined],
-    });
+    this.render(
+      `{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`,
+      {
+        name: 'test',
+        qualities: ['smaht', 'loyal', undefined],
+      }
+    );
 
     this.assertStableRerender();
 
@@ -612,10 +618,13 @@ class PartialTest extends RenderTest {
       'test',
       `{{#if quality.name}}You {{quality.name}}{{else}}No quality{{/if}}`
     );
-    this.render(`{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`, {
-      name: 'test',
-      qualities: [{ name: 'smaht' }, { name: 'loyal' }, { name: undefined }],
-    });
+    this.render(
+      `{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`,
+      {
+        name: 'test',
+        qualities: [{ name: 'smaht' }, { name: 'loyal' }, { name: undefined }],
+      }
+    );
 
     this.assertStableRerender();
 

--- a/packages/@glimmer/integration-tests/test/partial-test.ts
+++ b/packages/@glimmer/integration-tests/test/partial-test.ts
@@ -49,7 +49,7 @@ class PartialTest extends RenderTest {
   @test
   'static partial with local reference'() {
     this.registerPartial('test', `You {{quality.value}}`);
-    this.render(`{{#each qualities key='id' as |quality|}}{{partial 'test'}}. {{/each}}`, {
+    this.render(`{{#each this.qualities key='id' as |quality|}}{{partial 'test'}}. {{/each}}`, {
       qualities: [
         { id: 1, value: 'smaht' },
         { id: 2, value: 'loyal' },
@@ -72,7 +72,7 @@ class PartialTest extends RenderTest {
   @test
   'static partial with local reference (unknown)'() {
     this.registerPartial('test', `You {{quality}}`);
-    this.render(`{{#each qualities key='@index' as |quality|}}{{partial 'test'}}. {{/each}}`, {
+    this.render(`{{#each this.qualities key='@index' as |quality|}}{{partial 'test'}}. {{/each}}`, {
       qualities: ['smaht', 'loyal'],
     });
 
@@ -89,7 +89,7 @@ class PartialTest extends RenderTest {
     this.registerComponent('Glimmer', 'FooBar', `<p>{{@foo}}-{{partial 'test'}}</p>`);
 
     this.registerPartial('test', `{{@foo}}-{{@bar}}`);
-    this.render(`<FooBar @foo={{foo}} @bar={{bar}} />`, { foo: 'foo', bar: 'bar' });
+    this.render(`<FooBar @foo={{this.foo}} @bar={{this.bar}} />`, { foo: 'foo', bar: 'bar' });
     this.assertHTML(`<p>foo-foo-bar</p>`);
 
     this.assertStableRerender();
@@ -340,7 +340,7 @@ class PartialTest extends RenderTest {
   @test
   'dynamic partial with static content'() {
     this.registerPartial('test', `<div>Testing</div>`);
-    this.render(`Before {{partial name}} After`, { name: 'test' });
+    this.render(`Before {{partial this.name}} After`, { name: 'test' });
 
     this.assertHTML(`Before <div>Testing</div> After`);
     this.rerender({ name: 'test' });
@@ -350,10 +350,10 @@ class PartialTest extends RenderTest {
 
   @test
   'nested dynamic partial with dynamic content'() {
-    this.registerPartial('test', `<div>Testing {{wat}} {{partial nest}}</div>`);
-    this.registerPartial('nested', `<div>Nested {{lol}}</div>`);
+    this.registerPartial('test', `<div>Testing {{this.wat}} {{partial this.nest}}</div>`);
+    this.registerPartial('nested', `<div>Nested {{this.lol}}</div>`);
 
-    this.render(`Before {{partial name}} After`, {
+    this.render(`Before {{partial this.name}} After`, {
       name: 'test',
       nest: 'nested',
       wat: 'wat are',
@@ -382,7 +382,7 @@ class PartialTest extends RenderTest {
     );
 
     this.render(
-      `Hi {{person1}}. {{#with 'Sophie' as |person1|}}Hi {{person1}} (aged {{age}}), {{person2}}, {{person3}} and {{person4}}. {{partial 'person2-partial'}}{{/with}}`,
+      `Hi {{this.person1}}. {{#with 'Sophie' as |person1|}}Hi {{person1}} (aged {{this.age}}), {{this.person2}}, {{this.person3}} and {{this.person4}}. {{partial 'person2-partial'}}{{/with}}`,
       {
         person1: 'Context1',
         person2: 'Context2',
@@ -436,7 +436,7 @@ class PartialTest extends RenderTest {
 
   @test
   'dynamic partial with falsy value does not render'() {
-    this.render(`Before {{partial name}} After`, { name: false });
+    this.render(`Before {{partial this.name}} After`, { name: false });
 
     this.assertHTML(`Before <!----> After`);
     this.rerender({ name: false });
@@ -454,7 +454,7 @@ class PartialTest extends RenderTest {
   @test
   'dynamic partial that does not exist does not render'() {
     assert.throws(() => {
-      this.render(`Before {{partial name}} After`, { name: 'illuminati' });
+      this.render(`Before {{partial this.name}} After`, { name: 'illuminati' });
     }, /Could not find a partial named "illuminati"/);
   }
 
@@ -462,7 +462,7 @@ class PartialTest extends RenderTest {
   'dynamic partial with can change from falsy to real template'() {
     this.registerPartial('test', `<div>Testing</div>`);
 
-    this.render(`Before {{partial name}} After`, { name: false });
+    this.render(`Before {{partial this.name}} After`, { name: false });
 
     this.assertHTML(`Before <!----> After`);
     this.rerender({ name: false });
@@ -490,7 +490,7 @@ class PartialTest extends RenderTest {
   @test
   'dynamic partial with self reference'() {
     this.registerPartial('test', `I know {{item}}. I have the best {{item}}s.`);
-    this.render(`{{partial name}}`, { name: 'test', item: 'partial' });
+    this.render(`{{partial this.name}}`, { name: 'test', item: 'partial' });
 
     this.assertHTML(`I know partial. I have the best partials.`);
     this.rerender({ name: 'test', item: 'partial' });
@@ -505,7 +505,7 @@ class PartialTest extends RenderTest {
       'birdman',
       `Respeck my {{item}}. When my {{item}} come up put some respeck on it.`
     );
-    this.render(`{{partial name}}`, { name: 'weezy', item: 'name' });
+    this.render(`{{partial this.name}}`, { name: 'weezy', item: 'name' });
 
     this.assertHTML(`Ain't my birthday but I got my name on the cake.`);
     this.rerender({ name: 'birdman', item: 'name' });
@@ -522,7 +522,7 @@ class PartialTest extends RenderTest {
       'birdman',
       `Respeck my {{item}}. When my {{item}} come up put some respeck on it.`
     );
-    this.render(`{{partial name}}`, { name: 'weezy', item: 'partial' });
+    this.render(`{{partial this.name}}`, { name: 'weezy', item: 'partial' });
 
     this.assertHTML(`Ain't my birthday but I got my partial on the cake.`);
     this.rerender({ name: 'birdman', item: 'name' });
@@ -539,7 +539,7 @@ class PartialTest extends RenderTest {
       'birdman',
       `Respeck my {{noun}}. When my {{noun}} come up put some respeck on it.`
     );
-    this.render(`{{partial name}}`, { name: 'weezy', item: 'partial' });
+    this.render(`{{partial this.name}}`, { name: 'weezy', item: 'partial' });
 
     this.assertHTML(`Ain't my birthday but I got my partial on the cake.`);
     this.rerender({ name: 'birdman', noun: 'name' });
@@ -552,7 +552,7 @@ class PartialTest extends RenderTest {
   @test
   'dynamic partial with local reference'() {
     this.registerPartial('test', `You {{quality.value}}`);
-    this.render(`{{#each qualities key='id' as |quality|}}{{partial name}}. {{/each}}`, {
+    this.render(`{{#each this.qualities key='id' as |quality|}}{{partial this.name}}. {{/each}}`, {
       name: 'test',
       qualities: [
         { id: 1, value: 'smaht' },
@@ -577,7 +577,7 @@ class PartialTest extends RenderTest {
   @test
   'dynamic partial with local reference (unknown)'() {
     this.registerPartial('test', `You {{quality}}`);
-    this.render(`{{#each qualities key='@index' as |quality|}}{{partial name}}. {{/each}}`, {
+    this.render(`{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`, {
       name: 'test',
       qualities: ['smaht', 'loyal'],
     });
@@ -593,7 +593,7 @@ class PartialTest extends RenderTest {
   @test
   'partial with if statement on a simple local reference works as expected'() {
     this.registerPartial('test', `{{#if quality}}You {{quality}}{{else}}No quality{{/if}}`);
-    this.render(`{{#each qualities key='@index' as |quality|}}{{partial name}}. {{/each}}`, {
+    this.render(`{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`, {
       name: 'test',
       qualities: ['smaht', 'loyal', undefined],
     });
@@ -612,7 +612,7 @@ class PartialTest extends RenderTest {
       'test',
       `{{#if quality.name}}You {{quality.name}}{{else}}No quality{{/if}}`
     );
-    this.render(`{{#each qualities key='@index' as |quality|}}{{partial name}}. {{/each}}`, {
+    this.render(`{{#each this.qualities key='@index' as |quality|}}{{partial this.name}}. {{/each}}`, {
       name: 'test',
       qualities: [{ name: 'smaht' }, { name: 'loyal' }, { name: undefined }],
     });

--- a/packages/@glimmer/integration-tests/test/style-warnings-test.ts
+++ b/packages/@glimmer/integration-tests/test/style-warnings-test.ts
@@ -32,7 +32,9 @@ class StyleWarningsTest extends RenderTest {
   @test
   'Standard element with dynamic style and element modifier gives you 1 warning'() {
     this.registerModifier('foo', class {});
-    this.render('<button style={{this.dynAttr}} {{foo}}>click me</button>', { dynAttr: 'display:flex' });
+    this.render('<button style={{this.dynAttr}} {{foo}}>click me</button>', {
+      dynAttr: 'display:flex',
+    });
 
     assert.strictEqual(warnings, 1);
   }

--- a/packages/@glimmer/integration-tests/test/style-warnings-test.ts
+++ b/packages/@glimmer/integration-tests/test/style-warnings-test.ts
@@ -32,7 +32,7 @@ class StyleWarningsTest extends RenderTest {
   @test
   'Standard element with dynamic style and element modifier gives you 1 warning'() {
     this.registerModifier('foo', class {});
-    this.render('<button style={{dynAttr}} {{foo}}>click me</button>', { dynAttr: 'display:flex' });
+    this.render('<button style={{this.dynAttr}} {{foo}}>click me</button>', { dynAttr: 'display:flex' });
 
     assert.strictEqual(warnings, 1);
   }
@@ -47,7 +47,9 @@ class StyleWarningsTest extends RenderTest {
 
   @test
   'triple curlies are trusted'() {
-    this.render(`<div foo={{foo}} style={{{styles}}}>Thing</div>`, { styles: 'background: red' });
+    this.render(`<div foo={{this.foo}} style={{{this.styles}}}>Thing</div>`, {
+      styles: 'background: red',
+    });
 
     assert.strictEqual(warnings, 0);
     this.assertHTML('<div style="background: red">Thing</div>', 'initial render');

--- a/packages/@glimmer/integration-tests/test/updating-content-matrix-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-content-matrix-test.ts
@@ -175,7 +175,7 @@ function generateContentTestCase(
 
 generateContentTestCase(ContentTest, {
   name: 'double curlies',
-  template: '{{value}}',
+  template: '{{this.value}}',
   values: [
     {
       input: 'hello',

--- a/packages/@glimmer/integration-tests/test/updating-modifiers-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-modifiers-test.ts
@@ -30,7 +30,7 @@ class UpdatingModifiers extends RenderTest {
 
     this.registerModifier('foo', makeSyncDataAttrModifier(hooks));
 
-    this.render('<div><div {{foo bar baz=fizz}}></div></div>', {
+    this.render('<div><div {{foo this.bar baz=this.fizz}}></div></div>', {
       bar: 'Super Metroid',
     });
 
@@ -75,7 +75,7 @@ class UpdatingModifiers extends RenderTest {
 
     this.registerModifier('foo', makeSyncDataAttrModifier(hooks));
 
-    this.render('{{#if bar}}<div {{foo bar}}></div>{{else}}<div></div>{{/if}}', {
+    this.render('{{#if this.bar}}<div {{foo this.bar}}></div>{{else}}<div></div>{{/if}}', {
       bar: true,
     });
 

--- a/packages/@glimmer/integration-tests/test/updating-svg-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-svg-test.ts
@@ -52,7 +52,7 @@ class UpdatingSvgTest extends RenderTest {
       }
     };
 
-    this.render('{{#if hasForeignObject}}<foreignObject><div></div></foreignObject>{{/if}}', {
+    this.render('{{#if this.hasForeignObject}}<foreignObject><div></div></foreignObject>{{/if}}', {
       hasForeignObject: true,
     });
 
@@ -187,7 +187,7 @@ class UpdatingSvgTest extends RenderTest {
 
   @test
   'unsafe expression nested inside a namespace'() {
-    this.render('<svg>{{{content}}}</svg><div></div>', {
+    this.render('<svg>{{{this.content}}}</svg><div></div>', {
       content: '<path></path>',
     });
 
@@ -281,7 +281,7 @@ class UpdatingSvgTest extends RenderTest {
 
   @test
   'expression nested inside a namespace'() {
-    this.render('<div><svg>{{content}}</svg></div>', {
+    this.render('<div><svg>{{this.content}}</svg></div>', {
       content: 'Milly',
     });
 
@@ -311,7 +311,7 @@ class UpdatingSvgTest extends RenderTest {
 
   @test
   'expression nested inside a namespaced context.root element'() {
-    this.render('<svg>{{content}}</svg>', { content: 'Maurice' });
+    this.render('<svg>{{this.content}}</svg>', { content: 'Maurice' });
 
     let assertSvg = (callback?: (svg: SVGSVGElement) => void) => {
       if (assertNodeTagName(this.element.firstChild, 'svg')) {
@@ -338,7 +338,7 @@ class UpdatingSvgTest extends RenderTest {
 
   @test
   'HTML namespace is created in child templates'() {
-    this.render('{{#if isTrue}}<svg></svg>{{else}}<div><svg></svg></div>{{/if}}', { isTrue: true });
+    this.render('{{#if this.isTrue}}<svg></svg>{{else}}<div><svg></svg></div>{{/if}}', { isTrue: true });
 
     let assertNamespaces = (isTrue: boolean) => {
       if (isTrue) {
@@ -372,7 +372,7 @@ class UpdatingSvgTest extends RenderTest {
 
   @test
   'HTML namespace is continued to child templates'() {
-    this.render('<div><svg>{{#if isTrue}}<circle />{{/if}}</svg></div>', { isTrue: true });
+    this.render('<div><svg>{{#if this.isTrue}}<circle />{{/if}}</svg></div>', { isTrue: true });
 
     let assertNamespaces = (isTrue: boolean) => {
       if (assertNodeTagName(this.element.firstChild, 'div')) {

--- a/packages/@glimmer/integration-tests/test/updating-svg-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-svg-test.ts
@@ -338,7 +338,9 @@ class UpdatingSvgTest extends RenderTest {
 
   @test
   'HTML namespace is created in child templates'() {
-    this.render('{{#if this.isTrue}}<svg></svg>{{else}}<div><svg></svg></div>{{/if}}', { isTrue: true });
+    this.render('{{#if this.isTrue}}<svg></svg>{{else}}<div><svg></svg></div>{{/if}}', {
+      isTrue: true,
+    });
 
     let assertNamespaces = (isTrue: boolean) => {
       if (isTrue) {

--- a/packages/@glimmer/integration-tests/test/updating-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-test.ts
@@ -1623,9 +1623,12 @@ class UpdatingTest extends RenderTest {
 
   @test
   'The each helper with empty string items'() {
-    this.render(`<ul>{{#each this.list key='@identity' as |item|}}<li>{{item}}</li>{{/each}}</ul>`, {
-      list: [''],
-    });
+    this.render(
+      `<ul>{{#each this.list key='@identity' as |item|}}<li>{{item}}</li>{{/each}}</ul>`,
+      {
+        list: [''],
+      }
+    );
 
     let items = getElementsByTagName(this.element, 'li');
     let lastNode = items[items.length - 1];

--- a/packages/@glimmer/integration-tests/test/updating-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-test.ts
@@ -101,23 +101,23 @@ class UpdatingTest extends RenderTest {
     this.render(
       stripTight`
         <div>
-          [{{[]}}]
-          [{{[1]}}]
-          [{{[undefined]}}]
-          [{{[null]}}]
-          [{{[true]}}]
-          [{{[false]}}]
-          [{{[this]}}]
-          [{{[foo.bar]}}]
+          [{{this.[]}}]
+          [{{this.[1]}}]
+          [{{this.[undefined]}}]
+          [{{this.[null]}}]
+          [{{this.[true]}}]
+          [{{this.[false]}}]
+          [{{this.[this]}}]
+          [{{this.[foo.bar]}}]
 
-          [{{nested.[]}}]
-          [{{nested.[1]}}]
-          [{{nested.[undefined]}}]
-          [{{nested.[null]}}]
-          [{{nested.[true]}}]
-          [{{nested.[false]}}]
-          [{{nested.[this]}}]
-          [{{nested.[foo.bar]}}]
+          [{{this.nested.[]}}]
+          [{{this.nested.[1]}}]
+          [{{this.nested.[undefined]}}]
+          [{{this.nested.[null]}}]
+          [{{this.nested.[true]}}]
+          [{{this.nested.[false]}}]
+          [{{this.nested.[this]}}]
+          [{{this.nested.[foo.bar]}}]
         </div>
       `,
       state
@@ -893,7 +893,7 @@ class UpdatingTest extends RenderTest {
 
     const person = { name: new Name('Godfrey', 'Chan') };
 
-    this.render('<div>{{#with person.name.first as |f|}}{{f}}{{/with}}</div>', {
+    this.render('<div>{{#with this.person.name.first as |f|}}{{f}}{{/with}}</div>', {
       person,
     });
 
@@ -920,6 +920,7 @@ class UpdatingTest extends RenderTest {
 
   @test
   'block arguments should have higher precedence than helpers'() {
+    // Note: This test intentionally tests property fallback
     this.registerHelper('foo', () => 'foo-helper');
     this.registerHelper('bar', () => 'bar-helper');
     this.registerHelper('echo', (args) => args[0]);
@@ -931,17 +932,17 @@ class UpdatingTest extends RenderTest {
         value: "{{this.value}}";
         echo foo: "{{echo foo}}";
         echo bar: "{{echo bar}}";
-        echo value: "{{echo value}}";
+        echo value: "{{echo this.value}}";
 
         -----
 
-        {{#with value as |foo|}}
+        {{#with this.value as |foo|}}
           foo: "{{foo}}";
           bar: "{{bar}}";
           value: "{{this.value}}";
           echo foo: "{{echo foo}}";
           echo bar: "{{echo bar}}";
-          echo value: "{{echo value}}";
+          echo value: "{{echo this.value}}";
 
           -----
 
@@ -951,19 +952,19 @@ class UpdatingTest extends RenderTest {
             value: "{{this.value}}";
             echo foo: "{{echo foo}}";
             echo bar: "{{echo bar}}";
-            echo value: "{{echo value}}";
+            echo value: "{{echo this.value}}";
           {{/with}}
         {{/with}}
 
         -----
 
-        {{#with value as |bar|}}
+        {{#with this.value as |bar|}}
           foo: "{{foo}}";
           bar: "{{bar}}";
           value: "{{this.value}}";
           echo foo: "{{echo foo}}";
           echo bar: "{{echo bar}}";
-          echo value: "{{echo value}}";
+          echo value: "{{echo this.value}}";
         {{/with}}
       </div>
     `;
@@ -1100,7 +1101,7 @@ class UpdatingTest extends RenderTest {
   @test
   'block arguments (ensure balanced push/pop)'() {
     let person = { name: { first: 'Godfrey', last: 'Chan' } };
-    this.render('<div>{{#with person.name.first as |f|}}{{f}}{{/with}}{{f}}</div>', {
+    this.render('<div>{{#with this.person.name.first as |f|}}{{f}}{{/with}}{{f}}</div>', {
       person,
       f: 'Outer',
     });
@@ -1120,9 +1121,9 @@ class UpdatingTest extends RenderTest {
     this.render(
       stripTight`
         <div>
-          [{{#with person as |name|}}{{this.name}}{{/with}}]
-          [{{#with person as |name|}}{{#with this.name as |test|}}{{test}}{{/with}}{{/with}}]
-          [{{#with person as |name|}}{{#with (noop this.name) as |test|}}{{test}}{{/with}}{{/with}}]
+          [{{#with this.person as |name|}}{{this.name}}{{/with}}]
+          [{{#with this.person as |name|}}{{#with this.name as |test|}}{{test}}{{/with}}{{/with}}]
+          [{{#with this.person as |name|}}{{#with (noop this.name) as |test|}}{{test}}{{/with}}{{/with}}]
         </div>
       `,
       { person: 'Yehuda', name: 'Godfrey' }
@@ -1140,7 +1141,7 @@ class UpdatingTest extends RenderTest {
 
   @test
   'The with helper should consider an empty array truthy'() {
-    this.render('<div>{{#with condition as |c|}}{{c.length}}{{/with}}</div>', {
+    this.render('<div>{{#with this.condition as |c|}}{{c.length}}{{/with}}</div>', {
       condition: [],
     });
 
@@ -1202,7 +1203,7 @@ class UpdatingTest extends RenderTest {
       return;
     });
 
-    this.render('<div>{{capitalize value}}</div>', { value: 'hello' });
+    this.render('<div>{{capitalize this.value}}</div>', { value: 'hello' });
     this.assertHTML('<div>HELLO</div>');
 
     this.rerender({
@@ -1374,7 +1375,7 @@ class UpdatingTest extends RenderTest {
 
   @test
   'non-standard namespaced attribute nodes follow the normal dirtying rules'() {
-    this.render("<div epub:type='{{type}}'>hello</div>", { type: 'dedication' });
+    this.render("<div epub:type='{{this.type}}'>hello</div>", { type: 'dedication' });
     this.assertHTML("<div epub:type='dedication'>hello</div>", 'Initial render');
 
     this.rerender({ type: 'backmatter' });
@@ -1384,7 +1385,7 @@ class UpdatingTest extends RenderTest {
 
   @test
   'non-standard namespaced attribute nodes w/ concat follow the normal dirtying rules'() {
-    this.render("<div epub:type='dedication {{type}}'>hello</div>", { type: 'backmatter' });
+    this.render("<div epub:type='dedication {{this.type}}'>hello</div>", { type: 'backmatter' });
 
     this.assertHTML("<div epub:type='dedication backmatter'>hello</div>", 'Initial render');
     this.assertStableRerender();
@@ -1419,11 +1420,11 @@ class UpdatingTest extends RenderTest {
     let template = stripTight`
       <select multiple>
         <option>0</option>
-        <option selected={{one}}>1</option>
-        <option selected={{two}}>2</option>
-        <option selected={{three}}>3</option>
-        <option selected={{four}}>4</option>
-        <option selected={{five}}>5</option>
+        <option selected={{this.one}}>1</option>
+        <option selected={{this.two}}>2</option>
+        <option selected={{this.three}}>3</option>
+        <option selected={{this.four}}>4</option>
+        <option selected={{this.five}}>5</option>
       </select>
     `;
 
@@ -1516,7 +1517,7 @@ class UpdatingTest extends RenderTest {
     let tom = { key: '1', name: 'Tom Dale', class: 'tomdale' };
     let yehuda = { key: '2', name: 'Yehuda Katz', class: 'wycats' };
 
-    this.render("{{#each list key='key' as |item|}}{{item.name}}{{/each}}", {
+    this.render("{{#each this.list key='key' as |item|}}{{item.name}}{{/each}}", {
       list: [tom, yehuda],
     });
     this.assertInvariants('initial render');
@@ -1539,7 +1540,7 @@ class UpdatingTest extends RenderTest {
     let tom = { name: 'Tom Dale' };
     let yehuda = { name: 'Yehuda Katz' };
 
-    this.render('{{#if item}}{{item.name}}{{/if}}', { item: tom });
+    this.render('{{#if this.item}}{{this.item.name}}{{/if}}', { item: tom });
     this.assertInvariants('initial render');
 
     this.rerender();
@@ -1573,7 +1574,7 @@ class UpdatingTest extends RenderTest {
     let yehuda = { key: '2', name: 'Yehuda Katz', class: 'wycats' };
 
     this.render(
-      "<ul>{{#each list key='key' as |item|}}<li class='{{item.class}}'>{{item.name}}</li>{{/each}}</ul>",
+      "<ul>{{#each this.list key='key' as |item|}}<li class='{{item.class}}'>{{item.name}}</li>{{/each}}</ul>",
       { list: [tom, yehuda] }
     );
 
@@ -1622,7 +1623,7 @@ class UpdatingTest extends RenderTest {
 
   @test
   'The each helper with empty string items'() {
-    this.render(`<ul>{{#each list key='@identity' as |item|}}<li>{{item}}</li>{{/each}}</ul>`, {
+    this.render(`<ul>{{#each this.list key='@identity' as |item|}}<li>{{item}}</li>{{/each}}</ul>`, {
       list: [''],
     });
 
@@ -1647,7 +1648,7 @@ class UpdatingTest extends RenderTest {
   @test
   'The each helper with else'() {
     this.render(
-      `<ul>{{#each list key='name' as |item|}}<li class="{{item.class}}">{{item.name}}</li>{{else}}<li class="none">none</li>{{/each}}</ul>`,
+      `<ul>{{#each this.list key='name' as |item|}}<li class="{{item.class}}">{{item.name}}</li>{{else}}<li class="none">none</li>{{/each}}</ul>`,
       {
         list: [],
       }
@@ -1687,7 +1688,7 @@ class UpdatingTest extends RenderTest {
     let yehuda = { name: 'Yehuda Katz', class: 'wycats' };
 
     this.render(
-      "<ul>{{#each list key='@index' as |item index|}}<li class='{{item.class}}'>{{item.name}}<p class='index-{{index}}'>{{index}}</p></li>{{/each}}</ul>",
+      "<ul>{{#each this.list key='@index' as |item index|}}<li class='{{item.class}}'>{{item.name}}<p class='index-{{index}}'>{{index}}</p></li>{{/each}}</ul>",
       { list: [tom, yehuda] }
     );
 
@@ -1846,7 +1847,7 @@ class UpdatingTest extends RenderTest {
     let yehuda = { key: '2', name: 'Yehuda Katz', class: 'wycats' };
 
     this.render(
-      "<ul>{{#each list key='key' as |item index|}}<li class='{{item.class}}'>{{item.name}}<p class='index-{{index}}'>{{index}}</p></li>{{/each}}</ul>",
+      "<ul>{{#each this.list key='key' as |item index|}}<li class='{{item.class}}'>{{item.name}}<p class='index-{{index}}'>{{index}}</p></li>{{/each}}</ul>",
       { list: [tom, yehuda] }
     );
 

--- a/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
+++ b/packages/@glimmer/syntax/test/traversal/visiting-node-test.ts
@@ -36,7 +36,9 @@ function traversalEqual(node: AST.Node, expectedTraversal: Array<[string, AST.Ba
 QUnit.module('[glimmer-syntax] Traversal - visiting');
 
 test('Elements and attributes', function () {
-  let ast = parse(`<div id="id" class="large {{classes}}" value={{value}}><b></b><b></b></div>`);
+  let ast = parse(
+    `<div id="id" class="large {{this.classes}}" value={{this.value}}><b></b><b></b></div>`
+  );
   let el = ast.body[0] as AST.ElementNode;
   let concat = el.attributes[1].value as AST.ConcatStatement;
   let concatMustache = concat.parts[1] as AST.MustacheStatement;


### PR DESCRIPTION
Removes usages of property fallback from all tests, except tests which
are explicitly testing this functionality.