### PR TITLE
Update simple-html-tokenizer to v0.5.11 and support doctype

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@simple-dom/void-map": "^1.4.0",
     "babel-plugin-debug-macros": "^0.3.4",
     "fs-extra": "^9.0.0",
-    "simple-html-tokenizer": "^0.5.10",
+    "simple-html-tokenizer": "^0.5.11",
     "symlink-or-copy": "^1.3.1"
   },
   "devDependencies": {

--- a/packages/@glimmer/integration-tests/package.json
+++ b/packages/@glimmer/integration-tests/package.json
@@ -23,7 +23,7 @@
     "@simple-dom/interface": "^1.4.0",
     "@simple-dom/serializer": "^1.4.0",
     "@simple-dom/void-map": "^1.4.0",
-    "simple-html-tokenizer": "^0.5.10"
+    "simple-html-tokenizer": "^0.5.11"
   },
   "devDependencies": {
     "@types/qunit": "^2.9.0"

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -6,7 +6,7 @@
     "@glimmer/interfaces": "0.79.1",
     "@glimmer/util": "0.79.1",
     "@handlebars/parser": "~2.0.0",
-    "simple-html-tokenizer": "^0.5.10"
+    "simple-html-tokenizer": "^0.5.11"
   },
   "devDependencies": {
     "@glimmer/local-debug-flags": "0.79.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9008,10 +9008,10 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.1:
   dependencies:
     debug "^2.2.0"
 
-simple-html-tokenizer@^0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.10.tgz#0843e4f00c9677f1c81e3dfeefcee0a4aca8e5d0"
-  integrity sha512-1DHMUmvUOGuUZ9/+cX/+hOhWhRD5dEw6lodn8WuV+T+cQ31hhBcCu1dcDsNotowi4mMaNhrLyKoS+DtB81HdDA==
+simple-html-tokenizer@^0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz#4c5186083c164ba22a7b477b7687ac056ad6b1d9"
+  integrity sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
**Release notes**
https://github.com/tildeio/simple-html-tokenizer/releases/tag/v0.5.11

**Related to issue**
https://github.com/glimmerjs/glimmer-vm/issues/870