### PR TITLE
Remove deprecated support for mutation after consumption during certain manager hooks

### DIFF
--- a/packages/@glimmer/integration-tests/test/managers/modifier-manager-test.ts
+++ b/packages/@glimmer/integration-tests/test/managers/modifier-manager-test.ts
@@ -228,11 +228,9 @@ abstract class ModifierManagerTest extends RenderTest {
 
     let Main = defineComponent({ foo }, '<h1 {{foo}}>hello world</h1>');
 
-    this.renderComponent(Main);
-
-    assert.validateDeprecations(
-      /You attempted to update `foo` on `.*`, but it had already been used previously in the same computation/
-    );
+    assert.throws(() => {
+      this.renderComponent(Main);
+    }, /You attempted to update `foo` on `.*`, but it had already been used previously in the same computation/);
   }
 
   @test

--- a/packages/@glimmer/manager/lib/public/component.ts
+++ b/packages/@glimmer/manager/lib/public/component.ts
@@ -18,7 +18,6 @@ import {
 } from '@glimmer/interfaces';
 import { createConstRef, Reference } from '@glimmer/reference';
 import { registerDestructor } from '@glimmer/destroyable';
-import { deprecateMutationsInTrackingTransaction } from '@glimmer/validator';
 import { buildCapabilities, FROM_CAPABILITIES } from '../util/capabilities';
 import { argsProxyFor } from '../util/args-proxy';
 import { ManagerFactory } from './index';
@@ -142,15 +141,7 @@ export class CustomComponentManager<O extends Owner, ComponentInstance>
     let delegate = this.getDelegateFor(owner);
     let args = argsProxyFor(vmArgs.capture(), 'component');
 
-    let component: ComponentInstance;
-
-    if (DEBUG && deprecateMutationsInTrackingTransaction !== undefined) {
-      deprecateMutationsInTrackingTransaction(() => {
-        component = delegate.createComponent(definition, args);
-      });
-    } else {
-      component = delegate.createComponent(definition, args);
-    }
+    let component: ComponentInstance = delegate.createComponent(definition, args);
 
     return new CustomComponentState(component!, delegate, args);
   }

--- a/packages/@glimmer/manager/lib/public/modifier.ts
+++ b/packages/@glimmer/manager/lib/public/modifier.ts
@@ -12,12 +12,7 @@ import { registerDestructor } from '@glimmer/destroyable';
 import { setOwner } from '@glimmer/owner';
 import { valueForRef } from '@glimmer/reference';
 import { assign, castToBrowser, dict } from '@glimmer/util';
-import {
-  createUpdatableTag,
-  deprecateMutationsInTrackingTransaction,
-  untrack,
-  UpdatableTag,
-} from '@glimmer/validator';
+import { createUpdatableTag, untrack, UpdatableTag } from '@glimmer/validator';
 import { SimpleElement } from '@simple-dom/interface';
 import { buildCapabilities, FROM_CAPABILITIES } from '../util/capabilities';
 import { argsProxyFor } from '../util/args-proxy';
@@ -115,8 +110,6 @@ export class CustomModifierManager<O extends Owner, ModifierInstance>
     let argsProxy = argsProxyFor(capturedArgs, 'modifier');
     let args = useArgsProxy ? argsProxy : reifyArgs(capturedArgs);
 
-    let instance: ModifierInstance;
-
     let factoryOrDefinition = definition;
 
     if (passFactoryToCreate) {
@@ -134,13 +127,7 @@ export class CustomModifierManager<O extends Owner, ModifierInstance>
       };
     }
 
-    if (DEBUG && deprecateMutationsInTrackingTransaction !== undefined) {
-      deprecateMutationsInTrackingTransaction(() => {
-        instance = delegate.createModifier(factoryOrDefinition, args);
-      });
-    } else {
-      instance = delegate.createModifier(factoryOrDefinition, args);
-    }
+    let instance: ModifierInstance = delegate.createModifier(factoryOrDefinition, args);
 
     let tag = createUpdatableTag();
     let state: CustomModifierState<ModifierInstance>;

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -67,5 +67,4 @@ export {
   runInTrackingTransaction,
   beginTrackingTransaction,
   endTrackingTransaction,
-  deprecateMutationsInTrackingTransaction,
 } from './lib/debug';


### PR DESCRIPTION
This PR removes supporting infrastructure for allowing, but deprecating read after write in components and modifiers.  Going forward, this will error with a message that you attempted to read then write in the same transaction.

Ref Ember.js issue: https://github.com/emberjs/ember.js/issues/19617

Ember.js PR: https://github.com/emberjs/ember.js/pull/19735