### PR TITLE
Removes id from templates

### DIFF
--- a/packages/@glimmer/compiler/index.ts
+++ b/packages/@glimmer/compiler/index.ts
@@ -1,4 +1,4 @@
-export { defaultId, precompile, precompileJSON, PrecompileOptions } from './lib/compiler';
+export { precompile, precompileJSON, PrecompileOptions } from './lib/compiler';
 export {
   ProgramSymbols,
   buildStatement,

--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -4,51 +4,11 @@ import {
   TemplateJavascript,
 } from '@glimmer/interfaces';
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
-import { normalize, PrecompileOptions, Source, TemplateIdFn } from '@glimmer/syntax';
+import { normalize, PrecompileOptions, Source } from '@glimmer/syntax';
 import { LOCAL_LOGGER } from '@glimmer/util';
 
 import pass0 from './passes/1-normalization/index';
 import { visit as pass2 } from './passes/2-encoding/index';
-
-declare function require(id: 'crypto'): Crypto;
-declare function require(id: string): unknown;
-
-interface Crypto {
-  createHash(
-    alg: 'sha1'
-  ): {
-    update(src: string, encoding: 'utf8'): void;
-    digest(encoding: 'base64'): string;
-  };
-}
-
-export const defaultId: TemplateIdFn = (() => {
-  if (typeof require === 'function') {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-      const crypto = require('crypto');
-
-      let idFn: TemplateIdFn = (src) => {
-        let hash = crypto.createHash('sha1');
-        hash.update(src, 'utf8');
-        // trim to 6 bytes of data (2^48 - 1)
-        return hash.digest('base64').substring(0, 8);
-      };
-
-      idFn('test');
-
-      return idFn;
-    } catch (e) {}
-  }
-
-  return function idFn() {
-    return null;
-  };
-})();
-
-const defaultOptions: PrecompileOptions = {
-  id: defaultId,
-};
 
 /*
  * Compile a string into a template javascript string.
@@ -66,7 +26,7 @@ const defaultOptions: PrecompileOptions = {
  */
 export function precompileJSON(
   string: string,
-  options: PrecompileOptions = defaultOptions
+  options: PrecompileOptions = {}
 ): [block: SerializedTemplateBlock, usedLocals: string[]] {
   let source = new Source(string, options.meta?.moduleName);
   let [ast, locals] = normalize(source, options);
@@ -103,17 +63,12 @@ const SCOPE_PLACEHOLDER = '796d24e6-2450-4fb0-8cdf-b65638b5ef70';
  * @param {string} string a Glimmer template string
  * @return {string} a template javascript string
  */
-export function precompile(
-  source: string,
-  options: PrecompileOptions = defaultOptions
-): TemplateJavascript {
+export function precompile(source: string, options: PrecompileOptions = {}): TemplateJavascript {
   let [block, usedLocals] = precompileJSON(source, options);
 
   let moduleName = options.meta?.moduleName;
-  let idFn = options.id || defaultId;
   let blockJSON = JSON.stringify(block);
   let templateJSONObject: SerializedTemplateWithLazyBlock = {
-    id: idFn(JSON.stringify(options.meta) + blockJSON),
     block: blockJSON,
     moduleName: moduleName ?? '(unknown template module)',
     // lying to the type checker here because we're going to

--- a/packages/@glimmer/integration-tests/lib/compile.ts
+++ b/packages/@glimmer/integration-tests/lib/compile.ts
@@ -10,8 +10,6 @@ export function preprocess(templateSource: string, options?: PrecompileOptions):
   return createTemplate(templateSource, options)({});
 }
 
-let templateId = 0;
-
 export function createTemplate(
   templateSource: string,
   options: PrecompileOptions = {},
@@ -22,7 +20,6 @@ export function createTemplate(
   let reifiedScopeValues = usedLocals.map((key) => scopeValues[key]);
 
   let templateBlock: SerializedTemplateWithLazyBlock = {
-    id: String(templateId++),
     block: JSON.stringify(block),
     moduleName: options.meta?.moduleName ?? '(unknown template module)',
     scope: reifiedScopeValues.length > 0 ? () => reifiedScopeValues : null,

--- a/packages/@glimmer/integration-tests/lib/suites/custom-dom-helper.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/custom-dom-helper.ts
@@ -1,12 +1,10 @@
 import { AbstractNodeTest, NodeJitRenderDelegate } from '../modes/node/env';
 import { test } from '../test-decorator';
 import { NodeDOMTreeConstruction, serializeBuilder } from '@glimmer/node';
-import { RenderTest } from '../render-test';
 import { Environment, Cursor, ElementBuilder } from '@glimmer/interfaces';
 import { blockStack } from '../dom/blocks';
 import { strip } from '../test-helpers/strings';
 import { toInnerHTML } from '../dom/simple-utils';
-import { precompile } from '@glimmer/compiler';
 
 export class DOMHelperTests extends AbstractNodeTest {
   static suiteName = 'Server-side rendering in Node.js (normal)';
@@ -18,20 +16,6 @@ export class DOMHelperTests extends AbstractNodeTest {
     let helper = new NodeDOMTreeConstruction(null as any);
 
     this.assert.ok(!!helper, 'helper was instantiated without errors');
-  }
-}
-
-export class CompilationTests extends RenderTest {
-  static suiteName = 'Id generation';
-
-  @test
-  'generates id in node'() {
-    let template = precompile('hello');
-    let obj = JSON.parse(template);
-    this.assert.equal(obj.id, 'G0ggkEjw', 'short sha of template source');
-    template = precompile('hello', { meta: { moduleName: 'template/hello' } });
-    obj = JSON.parse(template);
-    this.assert.equal(obj.id, '4vC0bnaR', 'short sha of template source and meta');
   }
 }
 

--- a/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
@@ -3,14 +3,14 @@ import { preprocess } from '../..';
 import { module } from '../support';
 import { unwrapTemplate, assert as glimmerAssert } from '@glimmer/util';
 import { SexpOpcodes, WireFormat } from '@glimmer/interfaces';
-import { TemplateWithIdAndReferrer } from '@glimmer/opcode-compiler';
+import { TemplateWithReferrer } from '@glimmer/opcode-compiler';
 
 module('[glimmer-compiler] Compile options', ({ test }) => {
   test('moduleName option is passed into meta', (assert) => {
     let moduleName = "It ain't hard to tell";
     let template = unwrapTemplate(
       preprocess('Hi, {{name}}!', { meta: { moduleName } })
-    ) as TemplateWithIdAndReferrer;
+    ) as TemplateWithReferrer;
     assert.equal(template.referrer.moduleName, moduleName, 'Template has the moduleName');
   });
 });

--- a/packages/@glimmer/integration-tests/test/node-suites-node-test.ts
+++ b/packages/@glimmer/integration-tests/test/node-suites-node-test.ts
@@ -8,7 +8,6 @@ import {
   NodeJitRenderDelegate,
   SerializedDOMHelperTests,
   JitSerializationDelegate,
-  CompilationTests,
 } from '..';
 
 nodeSuite(ServerSideSuite);
@@ -16,7 +15,3 @@ nodeComponentSuite(ServerSideComponentSuite);
 
 suite(DOMHelperTests, NodeJitRenderDelegate);
 suite(SerializedDOMHelperTests, JitSerializationDelegate);
-
-if (typeof process !== 'undefined') {
-  suite(CompilationTests, NodeJitRenderDelegate);
-}

--- a/packages/@glimmer/integration-tests/test/precompile-test.ts
+++ b/packages/@glimmer/integration-tests/test/precompile-test.ts
@@ -3,12 +3,11 @@ import { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
 import { unwrapTemplate } from '@glimmer/util';
 import {
   templateFactory,
-  TemplateFactoryWithIdAndMeta,
-  TemplateWithIdAndReferrer,
+  TemplateFactoryWithMeta,
+  TemplateWithReferrer,
 } from '@glimmer/opcode-compiler';
 
 let serializedTemplate: SerializedTemplateWithLazyBlock;
-let serializedTemplateNoId: SerializedTemplateWithLazyBlock;
 
 QUnit.module('templateFactory', {
   beforeEach() {
@@ -16,46 +15,17 @@ QUnit.module('templateFactory', {
       meta: { moduleName: 'template/module/name' },
     });
     serializedTemplate = JSON.parse(templateJs);
-    serializedTemplate.id = 'server-id-1';
-
-    serializedTemplateNoId = JSON.parse(templateJs);
-    serializedTemplateNoId.id = null;
   },
 });
 
-QUnit.test('id of serialized template is exposed on the factory', (assert) => {
-  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithIdAndMeta;
-  assert.ok(factory.__id, 'is present');
-  assert.equal(factory.__id, serializedTemplate.id, 'id matches serialized template id');
-});
-
-QUnit.test('generates id if no id is on the serialized template', (assert) => {
-  let factory1 = templateFactory(serializedTemplateNoId) as TemplateFactoryWithIdAndMeta;
-  let factory2 = templateFactory(serializedTemplateNoId) as TemplateFactoryWithIdAndMeta;
-  assert.ok(factory1.__id, 'is present');
-  assert.ok(factory2.__id, 'is present');
-  assert.notEqual(
-    factory1.__id,
-    factory2.__id,
-    'factories without underlying id create new id per factory'
-  );
-});
-
-QUnit.test('id of template matches factory', (assert) => {
-  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithIdAndMeta;
-  let template = unwrapTemplate(factory()) as TemplateWithIdAndReferrer;
-  assert.ok(template.id, 'is present');
-  assert.equal(template.id, factory.__id, 'template id matches factory id');
-});
-
 QUnit.test('meta is accessible from factory', (assert) => {
-  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithIdAndMeta;
+  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithMeta;
   assert.deepEqual(factory.__meta, { moduleName: 'template/module/name' });
 });
 
 QUnit.test('meta is accessible from template', (assert) => {
   let factory = templateFactory(serializedTemplate);
-  let template = unwrapTemplate(factory()) as TemplateWithIdAndReferrer;
+  let template = unwrapTemplate(factory()) as TemplateWithReferrer;
   assert.deepEqual(
     template.referrer,
     { moduleName: 'template/module/name', owner: null },
@@ -67,7 +37,7 @@ QUnit.test('can inject owner into template', (assert) => {
   let owner = {};
   let factory = templateFactory(serializedTemplate);
 
-  let template = unwrapTemplate(factory(owner)) as TemplateWithIdAndReferrer;
+  let template = unwrapTemplate(factory(owner)) as TemplateWithReferrer;
 
   assert.strictEqual(template.referrer.owner, owner, 'is owner');
   assert.deepEqual(

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -515,7 +515,6 @@ export type SerializedTemplateBlockJSON = string;
  * A JSON object containing the SerializedTemplateBlock as JSON and TemplateMeta.
  */
 export interface SerializedTemplateWithLazyBlock {
-  id?: Option<string>;
   block: SerializedTemplateBlockJSON;
   moduleName: string;
   scope: (() => unknown[]) | undefined | null;

--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -13,7 +13,6 @@ export interface CompilableProgram extends CompilableTemplate<ProgramSymbolTable
 export type CompilableBlock = CompilableTemplate<BlockSymbolTable>;
 
 export interface LayoutWithContext {
-  readonly id: string;
   readonly block: SerializedTemplateBlock;
   readonly moduleName: string;
   readonly owner: Owner | null;

--- a/packages/@glimmer/opcode-compiler/index.ts
+++ b/packages/@glimmer/opcode-compiler/index.ts
@@ -21,8 +21,8 @@ export { PartialDefinitionImpl } from './lib/partial-template';
 export {
   default as templateFactory,
   templateCacheCounters,
-  TemplateFactoryWithIdAndMeta,
-  TemplateWithIdAndReferrer,
+  TemplateFactoryWithMeta,
+  TemplateWithReferrer,
 } from './lib/template';
 
 export { WrappedBuilder } from './lib/wrapped-component';

--- a/packages/@glimmer/opcode-compiler/lib/template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/template.ts
@@ -13,21 +13,17 @@ import { assign } from '@glimmer/util';
 import { compilable } from './compilable-template';
 import { WrappedBuilder } from './wrapped-component';
 
-let clientId = 0;
-
 export let templateCacheCounters = {
   cacheHit: 0,
   cacheMiss: 0,
 };
 
 // These interfaces are for backwards compatibility, some addons use these intimate APIs
-export interface TemplateFactoryWithIdAndMeta extends TemplateFactory {
-  __id?: string;
+export interface TemplateFactoryWithMeta extends TemplateFactory {
   __meta?: { moduleName: string };
 }
 
-export interface TemplateWithIdAndReferrer extends TemplateOk {
-  id: string;
+export interface TemplateWithReferrer extends TemplateOk {
   referrer: {
     moduleName: string;
     owner: Owner | null;
@@ -40,16 +36,11 @@ export interface TemplateWithIdAndReferrer extends TemplateOk {
  * of the template.
  */
 export default function templateFactory({
-  id: templateId,
   moduleName,
   block,
   scope,
   isStrictMode,
 }: SerializedTemplateWithLazyBlock): TemplateFactory {
-  // TODO(template-refactors): This should be removed in the near future, as it
-  // appears that id is unused. It is currently kept for backwards compat reasons.
-  let id = templateId || `client-${clientId++}`;
-
   // TODO: This caches JSON serialized output once in case a template is
   // compiled by multiple owners, but we haven't verified if this is actually
   // helpful. We should benchmark this in the future.
@@ -58,7 +49,7 @@ export default function templateFactory({
   let ownerlessTemplate: Template | null = null;
   let templateCache = new WeakMap<object, Template>();
 
-  let factory: TemplateFactoryWithIdAndMeta = (owner?: Owner) => {
+  let factory: TemplateFactoryWithMeta = (owner?: Owner) => {
     if (parsedBlock === undefined) {
       parsedBlock = JSON.parse(block);
     }
@@ -67,7 +58,6 @@ export default function templateFactory({
       if (ownerlessTemplate === null) {
         templateCacheCounters.cacheMiss++;
         ownerlessTemplate = new TemplateImpl({
-          id,
           block: parsedBlock,
           moduleName,
           owner: null,
@@ -85,7 +75,7 @@ export default function templateFactory({
 
     if (result === undefined) {
       templateCacheCounters.cacheMiss++;
-      result = new TemplateImpl({ id, block: parsedBlock, moduleName, owner, scope, isStrictMode });
+      result = new TemplateImpl({ block: parsedBlock, moduleName, owner, scope, isStrictMode });
       templateCache.set(owner, result);
     } else {
       templateCacheCounters.cacheHit++;
@@ -94,13 +84,12 @@ export default function templateFactory({
     return result;
   };
 
-  factory.__id = id;
   factory.__meta = { moduleName };
 
   return factory;
 }
 
-class TemplateImpl implements TemplateWithIdAndReferrer {
+class TemplateImpl implements TemplateWithReferrer {
   readonly result = 'ok';
 
   private layout: Option<CompilableProgram> = null;
@@ -111,10 +100,6 @@ class TemplateImpl implements TemplateWithIdAndReferrer {
 
   get moduleName() {
     return this.parsedLayout.moduleName;
-  }
-
-  get id() {
-    return this.parsedLayout.id;
   }
 
   // TODO(template-refactors): This should be removed in the near future, it is

--- a/packages/@glimmer/program/lib/util/default-template.ts
+++ b/packages/@glimmer/program/lib/util/default-template.ts
@@ -15,8 +15,6 @@ const DEFAULT_TEMPLATE_BLOCK: SerializedTemplateBlock = [
 ];
 
 export const DEFAULT_TEMPLATE: SerializedTemplateWithLazyBlock = {
-  // random uuid
-  id: '1b32f5c2-7623-43d6-a0ad-9672898920a1',
   moduleName: '__default__.hbs',
   block: JSON.stringify(DEFAULT_TEMPLATE_BLOCK),
   scope: null,

--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -11,7 +11,6 @@ export {
   ASTPluginBuilder,
   ASTPluginEnvironment,
   Syntax,
-  TemplateIdFn,
   PrecompileOptions,
 } from './lib/parser/tokenizer-event-handlers';
 export { default as print } from './lib/generation/print';

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -1,4 +1,3 @@
-import { Option } from '@glimmer/interfaces';
 import { assertPresent, assign } from '@glimmer/util';
 import { parse, parseWithoutProcessing } from '@handlebars/parser';
 import { EntityParser } from 'simple-html-tokenizer';
@@ -334,12 +333,7 @@ interface HandlebarsParseOptions {
   ignoreStandalone?: boolean;
 }
 
-export interface TemplateIdFn {
-  (src: string): Option<string>;
-}
-
 export interface PrecompileOptions extends PreprocessOptions {
-  id?: TemplateIdFn;
   customizeComponentName?(input: string): string;
 }
 


### PR DESCRIPTION
The template id was previously used for pre-IE11 support, before
Maps/WeakMaps existed and so a string ID was needed for templates. Now
it's no longer used, so this PR removes it for the time being.