### PR TITLE
Fix generics on setInternalHelperManager

### DIFF
--- a/packages/@glimmer/manager/lib/internal/index.ts
+++ b/packages/@glimmer/manager/lib/internal/index.ts
@@ -113,7 +113,7 @@ export function getInternalModifierManager(
 }
 
 export function setInternalHelperManager<T extends object, O extends Owner>(
-  manager: CustomHelperManager<O> | Helper,
+  manager: CustomHelperManager<O> | Helper<O>,
   definition: T
 ): T {
   return setManager(HELPER_MANAGERS, manager, definition);


### PR DESCRIPTION
Fixes the generic for Owner on setInternalHelperManager, so we can use
a generic that doesn't conflict with object