### PR TITLE
Fix evaluation stack off-by-one error introduced in #1293

### DIFF
--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
@@ -87,8 +87,10 @@ export function CallDynamic(
     op(Op.Fetch, $v0);
     append();
     op(MachineOp.PopFrame);
+    op(Op.Pop, 1);
   } else {
     op(MachineOp.PopFrame);
+    op(Op.Pop, 1);
     op(Op.Fetch, $v0);
   }
 }


### PR DESCRIPTION
Before #1293, the `Load` operation would have popped the helper definition off of the evaluation stack. After the #1293, nothing is popping it off anymore and that creates problem downstream.

This balances things out by inserting a `Pop(1)` in the original frame.

I couldn't think of a good way to test this, and this is blocking Ember beta, so we will merge this now (Ember has a test confirming this works) and @pzuraq will add a test later.