### PR TITLE
Add repository metadata to glimmer validator package

### DIFF
--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -3,6 +3,11 @@
   "version": "0.77.6",
   "description": "Objects used to track values and their dirtiness in Glimmer",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glimmerjs/glimmer-vm",
+    "directory": "packages/@glimmer/validator"
+  },
   "dependencies": {
     "@glimmer/env": "^0.1.7",
     "@glimmer/global-context": "0.77.6"


### PR DESCRIPTION
The npm package does not link back to the repository. This adds the meta data required to populate the [npm page](https://www.npmjs.com/package/@glimmer/validator). 

Part of Ember Conf 2021 Contributors workshop! Thank you @ef4! :)