### PR TITLE
[BUGFIX] Fix reactivity of dynamic attributes

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -529,7 +529,7 @@ function setDeferredAttr(
       .elements()
       .setDynamicAttribute(name, valueForRef(value), trusting, namespace);
     if (!isConstRef(value)) {
-      vm.updateWith(new UpdateDynamicAttributeOpcode(value, attribute));
+      vm.updateWith(new UpdateDynamicAttributeOpcode(value, attribute, vm.env));
     }
   }
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -1,4 +1,4 @@
-import { Reference, valueForRef, isConstRef } from '@glimmer/reference';
+import { Reference, valueForRef, isConstRef, createComputeRef } from '@glimmer/reference';
 import { Revision, Tag, valueForTag, validateTag, consumeTag } from '@glimmer/validator';
 import {
   check,
@@ -8,7 +8,7 @@ import {
   CheckNode,
   CheckMaybe,
 } from '@glimmer/debug';
-import { Op, Option, InternalModifierManager } from '@glimmer/interfaces';
+import { Op, Option, Environment, InternalModifierManager } from '@glimmer/interfaces';
 import { $t0 } from '@glimmer/vm';
 import { ModifierDefinition } from '../../modifier/interfaces';
 import { APPEND_OPCODES, UpdatingOpcode } from '../../opcodes';
@@ -159,27 +159,34 @@ APPEND_OPCODES.add(Op.DynamicAttr, (vm, { op1: _name, op2: trusting, op3: _names
   let attribute = vm.elements().setDynamicAttribute(name, value, !!trusting, namespace);
 
   if (!isConstRef(reference)) {
-    vm.updateWith(new UpdateDynamicAttributeOpcode(reference, attribute));
+    vm.updateWith(new UpdateDynamicAttributeOpcode(reference, attribute, vm.env));
   }
 });
 
 export class UpdateDynamicAttributeOpcode extends UpdatingOpcode {
   public type = 'patch-element';
 
-  public lastValue: unknown;
+  private updateRef: Reference;
 
-  constructor(private reference: Reference<unknown>, private attribute: DynamicAttribute) {
+  constructor(reference: Reference<unknown>, attribute: DynamicAttribute, env: Environment) {
     super();
-    this.lastValue = valueForRef(reference);
+
+    let initialized = false;
+
+    this.updateRef = createComputeRef(() => {
+      let value = valueForRef(reference);
+
+      if (initialized === true) {
+        attribute.update(value, env);
+      } else {
+        initialized = true;
+      }
+    });
+
+    valueForRef(this.updateRef);
   }
 
-  evaluate(vm: UpdatingVM) {
-    let { attribute, reference, lastValue } = this;
-    let currentValue = valueForRef(reference);
-
-    if (currentValue !== lastValue) {
-      attribute.update(currentValue, vm.env);
-      this.lastValue = currentValue;
-    }
+  evaluate() {
+    valueForRef(this.updateRef);
   }
 }


### PR DESCRIPTION
The updates to use autotracking through the VM resulted in a bug in
dynamic attributes. Previously, the updating opcode for dynamic
attributes would run its update function based on tags/autotracking -
whenever any tag updated (e.g. a tracked value was changed) the
attribute would call its `update` function. The `update` function would
then check the new value against the current value of the attribute, and
update if they were different.

The bug was we introduced a value comparison in the updating opcode
itself, based on the last value of the property to set the attribute to.
This meant that if the property was updated to the same value twice in
a row, it would not call `update`, even if the attribute's value had
changed (e.g. because the user typed something).