### PR TITLE
Ensure inline `if` returns `undefined` when no falsey value is provided

### DIFF
--- a/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
@@ -146,12 +146,13 @@ export class ExpressionEncoder {
   }
 
   IfInline({ condition, truthy, falsy }: mir.IfInline): WireFormat.Expressions.IfInline {
-    return [
-      SexpOpcodes.IfInline,
-      EXPR.expr(condition),
-      EXPR.expr(truthy),
-      falsy ? EXPR.expr(falsy) : null,
-    ];
+    let expr = [SexpOpcodes.IfInline, EXPR.expr(condition), EXPR.expr(truthy)];
+
+    if (falsy) {
+      expr.push(EXPR.expr(falsy));
+    }
+
+    return expr as WireFormat.Expressions.IfInline;
   }
 
   GetDynamicVar({ name }: mir.GetDynamicVar): WireFormat.Expressions.GetDynamicVar {

--- a/packages/@glimmer/integration-tests/test/updating-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-test.ts
@@ -756,6 +756,17 @@ class UpdatingTest extends RenderTest {
   }
 
   @test
+  'if keyword in SubExpression without falsey value returns undefined [GH emberjs/ember.js#19409]'() {
+    this.registerHelper('to-string', (args) => `${args[0]}`);
+
+    this.render('{{to-string (if this.condition "truthy")}}', {
+      condition: false,
+    });
+
+    this.assertHTML('undefined', 'Initial render');
+  }
+
+  @test
   'if keyword in append position with falsy'() {
     this.render('{{if this.condition "truthy" "falsy"}}', {
       condition: true,

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -261,7 +261,7 @@ export namespace Expressions {
     op: SexpOpcodes.IfInline,
     condition: Expression,
     truthyValue: Expression,
-    falsyValue: Option<Expression>
+    falsyValue?: Option<Expression>
   ];
 
   export type Not = [op: SexpOpcodes.Not, value: Expression];


### PR DESCRIPTION
Ember versions prior to 3.25 always returned `undefined` when no falsey value was provided, changing that from `undefined` -> `null` has broken a few apps.

Failing test for https://github.com/emberjs/ember.js/issues/19409
