### PR TITLE
Fix nested calls to helpers in dynamic helpers

### DIFF
--- a/packages/@glimmer/integration-tests/test/helpers/dynamic-helpers-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/dynamic-helpers-test.ts
@@ -1,4 +1,11 @@
-import { RenderTest, test, jitSuite, GlimmerishComponent, defineSimpleHelper } from '../..';
+import {
+  RenderTest,
+  test,
+  jitSuite,
+  GlimmerishComponent,
+  defineSimpleHelper,
+  defineComponent,
+} from '../..';
 
 class DynamicHelpersResolutionModeTest extends RenderTest {
   static suiteName = 'dynamic helpers in resolution mode';
@@ -34,6 +41,41 @@ class DynamicHelpersResolutionModeTest extends RenderTest {
     assert.validateDeprecations(
       /The `x\.foo` property path was used in a template for the `.*` component without using `this`/
     );
+  }
+
+  @test
+  'Can use a dynamic helper with nested helpers'() {
+    const foo = defineSimpleHelper(() => 'world!');
+    const bar = defineSimpleHelper((value: string) => 'Hello, ' + value);
+    const Bar = defineComponent(
+      { foo },
+      '{{this.bar (foo)}}',
+      class extends GlimmerishComponent {
+        bar = bar;
+      }
+    );
+
+    this.renderComponent(Bar);
+    this.assertHTML('Hello, world!');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use a dynamic helper with nested dynamic helpers'() {
+    const foo = defineSimpleHelper(() => 'world!');
+    const bar = defineSimpleHelper((value: string) => 'Hello, ' + value);
+    const Bar = defineComponent(
+      {},
+      '{{this.bar (this.foo)}}',
+      class extends GlimmerishComponent {
+        foo = foo;
+        bar = bar;
+      }
+    );
+
+    this.renderComponent(Bar);
+    this.assertHTML('Hello, world!');
+    this.assertStableRerender();
   }
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
@@ -1,4 +1,4 @@
-import { $v0 } from '@glimmer/vm';
+import { $fp, $v0 } from '@glimmer/vm';
 import {
   Option,
   Op,
@@ -79,13 +79,13 @@ export function CallDynamic(
   named: WireFormat.Core.Hash,
   append?: () => void
 ): void {
-  op(Op.Load, $v0);
   op(MachineOp.PushFrame);
   SimpleArgs(op, positional, named, false);
-  op(Op.DynamicHelper, $v0);
+  op(Op.Dup, $fp, 1);
+  op(Op.DynamicHelper);
   if (append) {
     op(Op.Fetch, $v0);
-    append?.();
+    append();
     op(MachineOp.PopFrame);
   } else {
     op(MachineOp.PopFrame);

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -73,10 +73,10 @@ APPEND_OPCODES.add(Op.Curry, (vm, { op1: type, op2: _isStrict }) => {
   );
 });
 
-APPEND_OPCODES.add(Op.DynamicHelper, (vm, { op1: _definitionRegister }) => {
+APPEND_OPCODES.add(Op.DynamicHelper, (vm) => {
   let stack = vm.stack;
+  let ref = check(stack.popJs(), CheckReference);
   let args = check(stack.popJs(), CheckArguments).capture();
-  let ref = vm.fetchValue<Reference>(_definitionRegister);
 
   let helperRef: Reference;
   let initialOwner: Owner = vm.getOwner();


### PR DESCRIPTION
Currently, nested calls to helpers in dynamic helpers cause problems
because the nested helper overwrites the register that we were using to
pass along the helper definition. This is actually a worse way of doing
something that the `Dup` opcode is designed to do anyways, so I updated
to do that, following the same pattern in DynamicModifiers. Added tests
for both dynamic helpers and modifiers with nested helpers.

Original issue: https://github.com/pzuraq/ember-could-get-used-to-this/pull/41