### PR TITLE
[BUGFIX] Do not eagerly consume modifier args during destruction

### DIFF
--- a/packages/@glimmer/manager/lib/public/modifier.ts
+++ b/packages/@glimmer/manager/lib/public/modifier.ts
@@ -112,7 +112,8 @@ export class CustomModifierManager<O extends Owner, ModifierInstance>
 
     let { useArgsProxy, passFactoryToCreate } = delegate.capabilities;
 
-    let args = useArgsProxy ? argsProxyFor(capturedArgs, 'modifier') : reifyArgs(capturedArgs);
+    let argsProxy = argsProxyFor(capturedArgs, 'modifier');
+    let args = useArgsProxy ? argsProxy : reifyArgs(capturedArgs);
 
     let instance: ModifierInstance;
 
@@ -168,7 +169,7 @@ export class CustomModifierManager<O extends Owner, ModifierInstance>
       state.debugName = typeof definition === 'function' ? definition.name : definition.toString();
     }
 
-    registerDestructor(state, () => delegate.destroyModifier(instance, state.args));
+    registerDestructor(state, () => delegate.destroyModifier(instance, argsProxy));
 
     return state;
   }


### PR DESCRIPTION
Currently, in the 3.13 modifier capabilities version, we eagerly consume
the arguments that are passed to the modifier when it is destroying.
This can cause issues with backtracking rerender when the state isn't
actually used, and neither is the consumption. This change makes it so
that we don't eagerly consume these arguments during destruction in
general.