### PR TITLE
Pin @handlebars/parser to 2.0.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "4.0.2"
   },
   "dependencies": {
-    "@handlebars/parser": "^2.0.0",
+    "@handlebars/parser": "~2.0.0",
     "@simple-dom/document": "^1.4.0",
     "@simple-dom/interface": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@glimmer/interfaces": "0.77.1",
     "@glimmer/util": "0.77.1",
-    "@handlebars/parser": "^2.0.0",
+    "@handlebars/parser": "~2.0.0",
     "simple-html-tokenizer": "^0.5.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,7 +1529,7 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@handlebars/parser@^2.0.0":
+"@handlebars/parser@~2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
   integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==


### PR DESCRIPTION
Updating to @handlebars/parser@2.1.0 introduces a number of test failures that need to be debugged:

```js
not ok 1378 Chrome 89.0 - [2 ms] - [integration] jit :: {{log}} keyword: correctly logs `this`
    ---
        actual: >
            null
        stack: >
            TypeError: Cannot read property 'length' of undefined
                at ExpressionNormalizer.path (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38770:23)
                at ExpressionNormalizer.normalize (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38746:23)
                at http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38795:22
                at Array.map (<anonymous>)
                at ExpressionNormalizer.callParts (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38794:30)
                at StatementNormalizer.MustacheStatement (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38956:33)
                at StatementNormalizer.normalize (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38900:23)
                at http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38625:25
                at Array.map (<anonymous>)
                at Object.normalize (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38624:67)
        message: >
            Died on test #2     at _loop (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17888:21)
                at http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17898:11
                at suite (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17900:9)
                at jitSuite (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17814:12)
                at Module.callback (http://localhost:7357/153311786233/tests/assets/tests.js:9760:18)
                at Module.exports (http://localhost:7357/153311786233/tests/assets/loader.js:106:32)
                at requireModule (http://localhost:7357/153311786233/tests/assets/loader.js:27:18)
                at http://localhost:7357/153311786233/tests/index.html?hidepassed:140:11: Cannot read property 'length' of undefined
        negative: >
            false
        browser log: |

not ok 1415 Chrome 89.0 - [3 ms] - [integration] jit :: modifiers: modifiers on components accept `this` in both positional params and named arguments, and updates when it changes
    ---
        actual: >
            null
        stack: >
            TypeError: Cannot read property 'length' of undefined
                at ExpressionNormalizer.path (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38770:23)
                at ExpressionNormalizer.normalize (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38746:23)
                at http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38795:22
                at Array.map (<anonymous>)
                at ExpressionNormalizer.callParts (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38794:30)
                at ElementNormalizer.modifier (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:39108:33)
                at http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:39059:23
                at Array.map (<anonymous>)
                at ElementNormalizer.ElementNode (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:39058:41)
                at StatementNormalizer.normalize (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:38897:52)
        message: >
            Died on test #2     at _loop (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17888:21)
                at http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17898:11
                at suite (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17900:9)
                at jitSuite (http://localhost:7357/153311786233/tests/assets/glimmer-vm.js:17814:12)
                at Module.callback (http://localhost:7357/153311786233/tests/assets/tests.js:11623:18)
                at Module.exports (http://localhost:7357/153311786233/tests/assets/loader.js:106:32)
                at requireModule (http://localhost:7357/153311786233/tests/assets/loader.js:27:18)
                at http://localhost:7357/153311786233/tests/index.html?hidepassed:140:11: Cannot read property 'length' of undefined
        negative: >
            false
        browser log: |
    ...
```

These failures were introduced by the changes in https://github.com/handlebars-lang/handlebars-parser/pull/4, but it is unclear **exactly** why they are failing. Someone needs to investigate.
