### PR TITLE
Exclude HTML elements from template locals by default

### DIFF
--- a/packages/@glimmer/syntax/test/template-locals-test.ts
+++ b/packages/@glimmer/syntax/test/template-locals-test.ts
@@ -31,6 +31,8 @@ QUnit.test('it works', function (assert) {
     {{#this.dynamicBlockComponent}}
     {{/this.dynamicBlockComponent}}
 
+    <button></button>
+
     <this.dynamicAngleComponent>
     </this.dynamicAngleComponent>
   `);
@@ -44,6 +46,22 @@ QUnit.test('it works', function (assert) {
     'some',
     'someOther',
   ]);
+});
+
+QUnit.test('it does not include locals', function (assert) {
+  let locals = getTemplateLocals(
+    `
+      <SomeComponent as |button|>
+        <button></button>
+        {{button}}
+      </SomeComponent>
+    `,
+    {
+      includeHtmlElements: true,
+    }
+  );
+
+  assert.deepEqual(locals, ['SomeComponent']);
 });
 
 QUnit.test('it can include keywords', function (assert) {
@@ -95,4 +113,17 @@ QUnit.test('it can include keywords', function (assert) {
     'some',
     'someOther',
   ]);
+});
+
+QUnit.test('it can include html elements', function (assert) {
+  let locals = getTemplateLocals(
+    `
+      <button></button>
+    `,
+    {
+      includeHtmlElements: true,
+    }
+  );
+
+  assert.deepEqual(locals, ['button']);
 });


### PR DESCRIPTION
Currently, all valid identifiers will be included in the output,
including HTML like identifiers. This can cause issues that are not
obvious from the get go, for instance:

```js
test('Supports the on modifier', async (assert) => {
  class MyComponent extends Component {
    static template = hbs`<button {{on "click" this.incrementCounter}}>Count: {{this.count}}</button>`;
    @tracked count = 0;

    @action
    incrementCounter() {
      this.count++;
    }
  }

  const element = document.getElementById('qunit-fixture')!;

  await renderComponent(MyComponent, element);
  assert.strictEqual(
    element.innerHTML,
    `<button>Count: 0</button>`,
    'the component was rendered'
  );

  const button = element.querySelector('button')!;
  button.click();

  await didRender();
  assert.strictEqual(
    element.innerHTML,
    `<button>Count: 1</button>`,
    'the component was rerendered'
  );
});
```

This test fails because `button` is technically an in-scope variable,
declared _after_ `renderComponent` is called. Using the template
transform, it thinks that `button` really exists and is a component
definition, and throws a ReferenceError when it attempts to access it
because it hasn't been defined yet.

This change would allow us to ignore any identifier that is:

1. Only used in angle bracket invocation
2. Has no path segments
3. Is all lower case

Preventing these collisions from happening with common HTML elements
such as `button`, `span`, `div`, etc. This also follows JSX's rules for
determining if a [value in scope is a component](https://reactjs.org/docs/jsx-in-depth.html#html-tags-vs.-react-components),
so at the least this strategy is already used in a real world framework
without much confusion.