### PR TITLE
Make defaultId function more robust

### DIFF
--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -23,10 +23,12 @@ interface Crypto {
 }
 
 export const defaultId: TemplateIdFn = (() => {
-  if (typeof require === 'function') {
+  let req: typeof require | undefined =
+    typeof module === 'object' && typeof module.require === 'function' ? module.require : require;
+
+  if (req) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-      const crypto = require('crypto');
+      const crypto = req('crypto');
 
       let idFn: TemplateIdFn = (src) => {
         let hash = crypto.createHash('sha1');


### PR DESCRIPTION
The current `defaultId` function for templates attempts to load the `crypto` module
when in Node. However, it uses `require` directly, which may be
clobbered by AMD require (in the case of Ember). This was previously
handled by using Babel transforms, but that solution is somewhat
brittle. This updates the logic to check for the `module` global
instead, and defers to it if it exists, before checking for `require`.