### PR TITLE
[cleanup]: Remove `this.` property fallback (e.g. the `this-property-fallback` deprecation)

### DIFF
--- a/benchmark/benchmarks/krausest/lib/components/Row.hbs
+++ b/benchmark/benchmarks/krausest/lib/components/Row.hbs
@@ -1,6 +1,6 @@
 <tr class={{if @item.selected "danger"}}>
   <td class="col-md-1">{{@item.id}}</td>
-  <td class="col-md-4"><a {{on "click" onSelect}}>{{@item.label}}</a></td>
+  <td class="col-md-4"><a {{on "click" this.onSelect}}>{{@item.label}}</a></td>
   <td class="col-md-1"><a><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
   <td class="col-md-6"></td>
 </tr>

--- a/packages/@glimmer/integration-tests/test/ember-component-test.ts
+++ b/packages/@glimmer/integration-tests/test/ember-component-test.ts
@@ -542,7 +542,7 @@ class CurlyScopeTest extends CurlyTest {
   }
 
   @test
-  'correct scope - self lookup inside #each'(assert: Assert) {
+  'correct scope - self lookup inside #each'() {
     this.registerComponent('TemplateOnly', 'SubItem', `<p>{{@name}}</p>`);
 
     let subitems = [{ id: 0 }, { id: 1 }, { id: 42 }];
@@ -552,8 +552,7 @@ class CurlyScopeTest extends CurlyTest {
         <div>
           {{#each this.items key="id" as |item|}}
             <SubItem @name={{this.id}} />
-            {{! Intentional property fallback to test self lookup }}
-            <SubItem @name={{id}} />
+            <SubItem @name={{this.id}} />
             <SubItem @name={{item.id}} />
           {{/each}}
         </div>`,
@@ -568,10 +567,6 @@ class CurlyScopeTest extends CurlyTest {
           <p>(self)</p><p>(self)</p><p>42</p>
         </div>
       `
-    );
-
-    assert.validateDeprecations(
-      /The `id` property was used in the `.*` template without using `this`/
     );
   }
 
@@ -1632,32 +1627,6 @@ class CurlyGlimmerComponentTest extends CurlyTest {
 
     this.assertHTML('Foo');
     this.assertStableNodes();
-  }
-
-  @test
-  'Can use implicit this fallback for `component.name` emberjs/ember.js#19313'(assert: Assert) {
-    this.registerComponent(
-      'Glimmer',
-      'Outer',
-      '{{component.name}}',
-      class extends GlimmerishComponent {
-        get component() {
-          return { name: 'Foo' };
-        }
-      }
-    );
-
-    this.render('<Outer />');
-    this.assertHTML('Foo');
-
-    this.rerender();
-
-    this.assertHTML('Foo');
-    this.assertStableNodes();
-
-    assert.validateDeprecations(
-      /The `component\.name` property path was used in the `.*` template without using `this`/
-    );
   }
 }
 

--- a/packages/@glimmer/integration-tests/test/helpers/dynamic-helpers-test.ts
+++ b/packages/@glimmer/integration-tests/test/helpers/dynamic-helpers-test.ts
@@ -21,29 +21,6 @@ class DynamicHelpersResolutionModeTest extends RenderTest {
   }
 
   @test
-  'Can invoke a helper definition based on this fallback lookup in resolution mode'(
-    assert: Assert
-  ) {
-    const foo = defineSimpleHelper(() => 'Hello, world!');
-    this.registerComponent(
-      'Glimmer',
-      'Bar',
-      '{{x.foo}}',
-      class extends GlimmerishComponent {
-        x = { foo };
-      }
-    );
-
-    this.render('<Bar/>');
-    this.assertHTML('Hello, world!');
-    this.assertStableRerender();
-
-    assert.validateDeprecations(
-      /The `x\.foo` property path was used in the `.*` template without using `this`/
-    );
-  }
-
-  @test
   'Can use a dynamic helper with nested helpers'() {
     const foo = defineSimpleHelper(() => 'world!');
     const bar = defineSimpleHelper((value: string) => 'Hello, ' + value);

--- a/packages/@glimmer/integration-tests/test/updating-test.ts
+++ b/packages/@glimmer/integration-tests/test/updating-test.ts
@@ -101,7 +101,7 @@ class UpdatingTest extends RenderTest {
     this.render(
       stripTight`
         <div>
-          [{{this.[]}}]
+          [{{this.['']}}]
           [{{this.[1]}}]
           [{{this.[undefined]}}]
           [{{this.[null]}}]
@@ -110,7 +110,7 @@ class UpdatingTest extends RenderTest {
           [{{this.[this]}}]
           [{{this.[foo.bar]}}]
 
-          [{{this.nested.[]}}]
+          [{{this.nested.['']}}]
           [{{this.nested.[1]}}]
           [{{this.nested.[undefined]}}]
           [{{this.nested.[null]}}]
@@ -125,7 +125,7 @@ class UpdatingTest extends RenderTest {
 
     this.assertHTML(stripTight`
       <div>
-        [empty string]
+        []
         [1]
         [undefined]
         [null]
@@ -134,7 +134,7 @@ class UpdatingTest extends RenderTest {
         [this]
         [foo.bar]
 
-        [empty string]
+        []
         [1]
         [undefined]
         [null]
@@ -159,7 +159,7 @@ class UpdatingTest extends RenderTest {
 
     this.assertHTML(stripTight`
       <div>
-        [EMPTY STRING]
+        []
         [ONE]
         [UNDEFINED]
         [NULL]
@@ -168,7 +168,7 @@ class UpdatingTest extends RenderTest {
         [THIS]
         [FOO.BAR]
 
-        [EMPTY STRING]
+        []
         [ONE]
         [UNDEFINED]
         [NULL]
@@ -196,7 +196,7 @@ class UpdatingTest extends RenderTest {
 
     this.assertHTML(stripTight`
       <div>
-        [empty string]
+        []
         [1]
         [undefined]
         [null]
@@ -205,7 +205,7 @@ class UpdatingTest extends RenderTest {
         [this]
         [foo.bar]
 
-        [empty string]
+        []
         [1]
         [undefined]
         [null]
@@ -215,10 +215,6 @@ class UpdatingTest extends RenderTest {
         [foo.bar]
       </div>
     `);
-
-    assert.validateDeprecations(
-      /The `` property was used in the `.*` template without using `this`/
-    );
   }
 
   @test
@@ -935,8 +931,8 @@ class UpdatingTest extends RenderTest {
         foo: "{{foo}}";
         bar: "{{bar}}";
         value: "{{this.value}}";
-        echo foo: "{{echo foo}}";
-        echo bar: "{{echo bar}}";
+        echo foo: "{{echo this.foo}}";
+        echo bar: "{{echo this.bar}}";
         echo value: "{{echo this.value}}";
 
         -----
@@ -946,7 +942,7 @@ class UpdatingTest extends RenderTest {
           bar: "{{bar}}";
           value: "{{this.value}}";
           echo foo: "{{echo foo}}";
-          echo bar: "{{echo bar}}";
+          echo bar: "{{echo this.bar}}";
           echo value: "{{echo this.value}}";
 
           -----
@@ -967,7 +963,7 @@ class UpdatingTest extends RenderTest {
           foo: "{{foo}}";
           bar: "{{bar}}";
           value: "{{this.value}}";
-          echo foo: "{{echo foo}}";
+          echo foo: "{{echo this.foo}}";
           echo bar: "{{echo bar}}";
           echo value: "{{echo this.value}}";
         {{/with}}
@@ -1101,19 +1097,12 @@ class UpdatingTest extends RenderTest {
       </div>`,
       'After reset'
     );
-
-    assert.validateDeprecations(
-      /The `foo` property path was used in the `.*` template without using `this`/,
-      /The `bar` property path was used in the `.*` template without using `this`/,
-      /The `bar` property path was used in the `.*` template without using `this`/,
-      /The `foo` property path was used in the `.*` template without using `this`/
-    );
   }
 
   @test
   'block arguments (ensure balanced push/pop)'() {
     let person = { name: { first: 'Godfrey', last: 'Chan' } };
-    this.render('<div>{{#with this.person.name.first as |f|}}{{f}}{{/with}}{{f}}</div>', {
+    this.render('<div>{{#with this.person.name.first as |f|}}{{f}}{{/with}}{{this.f}}</div>', {
       person,
       f: 'Outer',
     });
@@ -1124,10 +1113,6 @@ class UpdatingTest extends RenderTest {
     this.rerender({ person });
 
     this.assertHTML('<div>GodfreakOuter</div>', 'After updating');
-
-    assert.validateDeprecations(
-      /The `f` property was used in the `.*` template without using `this`/
-    );
   }
 
   @test

--- a/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
@@ -88,7 +88,6 @@ export type ResolveOptionalHelperOp = [
   op1: WireFormat.Expressions.Expression,
   op2: {
     ifHelper: (handle: number, name: string, moduleName: string) => void;
-    ifFallback: (name: string, moduleName: string) => void;
   }
 ];
 
@@ -99,7 +98,6 @@ export type ResolveOptionalComponentOrHelperOp = [
     ifComponent: (component: CompileTimeComponent) => void;
     ifHelper: (handle: number) => void;
     ifValue: (handle: number) => void;
-    ifFallback: (name: string) => void;
   }
 ];
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -309,7 +309,7 @@ export function resolveOptionalHelper(
   resolver: CompileTimeResolver,
   constants: CompileTimeConstants & ResolutionTimeConstants,
   meta: ContainingMetadata,
-  [, expr, { ifHelper, ifFallback }]: ResolveOptionalHelperOp
+  [, expr, { ifHelper }]: ResolveOptionalHelperOp
 ): void {
   assert(
     isGetFreeOptionalHelper(expr) || isGetFreeDeprecatedHelper(expr),
@@ -320,9 +320,7 @@ export function resolveOptionalHelper(
   let name = upvars[expr[1]];
   let helper = resolver.lookupHelper(name, owner);
 
-  if (helper === null) {
-    ifFallback(name, meta.moduleName);
-  } else {
+  if (helper) {
     ifHelper(constants.helper(helper, name), name, meta.moduleName);
   }
 }
@@ -334,7 +332,7 @@ export function resolveOptionalComponentOrHelper(
   resolver: CompileTimeResolver,
   constants: CompileTimeConstants & ResolutionTimeConstants,
   meta: ContainingMetadata,
-  [, expr, { ifComponent, ifHelper, ifValue, ifFallback }]: ResolveOptionalComponentOrHelperOp
+  [, expr, { ifComponent, ifHelper, ifValue }]: ResolveOptionalComponentOrHelperOp
 ): void {
   assert(
     isGetFreeOptionalComponentOrHelper(expr),
@@ -396,10 +394,7 @@ export function resolveOptionalComponentOrHelper(
 
     if (helper !== null) {
       ifHelper(constants.helper(helper, name));
-      return;
     }
-
-    ifFallback(name);
   }
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -1,4 +1,3 @@
-import { deprecate } from '@glimmer/global-context';
 import {
   CompileTimeComponent,
   ContentType,
@@ -159,24 +158,6 @@ STATEMENTS.add(SexpOpcodes.Append, (op, [, value]) => {
         op(MachineOp.PushFrame);
         op(Op.ConstantReference, handle);
         op(MachineOp.InvokeStatic, stdlibOperand('cautious-non-dynamic-append'));
-        op(MachineOp.PopFrame);
-      },
-
-      ifFallback(_name: string) {
-        op(MachineOp.PushFrame);
-        op(HighLevelResolutionOpcode.ResolveLocal, value[1], (name: string, moduleName: string) => {
-          deprecate(
-            `The \`${name}\` property was used in the \`${moduleName}\` template without using \`this\`. This fallback behavior has been deprecated, all properties must be looked up on \`this\` when used in the template: {{this.${name}}}`,
-            false,
-            {
-              id: 'this-property-fallback',
-            }
-          );
-
-          op(Op.GetVariable, 0);
-          op(Op.GetProperty, name);
-        });
-        op(MachineOp.InvokeStatic, stdlibOperand('cautious-append'));
         op(MachineOp.PopFrame);
       },
     });


### PR DESCRIPTION
This PR removes missing `this` deprecations and supporting code.

Ref Ember.js issue: https://github.com/emberjs/ember.js/issues/19617

Ember.js PR: https://github.com/emberjs/ember.js/pull/19736