### PR TITLE
Ensure hash works with custom tags

### DIFF
--- a/packages/@glimmer/runtime/lib/helpers/hash.ts
+++ b/packages/@glimmer/runtime/lib/helpers/hash.ts
@@ -6,8 +6,12 @@ import { combine, Tag, tagFor, track } from '@glimmer/validator';
 import { deprecate } from '@glimmer/global-context';
 import { internalHelper } from './internal-helper';
 
-function tagForKey(hash: CapturedNamedArguments, key: string): Tag {
-  return track(() => valueForRef(hash[key]));
+function tagForKey(namedArgs: CapturedNamedArguments, key: string): Tag {
+  return track(() => {
+    if (key in namedArgs) {
+      valueForRef(namedArgs[key]);
+    }
+  });
 }
 
 let hashProxyFor: (args: CapturedNamedArguments) => Record<string, unknown>;


### PR DESCRIPTION
We need to make sure references exist before we attempt to get
their value and track them.

Fixes: https://github.com/emberjs/ember.js/issues/19562