### PR TITLE
Fixes VM Babel plugin generation in browsers

### DIFF
--- a/packages/build-utils/@glimmer/vm-babel-plugins/index.js
+++ b/packages/build-utils/@glimmer/vm-babel-plugins/index.js
@@ -1,7 +1,16 @@
-module.exports = function generateVmPlugins({ isDebug } = { isDebug: true }) {
+function defaultTo(value, defaultVal) {
+  return value === undefined ? defaultVal : value;
+}
+
+module.exports = function generateVmPlugins(options = {}) {
+  let isDebug = defaultTo(options.isDebug, true);
+  let __loadPlugins = defaultTo(options.__loadPlugins, false);
+
   return [
     [
-      require.resolve('babel-plugin-debug-macros'),
+      __loadPlugins
+        ? require('babel-plugin-debug-macros')
+        : require.resolve('babel-plugin-debug-macros'),
       {
         debugTools: {
           source: '@glimmer/global-context',


### PR DESCRIPTION
Currently, attempting to use `@glimmer/vm-babel-plugins` in browsers with
standard build tooling fails due to the dynamic `require` that Babel
itself does with the resolved paths. This change provides an option that
allows us to load the plugins directly, which means that they will be
bundled properly.