### PR TITLE
Remove property descriptor assertion from args proxy

### DIFF
--- a/packages/@glimmer/manager/lib/util/args-proxy.ts
+++ b/packages/@glimmer/manager/lib/util/args-proxy.ts
@@ -84,18 +84,14 @@ class NamedArgsProxy implements ProxyHandler<{}> {
   }
 
   getOwnPropertyDescriptor(_target: {}, prop: string | number | symbol) {
-    if (DEBUG && !(prop in this.named)) {
-      throw new Error(
-        `args proxies do not have real property descriptors, so you should never need to call getOwnPropertyDescriptor yourself. This code exists for enumerability, such as in for-in loops and Object.keys(). Attempted to get the descriptor for \`${String(
-          prop
-        )}\``
-      );
+    if (prop in this.named) {
+      return {
+        enumerable: true,
+        configurable: true,
+      };
     }
 
-    return {
-      enumerable: true,
-      configurable: true,
-    };
+    return undefined;
   }
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/emberjs/ember.js/issues/19130.

The point of the assertion was to deter people from trying to define stuff on the args. The intention hasn’t changed — don’t do that! But it turns out that upholding that assertion is not as straightforward. JavaScript can, in certain cases, trigger the assertion internally.

How? The answer is Proxies. Despite having the ability to completely override internal methods, Proxies still have to abide by certain rules (the spec calls them “invariants”). Did you try to mark a property as non-configurable, even though it’s configurable on the target? That’s not supported! And the browser is required to check for this. That’s how calling `get` can turn into an additional, and perhaps unexpected, call to `getOwnPropertyDescriptor`.

In our case, the assertion was incorrectly triggered when trying to `get` an undefined property on a proxy whose target is an args proxy. That made it impossible to wrap args in a Proxy — a use-case that was deemed reasonable enough to support.