### PR TITLE
Ensure Entities are never transformed in codemod mode.

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -381,6 +381,17 @@ const syntax: Syntax = {
   Walker,
 };
 
+class CodemodEntityParser extends EntityParser {
+  // match upstream types, but never match an entity
+  constructor() {
+    super({});
+  }
+
+  parse(): string | undefined {
+    return undefined;
+  }
+}
+
 export function preprocess(
   input: string | Source | HBS.Program,
   options: PreprocessOptions = {}
@@ -412,7 +423,7 @@ export function preprocess(
 
   let entityParser = undefined;
   if (mode === 'codemod') {
-    entityParser = new EntityParser({});
+    entityParser = new CodemodEntityParser();
   }
 
   let offsets = SourceSpan.forCharPositions(source, 0, source.source.length);

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -114,6 +114,8 @@ QUnit.module('[glimmer-syntax] Code generation - source -> source', function () 
 
     // "stand alone"
     ' {{#foo}}\n  {{bar}}\n {{/foo}}',
+
+    `<span class="stampFont" style="font-family: 'stampfont'">&#xf000;</span>`,
   ].forEach(buildTest);
 });
 


### PR DESCRIPTION
The prior changes (in 458fe54899c942f69f26cf789fa5339627f2fa81) ensured that **named** entities were never matched (things like `&nbsp;`) but still allowed matching of char codes (hex or base 10).

This ensures that **no** entities can be matched.

Fixes https://github.com/glimmerjs/glimmer-vm/issues/1283
