### PR TITLE
Adds isHashProxy

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -63,7 +63,7 @@ export {
 export { invokeHelper } from './lib/helpers/invoke';
 
 export { default as fn } from './lib/helpers/fn';
-export { default as hash } from './lib/helpers/hash';
+export { default as hash, isHashProxy } from './lib/helpers/hash';
 export { default as array } from './lib/helpers/array';
 export { default as get } from './lib/helpers/get';
 export { default as concat } from './lib/helpers/concat';

--- a/packages/@glimmer/runtime/lib/helpers/hash.ts
+++ b/packages/@glimmer/runtime/lib/helpers/hash.ts
@@ -1,10 +1,16 @@
 import { CapturedArguments, CapturedNamedArguments, Dict } from '@glimmer/interfaces';
 import { setCustomTagFor } from '@glimmer/manager';
 import { createComputeRef, createConstRef, Reference, valueForRef } from '@glimmer/reference';
-import { dict, HAS_NATIVE_PROXY } from '@glimmer/util';
+import { dict, HAS_NATIVE_PROXY, _WeakSet } from '@glimmer/util';
 import { combine, Tag, tagFor, track } from '@glimmer/validator';
 import { deprecate } from '@glimmer/global-context';
 import { internalHelper } from './internal-helper';
+
+const HASH_PROXIES = new _WeakSet();
+
+export function isHashProxy(obj: unknown): boolean {
+  return HASH_PROXIES.has(obj as object);
+}
 
 function tagForKey(namedArgs: CapturedNamedArguments, key: string): Tag {
   return track(() => {
@@ -96,6 +102,8 @@ if (HAS_NATIVE_PROXY) {
       return combine([argTag, proxyTag]);
     });
 
+    HASH_PROXIES.add(proxy);
+
     return proxy;
   };
 } else {
@@ -129,6 +137,8 @@ if (HAS_NATIVE_PROXY) {
 
       return combine([argTag, proxyTag]);
     });
+
+    HASH_PROXIES.add(proxy);
 
     return proxy;
   };


### PR DESCRIPTION
Adds `isHashProxy` to be able to determine if a value is a hash proxy.
This will be used to special case chain tags for computeds/observers.