### PR TITLE
Remove deprecated Component Manager version 3.4

### DIFF
--- a/packages/@glimmer/manager/lib/public/component.ts
+++ b/packages/@glimmer/manager/lib/public/component.ts
@@ -43,15 +43,11 @@ export function componentCapabilities<Version extends keyof ComponentCapabilitie
   managerAPI: Version,
   options: ComponentCapabilitiesVersions[Version] = {}
 ): ComponentCapabilities {
-  if (DEBUG && managerAPI !== '3.4' && managerAPI !== '3.13') {
+  if (DEBUG && managerAPI !== '3.13') {
     throw new Error('Invalid component manager compatibility specified');
   }
 
-  let updateHook = true;
-
-  if (managerAPI === '3.13') {
-    updateHook = Boolean((options as ComponentCapabilitiesVersions['3.13']).updateHook);
-  }
+  let updateHook = Boolean((options as ComponentCapabilitiesVersions['3.13']).updateHook);
 
   return buildCapabilities({
     asyncLifeCycleCallbacks: Boolean(options.asyncLifecycleCallbacks),


### PR DESCRIPTION
According to the [deprecation guide](https://deprecations.emberjs.com/v3.x/#toc_manager-capabilities-components-3-4), support for 3.4 is removed in Ember 4.0 and `update hooks are no longer called by default`.