### PR TITLE
Fix global-context test leakage

### DIFF
--- a/packages/@glimmer/destroyable/test/destroyables-test.ts
+++ b/packages/@glimmer/destroyable/test/destroyables-test.ts
@@ -28,7 +28,7 @@ function flush() {
 module('Destroyables', (hooks) => {
   let originalContext: GlobalContext | null;
 
-  hooks.before(() => {
+  hooks.beforeEach(() => {
     originalContext = testOverrideGlobalContext!({
       scheduleDestroy<T extends object>(destroyable: T, destructor: (obj: T) => void) {
         destroyQueue.push(() => destructor(destroyable));
@@ -40,7 +40,7 @@ module('Destroyables', (hooks) => {
     });
   });
 
-  hooks.after(() => {
+  hooks.afterEach(() => {
     testOverrideGlobalContext!(originalContext);
   });
 

--- a/packages/@glimmer/global-context/index.ts
+++ b/packages/@glimmer/global-context/index.ts
@@ -219,18 +219,20 @@ if (DEBUG) {
       globalContextWasSet = true;
     }
 
-    scheduleRevalidate = context?.scheduleRevalidate || scheduleRevalidate;
-    scheduleDestroy = context?.scheduleDestroy || scheduleDestroy;
-    scheduleDestroyed = context?.scheduleDestroyed || scheduleDestroyed;
-    toIterator = context?.toIterator || toIterator;
-    toBool = context?.toBool || toBool;
-    getProp = context?.getProp || getProp;
-    setProp = context?.setProp || setProp;
-    getPath = context?.getPath || getPath;
-    setPath = context?.setPath || setPath;
-    warnIfStyleNotTrusted = context?.warnIfStyleNotTrusted || warnIfStyleNotTrusted;
-    assert = context?.assert || assert;
-    deprecate = context?.deprecate || deprecate;
+    // We use `undefined as any` here to unset the values when resetting the
+    // context at the end of a test.
+    scheduleRevalidate = context?.scheduleRevalidate || (undefined as any);
+    scheduleDestroy = context?.scheduleDestroy || (undefined as any);
+    scheduleDestroyed = context?.scheduleDestroyed || (undefined as any);
+    toIterator = context?.toIterator || (undefined as any);
+    toBool = context?.toBool || (undefined as any);
+    getProp = context?.getProp || (undefined as any);
+    setProp = context?.setProp || (undefined as any);
+    getPath = context?.getPath || (undefined as any);
+    setPath = context?.setPath || (undefined as any);
+    warnIfStyleNotTrusted = context?.warnIfStyleNotTrusted || (undefined as any);
+    assert = context?.assert || (undefined as any);
+    deprecate = context?.deprecate || (undefined as any);
 
     return originalGlobalContext;
   };

--- a/packages/@glimmer/integration-tests/test/style-warnings-test.ts
+++ b/packages/@glimmer/integration-tests/test/style-warnings-test.ts
@@ -14,6 +14,10 @@ class StyleWarningsTest extends RenderTest {
       warnIfStyleNotTrusted() {
         warnings++;
       },
+
+      getProp(obj, key) {
+        return (obj as any)[key];
+      },
     });
   }
 

--- a/packages/@glimmer/reference/test/iterable-test.ts
+++ b/packages/@glimmer/reference/test/iterable-test.ts
@@ -54,11 +54,11 @@ class IterableWrapper {
 module('@glimmer/reference: IterableReference', (hooks) => {
   let originalContext: GlobalContext | null;
 
-  hooks.before(() => {
+  hooks.beforeEach(() => {
     originalContext = testOverrideGlobalContext!(TestContext);
   });
 
-  hooks.after(() => {
+  hooks.afterEach(() => {
     testOverrideGlobalContext!(originalContext);
   });
 

--- a/packages/@glimmer/reference/test/references-test.ts
+++ b/packages/@glimmer/reference/test/references-test.ts
@@ -39,7 +39,7 @@ module('References', (hooks) => {
   let getCount = 0;
   let setCount = 0;
 
-  hooks.before(() => {
+  hooks.beforeEach(() => {
     originalContext = testOverrideGlobalContext!({
       getProp(obj: object, key: string): unknown {
         getCount++;
@@ -50,10 +50,12 @@ module('References', (hooks) => {
         setCount++;
         (obj as Record<string, unknown>)[key] = value;
       },
+
+      scheduleRevalidate() {},
     });
   });
 
-  hooks.after(() => {
+  hooks.afterEach(() => {
     testOverrideGlobalContext!(originalContext);
   });
 


### PR DESCRIPTION
Currently the global context leaks some of the values which are setup by:

1. Setting the previous context value if one existed and none were passed
   in when overriding it in tests
2. Doing the overrides in `before` and `after` instead of `beforeEach`
   and `afterEach`, since tests can run in arbitrary order.

This PR fixes both of these issues.