### PR TITLE
Remove deprecated Modifier Manager version 3.13

### DIFF
--- a/packages/@glimmer/integration-tests/test/managers/modifier-manager-test.ts
+++ b/packages/@glimmer/integration-tests/test/managers/modifier-manager-test.ts
@@ -282,81 +282,6 @@ abstract class ModifierManagerTest extends RenderTest {
   }
 }
 
-class ModifierManagerTest313 extends ModifierManagerTest {
-  static suiteName = 'Basic Custom Modifier Manager: 3.13';
-
-  CustomModifierManager = class CustomModifierManager implements ModifierManager<CustomModifier> {
-    capabilities = modifierCapabilities('3.13');
-
-    constructor(public owner: Owner) {}
-
-    createModifier(
-      Modifier: { create(owner: Owner, args: Arguments): CustomModifier },
-      args: Arguments
-    ) {
-      return Modifier.create(this.owner, args);
-    }
-
-    installModifier(instance: CustomModifier, element: Element, args: Arguments) {
-      instance.element = element;
-      instance.args = args;
-      instance.didInsertElement();
-    }
-
-    updateModifier(instance: CustomModifier, args: Arguments) {
-      instance.args = args;
-      instance.didUpdate();
-    }
-
-    destroyModifier(instance: CustomModifier) {
-      instance.willDestroyElement();
-    }
-  };
-
-  @test 'modifers consume all arguments'(assert: Assert) {
-    let insertCount = 0;
-    let updateCount = 0;
-
-    let foo = this.defineModifier(
-      class extends CustomModifier {
-        didInsertElement() {
-          insertCount++;
-
-          // consume qux
-          // eslint-disable-next-line no-unused-expressions
-          this.args.named.qux;
-        }
-
-        didUpdate() {
-          updateCount++;
-
-          // consume qux
-          // eslint-disable-next-line no-unused-expressions
-          this.args.named.qux;
-        }
-      }
-    );
-
-    let Main = defineComponent({ foo }, '<h1 {{foo bar=@bar qux=@qux}}>hello world</h1>');
-    let args = trackedObj({ bar: 'bar', qux: 'qux' });
-
-    this.renderComponent(Main, args);
-
-    this.assertHTML(`<h1>hello world</h1>`);
-
-    assert.equal(insertCount, 1);
-    assert.equal(updateCount, 0);
-
-    args.bar = 'other bar';
-    this.rerender();
-    assert.equal(updateCount, 1);
-
-    args.qux = 'quuuuxxxxxx';
-    this.rerender();
-    assert.equal(updateCount, 2);
-  }
-}
-
 class ModifierManagerTest322 extends ModifierManagerTest {
   static suiteName = 'Basic Custom Modifier Manager: 3.22';
 
@@ -488,4 +413,3 @@ class ModifierManagerTest322 extends ModifierManagerTest {
 }
 
 jitSuite(ModifierManagerTest322);
-jitSuite(ModifierManagerTest313);

--- a/packages/@glimmer/manager/lib/public/modifier.ts
+++ b/packages/@glimmer/manager/lib/public/modifier.ts
@@ -27,17 +27,17 @@ export function modifierCapabilities<Version extends keyof ModifierCapabilitiesV
   managerAPI: Version,
   optionalFeatures: ModifierCapabilitiesVersions[Version] = {}
 ): ModifierCapabilities {
-  if (DEBUG && managerAPI !== '3.13' && managerAPI !== '3.22') {
+  if (DEBUG && managerAPI !== '3.22') {
     throw new Error('Invalid modifier manager compatibility specified');
   }
 
   return buildCapabilities({
     disableAutoTracking: Boolean(optionalFeatures.disableAutoTracking),
-    useArgsProxy: managerAPI === '3.13' ? false : true,
+    useArgsProxy: true,
 
     // This capability is used in Ember, exclusively in resolution mode. See the
     // Ember glimmer resolver for details.
-    passFactoryToCreate: managerAPI === '3.13',
+    passFactoryToCreate: false,
   });
 }
 


### PR DESCRIPTION
According to the [deprecation guide](https://deprecations.emberjs.com/v3.x/#toc_manager-capabilities-modifiers-3-13), support for 3.13 is removed in Ember 4.0