### PR TITLE
[BUGFIX] Ensure owner is available during resolution for all components

### DIFF
--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -109,16 +109,16 @@ export interface ResolutionTimeConstants {
   ): number | null;
   modifier(definitionState: ModifierDefinitionState, resolvedName?: string | null): number;
 
-  component(definitionState: ComponentDefinitionState): ComponentDefinition;
   component(
     definitionState: ComponentDefinitionState,
-    isOptional: true
-  ): ComponentDefinition | null;
-  component(
-    definitionState: ComponentDefinitionState,
-    isOptional: false,
-    owner: Owner
+    owner: object,
+    isOptional?: false
   ): ComponentDefinition;
+  component(
+    definitionState: ComponentDefinitionState,
+    owner: object,
+    isOptional?: boolean
+  ): ComponentDefinition | null;
 
   resolvedComponent(
     definitionState: ResolvedComponentDefinition,

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -101,12 +101,17 @@ export function resolveComponent(
   }
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues } = meta;
+    let { scopeValues, owner } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
-    then(constants.component(definition as object));
+    then(
+      constants.component(
+        definition as object,
+        expect(owner, 'BUG: expected owner when resolving component definition')
+      )
+    );
   } else {
     let { upvars, owner } = assertResolverInvariants(meta);
 
@@ -230,12 +235,16 @@ export function resolveComponentOrHelper(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues } = meta;
+    let { scopeValues, owner } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
-    let component = constants.component(definition as object, true);
+    let component = constants.component(
+      definition as object,
+      expect(owner, 'BUG: expected owner when resolving component definition'),
+      true
+    );
 
     if (component !== null) {
       ifComponent(component);
@@ -324,7 +333,7 @@ export function resolveOptionalComponentOrHelper(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetTemplateSymbol) {
-    let { scopeValues } = meta;
+    let { scopeValues, owner } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
@@ -338,7 +347,11 @@ export function resolveOptionalComponentOrHelper(
       return;
     }
 
-    let component = constants.component(definition, true);
+    let component = constants.component(
+      definition,
+      expect(owner, 'BUG: expected owner when resolving component definition'),
+      true
+    );
 
     if (component !== null) {
       ifComponent(component);

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -196,15 +196,11 @@ export class ConstantsImpl
     return handle;
   }
 
-  component(definitionState: ComponentDefinitionState): ComponentDefinition;
+  component(definitionState: ComponentDefinitionState, owner: object): ComponentDefinition;
   component(
     definitionState: ComponentDefinitionState,
-    isOptional: true
-  ): ComponentDefinition | null;
-  component(
-    definitionState: ComponentDefinitionState,
-    isOptional?: true,
-    owner?: object
+    owner: object,
+    isOptional?: true
   ): ComponentDefinition | null {
     let definition = this.componentDefinitionCache.get(definitionState);
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -155,7 +155,7 @@ APPEND_OPCODES.add(Op.ResolveDynamicComponent, (vm, { op1: _isStrict }) => {
   } else if (isCurriedValue(component)) {
     definition = component;
   } else {
-    definition = constants.component(component);
+    definition = constants.component(component, owner);
   }
 
   stack.pushJs(definition);
@@ -178,7 +178,7 @@ APPEND_OPCODES.add(Op.ResolveCurriedComponent, (vm) => {
   if (isCurriedValue(value)) {
     definition = value;
   } else {
-    definition = constants.component(value as object, true);
+    definition = constants.component(value as object, vm.getOwner(), true);
 
     if (DEBUG && definition === null) {
       throw new Error(
@@ -266,7 +266,7 @@ APPEND_OPCODES.add(Op.PrepareArgs, (vm, { op1: _state }) => {
         value
       );
     } else {
-      definition = constants.component(value);
+      definition = constants.component(value, owner);
     }
 
     let { manager } = definition;

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -80,7 +80,7 @@ function renderInvocation(
   // Prefix argument names with `@` symbol
   const argNames = argList.map(([name]) => `@${name}`);
 
-  let reified = vm[CONSTANTS].component(definition, false, owner);
+  let reified = vm[CONSTANTS].component(definition, owner);
 
   vm.pushFrame();
 


### PR DESCRIPTION
Previously, strict components were not passed an owner when they were
defined. This turned out to be incorrect, because even if strict
components did not use an owner to resolve components, the components
that they used in scope could potentially be non-strict, and resolve
components. Those components effectively become different components
based on the currently active owner, so we have to pass the owner no
matter what type of component we are rendering.