### PR TITLE
Revert "Removes id from templates"

### DIFF
--- a/packages/@glimmer/compiler/index.ts
+++ b/packages/@glimmer/compiler/index.ts
@@ -1,4 +1,4 @@
-export { precompile, precompileJSON, PrecompileOptions } from './lib/compiler';
+export { defaultId, precompile, precompileJSON, PrecompileOptions } from './lib/compiler';
 export {
   ProgramSymbols,
   buildStatement,

--- a/packages/@glimmer/integration-tests/lib/compile.ts
+++ b/packages/@glimmer/integration-tests/lib/compile.ts
@@ -10,6 +10,8 @@ export function preprocess(templateSource: string, options?: PrecompileOptions):
   return createTemplate(templateSource, options)({});
 }
 
+let templateId = 0;
+
 export function createTemplate(
   templateSource: string,
   options: PrecompileOptions = {},
@@ -20,6 +22,7 @@ export function createTemplate(
   let reifiedScopeValues = usedLocals.map((key) => scopeValues[key]);
 
   let templateBlock: SerializedTemplateWithLazyBlock = {
+    id: String(templateId++),
     block: JSON.stringify(block),
     moduleName: options.meta?.moduleName ?? '(unknown template module)',
     scope: reifiedScopeValues.length > 0 ? () => reifiedScopeValues : null,

--- a/packages/@glimmer/integration-tests/lib/suites/custom-dom-helper.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/custom-dom-helper.ts
@@ -1,10 +1,12 @@
 import { AbstractNodeTest, NodeJitRenderDelegate } from '../modes/node/env';
 import { test } from '../test-decorator';
 import { NodeDOMTreeConstruction, serializeBuilder } from '@glimmer/node';
+import { RenderTest } from '../render-test';
 import { Environment, Cursor, ElementBuilder } from '@glimmer/interfaces';
 import { blockStack } from '../dom/blocks';
 import { strip } from '../test-helpers/strings';
 import { toInnerHTML } from '../dom/simple-utils';
+import { precompile } from '@glimmer/compiler';
 
 export class DOMHelperTests extends AbstractNodeTest {
   static suiteName = 'Server-side rendering in Node.js (normal)';
@@ -16,6 +18,20 @@ export class DOMHelperTests extends AbstractNodeTest {
     let helper = new NodeDOMTreeConstruction(null as any);
 
     this.assert.ok(!!helper, 'helper was instantiated without errors');
+  }
+}
+
+export class CompilationTests extends RenderTest {
+  static suiteName = 'Id generation';
+
+  @test
+  'generates id in node'() {
+    let template = precompile('hello');
+    let obj = JSON.parse(template);
+    this.assert.equal(obj.id, 'G0ggkEjw', 'short sha of template source');
+    template = precompile('hello', { meta: { moduleName: 'template/hello' } });
+    obj = JSON.parse(template);
+    this.assert.equal(obj.id, '4vC0bnaR', 'short sha of template source and meta');
   }
 }
 

--- a/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer/integration-tests/test/compiler/compile-options-test.ts
@@ -3,14 +3,14 @@ import { preprocess } from '../..';
 import { module } from '../support';
 import { unwrapTemplate, assert as glimmerAssert } from '@glimmer/util';
 import { SexpOpcodes, WireFormat } from '@glimmer/interfaces';
-import { TemplateWithReferrer } from '@glimmer/opcode-compiler';
+import { TemplateWithIdAndReferrer } from '@glimmer/opcode-compiler';
 
 module('[glimmer-compiler] Compile options', ({ test }) => {
   test('moduleName option is passed into meta', (assert) => {
     let moduleName = "It ain't hard to tell";
     let template = unwrapTemplate(
       preprocess('Hi, {{name}}!', { meta: { moduleName } })
-    ) as TemplateWithReferrer;
+    ) as TemplateWithIdAndReferrer;
     assert.equal(template.referrer.moduleName, moduleName, 'Template has the moduleName');
   });
 });

--- a/packages/@glimmer/integration-tests/test/node-suites-node-test.ts
+++ b/packages/@glimmer/integration-tests/test/node-suites-node-test.ts
@@ -8,6 +8,7 @@ import {
   NodeJitRenderDelegate,
   SerializedDOMHelperTests,
   JitSerializationDelegate,
+  CompilationTests,
 } from '..';
 
 nodeSuite(ServerSideSuite);
@@ -15,3 +16,7 @@ nodeComponentSuite(ServerSideComponentSuite);
 
 suite(DOMHelperTests, NodeJitRenderDelegate);
 suite(SerializedDOMHelperTests, JitSerializationDelegate);
+
+if (typeof process !== 'undefined') {
+  suite(CompilationTests, NodeJitRenderDelegate);
+}

--- a/packages/@glimmer/integration-tests/test/precompile-test.ts
+++ b/packages/@glimmer/integration-tests/test/precompile-test.ts
@@ -3,11 +3,12 @@ import { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
 import { unwrapTemplate } from '@glimmer/util';
 import {
   templateFactory,
-  TemplateFactoryWithMeta,
-  TemplateWithReferrer,
+  TemplateFactoryWithIdAndMeta,
+  TemplateWithIdAndReferrer,
 } from '@glimmer/opcode-compiler';
 
 let serializedTemplate: SerializedTemplateWithLazyBlock;
+let serializedTemplateNoId: SerializedTemplateWithLazyBlock;
 
 QUnit.module('templateFactory', {
   beforeEach() {
@@ -15,17 +16,46 @@ QUnit.module('templateFactory', {
       meta: { moduleName: 'template/module/name' },
     });
     serializedTemplate = JSON.parse(templateJs);
+    serializedTemplate.id = 'server-id-1';
+
+    serializedTemplateNoId = JSON.parse(templateJs);
+    serializedTemplateNoId.id = null;
   },
 });
 
+QUnit.test('id of serialized template is exposed on the factory', (assert) => {
+  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithIdAndMeta;
+  assert.ok(factory.__id, 'is present');
+  assert.equal(factory.__id, serializedTemplate.id, 'id matches serialized template id');
+});
+
+QUnit.test('generates id if no id is on the serialized template', (assert) => {
+  let factory1 = templateFactory(serializedTemplateNoId) as TemplateFactoryWithIdAndMeta;
+  let factory2 = templateFactory(serializedTemplateNoId) as TemplateFactoryWithIdAndMeta;
+  assert.ok(factory1.__id, 'is present');
+  assert.ok(factory2.__id, 'is present');
+  assert.notEqual(
+    factory1.__id,
+    factory2.__id,
+    'factories without underlying id create new id per factory'
+  );
+});
+
+QUnit.test('id of template matches factory', (assert) => {
+  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithIdAndMeta;
+  let template = unwrapTemplate(factory()) as TemplateWithIdAndReferrer;
+  assert.ok(template.id, 'is present');
+  assert.equal(template.id, factory.__id, 'template id matches factory id');
+});
+
 QUnit.test('meta is accessible from factory', (assert) => {
-  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithMeta;
+  let factory = templateFactory(serializedTemplate) as TemplateFactoryWithIdAndMeta;
   assert.deepEqual(factory.__meta, { moduleName: 'template/module/name' });
 });
 
 QUnit.test('meta is accessible from template', (assert) => {
   let factory = templateFactory(serializedTemplate);
-  let template = unwrapTemplate(factory()) as TemplateWithReferrer;
+  let template = unwrapTemplate(factory()) as TemplateWithIdAndReferrer;
   assert.deepEqual(
     template.referrer,
     { moduleName: 'template/module/name', owner: null },
@@ -37,7 +67,7 @@ QUnit.test('can inject owner into template', (assert) => {
   let owner = {};
   let factory = templateFactory(serializedTemplate);
 
-  let template = unwrapTemplate(factory(owner)) as TemplateWithReferrer;
+  let template = unwrapTemplate(factory(owner)) as TemplateWithIdAndReferrer;
 
   assert.strictEqual(template.referrer.owner, owner, 'is owner');
   assert.deepEqual(

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -515,6 +515,7 @@ export type SerializedTemplateBlockJSON = string;
  * A JSON object containing the SerializedTemplateBlock as JSON and TemplateMeta.
  */
 export interface SerializedTemplateWithLazyBlock {
+  id?: Option<string>;
   block: SerializedTemplateBlockJSON;
   moduleName: string;
   scope: (() => unknown[]) | undefined | null;

--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -13,6 +13,7 @@ export interface CompilableProgram extends CompilableTemplate<ProgramSymbolTable
 export type CompilableBlock = CompilableTemplate<BlockSymbolTable>;
 
 export interface LayoutWithContext {
+  readonly id: string;
   readonly block: SerializedTemplateBlock;
   readonly moduleName: string;
   readonly owner: Owner | null;

--- a/packages/@glimmer/opcode-compiler/index.ts
+++ b/packages/@glimmer/opcode-compiler/index.ts
@@ -21,8 +21,8 @@ export { PartialDefinitionImpl } from './lib/partial-template';
 export {
   default as templateFactory,
   templateCacheCounters,
-  TemplateFactoryWithMeta,
-  TemplateWithReferrer,
+  TemplateFactoryWithIdAndMeta,
+  TemplateWithIdAndReferrer,
 } from './lib/template';
 
 export { WrappedBuilder } from './lib/wrapped-component';

--- a/packages/@glimmer/program/lib/util/default-template.ts
+++ b/packages/@glimmer/program/lib/util/default-template.ts
@@ -15,6 +15,8 @@ const DEFAULT_TEMPLATE_BLOCK: SerializedTemplateBlock = [
 ];
 
 export const DEFAULT_TEMPLATE: SerializedTemplateWithLazyBlock = {
+  // random uuid
+  id: '1b32f5c2-7623-43d6-a0ad-9672898920a1',
   moduleName: '__default__.hbs',
   block: JSON.stringify(DEFAULT_TEMPLATE_BLOCK),
   scope: null,

--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -11,6 +11,7 @@ export {
   ASTPluginBuilder,
   ASTPluginEnvironment,
   Syntax,
+  TemplateIdFn,
   PrecompileOptions,
 } from './lib/parser/tokenizer-event-handlers';
 export { default as print } from './lib/generation/print';

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -1,3 +1,4 @@
+import { Option } from '@glimmer/interfaces';
 import { assertPresent, assign } from '@glimmer/util';
 import { parse, parseWithoutProcessing } from '@handlebars/parser';
 import { EntityParser } from 'simple-html-tokenizer';
@@ -333,7 +334,12 @@ interface HandlebarsParseOptions {
   ignoreStandalone?: boolean;
 }
 
+export interface TemplateIdFn {
+  (src: string): Option<string>;
+}
+
 export interface PrecompileOptions extends PreprocessOptions {
+  id?: TemplateIdFn;
   customizeComponentName?(input: string): string;
 }
 


### PR DESCRIPTION
Reverts glimmerjs/glimmer-vm#1262

This change is making it difficult for us to land recent bugfixes on the release branch of Ember. After discussion with @rwjblue, we decided to revert it for the time being, merge the safer change proposed in #1261, and then once we've landed the remaining bugfixes we need to in recent versions of Ember/Glimmer re-merge this change.