### PR TITLE
[BUGFIX] Fix reactivity of dynamic attributes

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -544,7 +544,7 @@ function setDeferredAttr(
       .elements()
       .setDynamicAttribute(name, valueForRef(value), trusting, namespace);
     if (!isConstRef(value)) {
-      vm.updateWith(new UpdateDynamicAttributeOpcode(value, attribute));
+      vm.updateWith(new UpdateDynamicAttributeOpcode(value, attribute, vm.env));
     }
   }
 }


### PR DESCRIPTION
The updates to use autotracking through the VM resulted in a bug in
dynamic attributes. Previously, the updating opcode for dynamic
attributes would run its update function based on tags/autotracking -
whenever any tag updated (e.g. a tracked value was changed) the
attribute would call its `update` function. The `update` function would
then check the new value against the current value of the attribute, and
update if they were different.

The bug was we introduced a value comparison in the updating opcode
itself, based on the last value of the property to set the attribute to.
This meant that if the property was updated to the same value twice in
a row, it would not call `update`, even if the attribute's value had
changed (e.g. because the user typed something).

Fixes https://github.com/emberjs/ember.js/issues/19341