### PR TITLE
Omit scope property from precompiled templates in loose mode

### DIFF
--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -122,6 +122,10 @@ export function precompile(
     isStrictMode: options.strictMode ?? false,
   };
 
+  if (!options.strictMode) {
+    delete templateJSONObject.scope;
+  }
+
   // JSON is javascript
   let stringified = JSON.stringify(templateJSONObject);
 

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -518,7 +518,7 @@ export interface SerializedTemplateWithLazyBlock {
   id?: Option<string>;
   block: SerializedTemplateBlockJSON;
   moduleName: string;
-  scope: (() => unknown[]) | null;
+  scope: (() => unknown[]) | undefined | null;
   isStrictMode: boolean;
 }
 

--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -17,7 +17,7 @@ export interface LayoutWithContext {
   readonly block: SerializedTemplateBlock;
   readonly moduleName: string;
   readonly owner: Owner | null;
-  readonly scope: (() => unknown[]) | null;
+  readonly scope: (() => unknown[]) | undefined | null;
   readonly isStrictMode: boolean;
   readonly asPartial: boolean;
 }


### PR DESCRIPTION
An older version of babel-plugin-htmlbars-inline-precompile errors if the resulting JSON includes `null`, this avoids that issue by not emitting `scope: null` when strict mode is disabled.

Related to https://github.com/emberjs/ember.js/issues/19331