### PR TITLE
Add test for `{{array.[0]}}` with the printer

### DIFF
--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -55,6 +55,9 @@ let templates = [
 
   // unescaped
   '{{{unescaped}}}',
+  
+  // odd handlebars syntax
+  '{{array.[0]}}',
 ];
 
 QUnit.module('[glimmer-syntax] Code generation', function () {


### PR DESCRIPTION
Currently using `{{array.[0]}}` parses and "functions" when used in a template, but the printer does not support this syntax.

Ultimately, we should either throw an error for this syntax _or_ support it in the printer.