### PR TITLE
Deprecate `@foo={{helper}}`

### DIFF
--- a/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
@@ -91,6 +91,8 @@ function printPath(path: ASTv2.ExpressionNode): string {
     }
     case 'Call':
       return `(${printPath(path.callee)} ...)`;
+    case 'DeprecatedCall':
+      return `${path.callee.name}`;
     case 'Interpolate':
       throw unreachable('a concat statement cannot appear as the head of an expression');
   }

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/expressions.ts
@@ -26,6 +26,8 @@ export class NormalizeExpressions {
         }
 
         return this.CallExpression(node, state);
+      case 'DeprecatedCall':
+        return this.DeprecaedCallExpression(node, state);
     }
   }
 
@@ -106,6 +108,13 @@ export class NormalizeExpressions {
           })
       );
     }
+  }
+
+  DeprecaedCallExpression(
+    { arg, callee, loc }: ASTv2.DeprecatedCallExpression,
+    _state: NormalizationState
+  ): Result<mir.ExpressionNode> {
+    return Ok(new mir.DeprecatedCallExpression({ loc, arg, callee }));
   }
 
   Args({ positional, named, loc }: ASTv2.Args, state: NormalizationState): Result<mir.Args> {

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
@@ -15,6 +15,8 @@ export class ExpressionEncoder {
         return this.Literal(expr);
       case 'CallExpression':
         return this.CallExpression(expr);
+      case 'DeprecatedCallExpression':
+        return this.DeprecatedCallExpression(expr);
       case 'PathExpression':
         return this.PathExpression(expr);
       case 'Arg':
@@ -101,6 +103,13 @@ export class ExpressionEncoder {
 
   CallExpression({ callee, args }: mir.CallExpression): WireFormat.Expressions.Helper {
     return [SexpOpcodes.Call, EXPR.expr(callee), ...EXPR.Args(args)];
+  }
+
+  DeprecatedCallExpression({
+    arg,
+    callee,
+  }: mir.DeprecatedCallExpression): WireFormat.Expressions.GetPathFreeAsDeprecatedHelperHeadOrThisFallback {
+    return [SexpOpcodes.GetFreeAsDeprecatedHelperHeadOrThisFallback, callee.symbol, [arg.chars]];
   }
 
   Tail({ members }: mir.Tail): PresentArray<string> {

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/mir.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/mir.ts
@@ -146,6 +146,11 @@ export class CallExpression extends node('CallExpression').fields<{
   callee: ExpressionNode;
   args: Args;
 }>() {}
+export class DeprecatedCallExpression extends node('DeprecatedCallExpression').fields<{
+  arg: SourceSlice;
+  callee: ASTv2.FreeVarReference;
+}>() {}
+
 export class Modifier extends node('Modifier').fields<{ callee: ExpressionNode; args: Args }>() {}
 export class InvokeBlock extends node('InvokeBlock').fields<{
   head: ExpressionNode;
@@ -208,6 +213,7 @@ export type ExpressionNode =
   | ASTv2.VariableReference
   | InterpolateExpression
   | CallExpression
+  | DeprecatedCallExpression
   | Not
   | IfInline
   | HasBlock

--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -190,6 +190,9 @@ export default class WireFormatDebugger {
         case Op.GetFreeAsHelperHeadOrThisFallback:
           return ['GetFreeAsHelperHeadOrThisFallback', this.upvars[opcode[1]], opcode[2]];
 
+        case Op.GetFreeAsDeprecatedHelperHeadOrThisFallback:
+          return ['GetFreeAsDeprecatedHelperHeadOrThisFallback', this.upvars[opcode[1]]];
+
         case Op.GetFreeAsHelperHead:
           return ['GetFreeAsHelperHead', this.upvars[opcode[1]], opcode[2]];
 

--- a/packages/@glimmer/integration-tests/lib/suites/components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/components.ts
@@ -647,7 +647,7 @@ export class GlimmerishComponents extends RenderTest {
     this.registerComponent(
       'Glimmer',
       'Main',
-      '<div><Child @value={{count}} /></div>',
+      '<div><Child @value={{(count)}} /></div>',
       MainComponent
     );
     this.registerComponent('Glimmer', 'Child', '{{@value}} {{this.args.value}}');

--- a/packages/@glimmer/integration-tests/test/ember-component-test.ts
+++ b/packages/@glimmer/integration-tests/test/ember-component-test.ts
@@ -571,7 +571,7 @@ class CurlyScopeTest extends CurlyTest {
     );
 
     assert.validateDeprecations(
-      /The `id` property was used in the template for the `.*` component without using `this`/
+      /The `id` property was used in the `.*` template without using `this`/
     );
   }
 
@@ -1656,7 +1656,7 @@ class CurlyGlimmerComponentTest extends CurlyTest {
     this.assertStableNodes();
 
     assert.validateDeprecations(
-      /The `component\.name` property path was used in a template for the `.*` component without using `this`/
+      /The `component\.name` property path was used in the `.*` template without using `this`/
     );
   }
 }

--- a/packages/@glimmer/integration-tests/test/helpers/dynamic-helpers-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/dynamic-helpers-test.ts
@@ -32,7 +32,7 @@ class DynamicHelpersResolutionModeTest extends RenderTest {
     this.assertStableRerender();
 
     assert.validateDeprecations(
-      /The `x\.foo` property path was used in a template for the `.*` component without using `this`/
+      /The `x\.foo` property path was used in the `.*` template without using `this`/
     );
   }
 }

--- a/packages/@glimmer/integration-tests/test/syntax/argument-less-helper-paren-less-invoke-test.ts
+++ b/packages/@glimmer/integration-tests/test/syntax/argument-less-helper-paren-less-invoke-test.ts
@@ -1,0 +1,95 @@
+import { RenderTest, jitSuite, test, defineSimpleHelper } from '../..';
+
+class ArgumentLessHelperParenLessInvokeTest extends RenderTest {
+  static suiteName = 'argument-less helper paren-less invoke';
+
+  @test
+  'invoking an argument-less helper without parens in named argument position is deprecated'(
+    assert: Assert
+  ) {
+    this.registerHelper('is-string', ([value]: readonly unknown[]) => typeof value === 'string');
+
+    this.registerHelper('foo', () => 'Hello, world!');
+    this.registerComponent('TemplateOnly', 'Bar', '[{{is-string @content}}][{{@content}}]');
+
+    this.render('<Bar @content={{foo}} />', { foo: 'Not it!' });
+    this.assertHTML('[true][Hello, world!]');
+    this.assertStableRerender();
+
+    assert.validateDeprecations(
+      new RegExp(
+        /The `foo` helper was used in the `\(unknown template module\)` template as /.source +
+          /`@content={{foo}}`\. This is ambigious between wanting the `@content` argument /.source +
+          /to be the `foo` helper itself, or the result of invoking the `foo` helper /.source +
+          /\(current behavior\)\. This implicit invocation behavior has been deprecated\./.source
+      )
+    );
+  }
+
+  @test
+  'invoking an argument-less helper with parens in named argument position is not deprecated'() {
+    this.registerHelper('is-string', ([value]: readonly unknown[]) => typeof value === 'string');
+
+    this.registerHelper('foo', () => 'Hello, world!');
+    this.registerComponent('TemplateOnly', 'Bar', '[{{is-string @content}}][{{@content}}]');
+
+    this.render('<Bar @content={{(foo)}} />');
+    this.assertHTML('[true][Hello, world!]');
+    this.assertStableRerender();
+  }
+
+  @test
+  'invoking an argument-less helper with quotes in named argument position is not deprecated'() {
+    this.registerHelper('is-string', ([value]: readonly unknown[]) => typeof value === 'string');
+
+    this.registerHelper('foo', () => 'Hello, world!');
+    this.registerComponent('TemplateOnly', 'Bar', '[{{is-string @content}}][{{@content}}]');
+
+    this.render('<Bar @content="{{foo}}" />');
+    this.assertHTML('[true][Hello, world!]');
+    this.assertStableRerender();
+  }
+
+  @test
+  'passing a local helper in named argument position is not deprecated'() {
+    this.registerHelper('is-string', ([value]: readonly unknown[]) => typeof value === 'string');
+
+    const foo = defineSimpleHelper(() => 'Hello, world!');
+
+    this.registerComponent('TemplateOnly', 'Bar', '[{{is-string @content}}][{{@content}}]');
+
+    this.render('{{#let this.foo as |foo|}}<Bar @content={{foo}} />{{/let}}', { foo });
+    this.assertHTML('[false][Hello, world!]');
+    this.assertStableRerender();
+  }
+
+  @test
+  'invoking a local helper with parens in named argument position is not deprecated'() {
+    this.registerHelper('is-string', ([value]: readonly unknown[]) => typeof value === 'string');
+
+    const foo = defineSimpleHelper(() => 'Hello, world!');
+
+    this.registerComponent('TemplateOnly', 'Bar', '[{{is-string @content}}][{{@content}}]');
+
+    this.render('{{#let this.foo as |foo|}}<Bar @content={{(foo)}} />{{/let}}', { foo });
+    this.assertHTML('[true][Hello, world!]');
+    this.assertStableRerender();
+  }
+
+  // TODO: this should work, but doesn't
+
+  // @test
+  // 'invoking a helper with quotes in named argument position is not deprecated'() {
+  //   this.registerHelper('is-string', ([value]: readonly unknown[]) => typeof value === 'string');
+
+  //   const foo = defineSimpleHelper(() => 'Hello, world!');
+
+  //   this.registerComponent('TemplateOnly', 'Bar', '[{{is-string @content}}][{{@content}}]');
+
+  //   this.render('{{#let this.foo as |foo|}}<Bar @content="{{foo}}" />{{/let}}', { foo });
+  //   this.assertHTML('[true][Hello, world!]');
+  //   this.assertStableRerender();
+  // }
+}
+
+jitSuite(ArgumentLessHelperParenLessInvokeTest);

--- a/packages/@glimmer/integration-tests/test/updating-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-test.ts
@@ -217,7 +217,7 @@ class UpdatingTest extends RenderTest {
     `);
 
     assert.validateDeprecations(
-      /The `` property was used in a template for the `.*` component without using `this`/
+      /The `` property was used in the `.*` template without using `this`/
     );
   }
 
@@ -1117,10 +1117,10 @@ class UpdatingTest extends RenderTest {
     );
 
     assert.validateDeprecations(
-      /The `foo` property path was used in a template for the `.*` component without using `this`/,
-      /The `bar` property path was used in a template for the `.*` component without using `this`/,
-      /The `bar` property path was used in a template for the `.*` component without using `this`/,
-      /The `foo` property path was used in a template for the `.*` component without using `this`/
+      /The `foo` property path was used in the `.*` template without using `this`/,
+      /The `bar` property path was used in the `.*` template without using `this`/,
+      /The `bar` property path was used in the `.*` template without using `this`/,
+      /The `foo` property path was used in the `.*` template without using `this`/
     );
   }
 
@@ -1140,7 +1140,7 @@ class UpdatingTest extends RenderTest {
     this.assertHTML('<div>GodfreakOuter</div>', 'After updating');
 
     assert.validateDeprecations(
-      /The `f` property was used in a template for the `.*` component without using `this`/
+      /The `f` property was used in the `.*` template without using `this`/
     );
   }
 

--- a/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
@@ -87,7 +87,7 @@ export type ResolveOptionalHelperOp = [
   op: HighLevelResolutionOpcode.ResolveOptionalHelper,
   op1: WireFormat.Expressions.Expression,
   op2: {
-    ifHelper: (handle: number) => void;
+    ifHelper: (handle: number, name: string, moduleName: string) => void;
     ifFallback: (name: string, moduleName: string) => void;
   }
 ];

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -79,6 +79,8 @@ export const enum SexpOpcodes {
   GetFreeAsComponentOrHelperHead = 35,
   // a helper or `this` fallback `attr={{x}}`
   GetFreeAsHelperHeadOrThisFallback = 36,
+  // a helper or `this` fallback (deprecated) `@arg={{x}}`
+  GetFreeAsDeprecatedHelperHeadOrThisFallback = 99,
   // a call head `(x)`
   GetFreeAsHelperHead = 37,
   GetFreeAsModifierHead = 38,
@@ -176,6 +178,10 @@ export namespace Expressions {
     SexpOpcodes.GetFreeAsHelperHeadOrThisFallback,
     number
   ];
+  export type GetFreeAsDeprecatedHelperHeadOrThisFallback = [
+    SexpOpcodes.GetFreeAsDeprecatedHelperHeadOrThisFallback,
+    number
+  ];
   export type GetFreeAsHelperHead = [SexpOpcodes.GetFreeAsHelperHead, number];
   export type GetFreeAsModifierHead = [SexpOpcodes.GetFreeAsModifierHead, number];
   export type GetFreeAsComponentHead = [SexpOpcodes.GetFreeAsComponentHead, number];
@@ -185,6 +191,7 @@ export namespace Expressions {
     | GetFreeAsComponentOrHelperHeadOrThisFallback
     | GetFreeAsComponentOrHelperHead
     | GetFreeAsHelperHeadOrThisFallback
+    | GetFreeAsDeprecatedHelperHeadOrThisFallback
     | GetFreeAsHelperHead
     | GetFreeAsModifierHead
     | GetFreeAsComponentHead;
@@ -210,6 +217,11 @@ export namespace Expressions {
     number,
     Path
   ];
+  export type GetPathFreeAsDeprecatedHelperHeadOrThisFallback = [
+    SexpOpcodes.GetFreeAsDeprecatedHelperHeadOrThisFallback,
+    number,
+    Path
+  ];
   export type GetPathFreeAsHelperHead = [SexpOpcodes.GetFreeAsHelperHead, number, Path];
   export type GetPathFreeAsModifierHead = [SexpOpcodes.GetFreeAsModifierHead, number, Path];
   export type GetPathFreeAsComponentHead = [SexpOpcodes.GetFreeAsComponentHead, number, Path];
@@ -219,6 +231,7 @@ export namespace Expressions {
     | GetPathFreeAsComponentOrHelperHeadOrThisFallback
     | GetPathFreeAsComponentOrHelperHead
     | GetPathFreeAsHelperHeadOrThisFallback
+    | GetPathFreeAsDeprecatedHelperHeadOrThisFallback
     | GetPathFreeAsHelperHead
     | GetPathFreeAsModifierHead
     | GetPathFreeAsComponentHead;

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -50,6 +50,14 @@ export const isGetFreeOptionalHelper = makeResolutionTypeVerifier(
   SexpOpcodes.GetFreeAsHelperHeadOrThisFallback
 );
 
+export function isGetFreeDeprecatedHelper(
+  opcode: Expressions.Expression
+): opcode is Expressions.GetPathFreeAsDeprecatedHelperHeadOrThisFallback {
+  return (
+    Array.isArray(opcode) && opcode[0] === SexpOpcodes.GetFreeAsDeprecatedHelperHeadOrThisFallback
+  );
+}
+
 export const isGetFreeOptionalComponentOrHelper = makeResolutionTypeVerifier(
   SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback
 );
@@ -303,7 +311,10 @@ export function resolveOptionalHelper(
   meta: ContainingMetadata,
   [, expr, { ifHelper, ifFallback }]: ResolveOptionalHelperOp
 ): void {
-  assert(isGetFreeOptionalHelper(expr), 'Attempted to resolve a helper with incorrect opcode');
+  assert(
+    isGetFreeOptionalHelper(expr) || isGetFreeDeprecatedHelper(expr),
+    'Attempted to resolve a helper with incorrect opcode'
+  );
   let { upvars, owner } = assertResolverInvariants(meta);
 
   let name = upvars[expr[1]];
@@ -312,7 +323,7 @@ export function resolveOptionalHelper(
   if (helper === null) {
     ifFallback(name, meta.moduleName);
   } else {
-    ifHelper(constants.helper(helper, name));
+    ifHelper(constants.helper(helper, name), name, meta.moduleName);
   }
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -184,7 +184,7 @@ STATEMENTS.add(SexpOpcodes.Append, (op, [, value]) => {
         op(MachineOp.PushFrame);
         op(HighLevelResolutionOpcode.ResolveLocal, value[1], (name: string, moduleName: string) => {
           deprecate(
-            `The \`${name}\` property was used in a template for the \`${moduleName}\` component without using \`this\`. This fallback behavior has been deprecated, all properties must be looked up on \`this\` when used in the template: {{this.${name}}}`,
+            `The \`${name}\` property was used in the \`${moduleName}\` template without using \`this\`. This fallback behavior has been deprecated, all properties must be looked up on \`this\` when used in the template: {{this.${name}}}`,
             false,
             {
               id: 'this-property-fallback',

--- a/packages/@glimmer/syntax/lib/v2-a/builders.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/builders.ts
@@ -174,7 +174,7 @@ export class Builder {
     context: ASTv2.FreeVarResolution;
     symbol: number;
     loc: SourceSpan;
-  }): ASTv2.VariableReference {
+  }): ASTv2.FreeVarReference {
     assert(
       name !== 'this',
       `You called builders.freeVar() with 'this'. Call builders.this instead`
@@ -217,6 +217,18 @@ export class Builder {
       loc,
       callee: parts.callee,
       args: parts.args,
+    });
+  }
+
+  deprecatedCall(
+    arg: SourceSlice,
+    callee: ASTv2.FreeVarReference,
+    loc: SourceSpan
+  ): ASTv2.DeprecatedCallExpression {
+    return new ASTv2.DeprecatedCallExpression({
+      loc,
+      arg,
+      callee,
     });
   }
 

--- a/packages/@glimmer/syntax/lib/v2-a/objects/expr.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/objects/expr.ts
@@ -3,7 +3,7 @@ import { PresentArray } from '@glimmer/interfaces';
 import { SourceSlice } from '../../source/slice';
 import type { CallFields } from './base';
 import { node } from './node';
-import type { VariableReference } from './refs';
+import type { FreeVarReference, VariableReference } from './refs';
 
 /**
  * A Handlebars literal.
@@ -83,6 +83,24 @@ export class PathExpression extends node('Path').fields<{
 export class CallExpression extends node('Call').fields<CallFields>() {}
 
 /**
+ * Corresponds to a possible deprecated helper call. Must be:
+ *
+ * 1. A free variable (not this.foo, not @foo, not local).
+ * 2. Argument-less.
+ * 3. In a component invocation's named argument position.
+ * 4. Not parenthesized (not @bar={{(helper)}}).
+ * 5. Not interpolated (not @bar="{{helper}}").
+ *
+ * ```hbs
+ * <Foo @bar={{helper}} />
+ * ```
+ */
+export class DeprecatedCallExpression extends node('DeprecatedCall').fields<{
+  arg: SourceSlice;
+  callee: FreeVarReference;
+}>() {}
+
+/**
  * Corresponds to an interpolation in attribute value position.
  *
  * ```hbs
@@ -97,4 +115,5 @@ export type ExpressionNode =
   | LiteralExpression
   | PathExpression
   | CallExpression
+  | DeprecatedCallExpression
   | InterpolateExpression;

--- a/packages/@glimmer/syntax/lib/v2-a/serialize/serialize.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/serialize/serialize.ts
@@ -10,6 +10,7 @@ import type {
   SerializedBlock,
   SerializedCallExpression,
   SerializedContentNode,
+  SerializedDeprecatedCallExpression,
   SerializedElementModifier,
   SerializedExpressionNode,
   SerializedFreeVarReference,
@@ -93,6 +94,14 @@ export class ExprSerializer {
       loc: call.loc.serialize(),
       callee: visit.expr(call.callee),
       args: ARGS.args(call.args),
+    };
+  }
+
+  deprecatedCall(call: ASTv2.DeprecatedCallExpression): SerializedDeprecatedCallExpression {
+    return {
+      type: 'DeprecatedCall',
+      loc: call.loc.serialize(),
+      callee: REF.free(call.callee),
     };
   }
 
@@ -271,6 +280,8 @@ const visit = {
         return EXPR.path(expr);
       case 'Call':
         return EXPR.call(expr);
+      case 'DeprecatedCall':
+        return EXPR.deprecatedCall(expr);
       case 'Interpolate':
         return EXPR.interpolate(expr);
     }

--- a/packages/@glimmer/syntax/lib/v2-a/serialize/types.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/serialize/types.ts
@@ -59,10 +59,16 @@ export interface SerializedCallExpression extends SerializedCallNode {
   type: 'Call';
 }
 
+export interface SerializedDeprecatedCallExpression extends SerializedBaseNode {
+  type: 'DeprecatedCall';
+  callee: SerializedFreeVarReference;
+}
+
 export type SerializedExpressionNode =
   | SerializedLiteralExpression
   | SerializedPathExpression
   | SerializedCallExpression
+  | SerializedDeprecatedCallExpression
   | SerializedInterpolateExpression;
 
 export interface SerializedArgs extends SerializedBaseNode {


### PR DESCRIPTION
Per [RFC 496](https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md#3-no-implicit-invocation-of-argument-less-helpers), this commit deprecates the implicit invocation of argument-less helpers and requires explicit parenthesis if:

1. Non-strict mode, AND
2. `helper` is a free variable (not `this.helper`, `@helper` or
   a local variable), AND
3. No arguments are provided to the helper, AND
4. It's in a component invocation's named argument position (not
   `<div id={{helper}}>` or `<Foo bar={{helper}}>`), AND
5. Not parenthesized (not `@foo={{(helper)}}`), AND
6. Not interpolated (not `@foo="{{helper}}"`).

The cases in real apps where all of the above are true should be quite rare, as most helpers take at least one argument.

This is probably not the most efficient/minimal changes to the compiler infrastructure, but I chose to optimize for making the change easier to remove/rollback (i.e. adding new nodes instead of changing existing ones) as we won't be needing this for very long.