### PR TITLE
Use `Object.assign` instead of custom `copy` function

### DIFF
--- a/packages/@glimmer/syntax/lib/v2-a/objects/node.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/objects/node.ts
@@ -60,7 +60,7 @@ export function node<T extends string>(
           constructor(fields: BaseNodeFields & Fields) {
             this.type = type;
             this.loc = fields.loc;
-            copy(fields, (this as unknown) as ConstructingTypedNode<Fields>);
+            Object.assign(this, fields);
           }
         } as TypedNodeConstructor<T, BaseNodeFields & Fields>;
       },
@@ -73,18 +73,13 @@ export function node<T extends string>(
 
           constructor(fields: BaseNodeFields & Fields) {
             this.loc = fields.loc;
-
-            copy(fields, (this as unknown) as ConstructingNode<Fields>);
+            Object.assign(this, fields);
           }
         } as NodeConstructor<BaseNodeFields & Fields>;
       },
     };
   }
 }
-
-type ConstructingTypedNode<Fields> = Fields & BaseNodeFields;
-
-type ConstructingNode<Fields> = BaseNodeFields & Fields;
 
 export interface NodeConstructor<Fields> {
   new (fields: Fields): Readonly<Fields>;
@@ -94,14 +89,4 @@ type TypedNode<T extends string, Fields> = { type: T } & Readonly<Fields>;
 
 export interface TypedNodeConstructor<T extends string, Fields> {
   new (options: Fields): TypedNode<T, Fields>;
-}
-
-function keys<O extends object>(object: O): (keyof O)[] {
-  return Object.keys(object) as (keyof O)[];
-}
-
-function copy<O extends object>(object1: O, object2: O) {
-  for (let key of keys(object1)) {
-    object2[key] = object1[key];
-  }
 }

--- a/packages/@glimmer/syntax/lib/v2-a/objects/node.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/objects/node.ts
@@ -1,3 +1,5 @@
+import { assign } from '@glimmer/util';
+
 import { SourceSpan } from '../../source/span';
 
 export interface BaseNodeFields {
@@ -54,13 +56,13 @@ export function node<T extends string>(
     return {
       fields<Fields extends object>(): TypedNodeConstructor<T, BaseNodeFields & Fields> {
         return class {
-          // SAFETY: initialized via Object.assign in the constructor.
+          // SAFETY: initialized via `assign` in the constructor.
           declare readonly loc: SourceSpan;
           readonly type: T;
 
           constructor(fields: BaseNodeFields & Fields) {
             this.type = type;
-            Object.assign(this, fields);
+            assign(this, fields);
           }
         } as TypedNodeConstructor<T, BaseNodeFields & Fields>;
       },
@@ -69,11 +71,11 @@ export function node<T extends string>(
     return {
       fields<Fields>(): NodeConstructor<Fields & BaseNodeFields> {
         return class {
-          // SAFETY: initialized via Object.assign in the constructor.
+          // SAFETY: initialized via `assign` in the constructor.
           declare readonly loc: SourceSpan;
 
           constructor(fields: BaseNodeFields & Fields) {
-            Object.assign(this, fields);
+            assign(this, fields);
           }
         } as NodeConstructor<BaseNodeFields & Fields>;
       },

--- a/packages/@glimmer/syntax/lib/v2-a/objects/node.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/objects/node.ts
@@ -54,12 +54,12 @@ export function node<T extends string>(
     return {
       fields<Fields extends object>(): TypedNodeConstructor<T, BaseNodeFields & Fields> {
         return class {
-          readonly loc: SourceSpan;
+          // SAFETY: initialized via Object.assign in the constructor.
+          declare readonly loc: SourceSpan;
           readonly type: T;
 
           constructor(fields: BaseNodeFields & Fields) {
             this.type = type;
-            this.loc = fields.loc;
             Object.assign(this, fields);
           }
         } as TypedNodeConstructor<T, BaseNodeFields & Fields>;
@@ -69,10 +69,10 @@ export function node<T extends string>(
     return {
       fields<Fields>(): NodeConstructor<Fields & BaseNodeFields> {
         return class {
-          readonly loc: SourceSpan;
+          // SAFETY: initialized via Object.assign in the constructor.
+          declare readonly loc: SourceSpan;
 
           constructor(fields: BaseNodeFields & Fields) {
-            this.loc = fields.loc;
             Object.assign(this, fields);
           }
         } as NodeConstructor<BaseNodeFields & Fields>;


### PR DESCRIPTION
While investigating possible ways of mitigating the build time costs identified in emberjs/ember.js#19750, we noticed this custom `copy` implementation. Since it performs the same basic behavior as `Object.assign`, I replaced it with `Object.assign`.

This has no impact on runtime performance (see below), and drops about 1.1KB of non-minified, uncompressed bytes across the wire.

## Runtime Performance

I ran it against the set of templates we pulled together in https://github.com/brendenpalmer/repro-ember-3-25-template-regression, using [this PR](https://github.com/brendenpalmer/repro-ember-3-25-template-regression/pull/2) with the following results.

While it looks like a small percentage decrease against the baseline, the variance between runs is significant enough (even with 5 runs per compiler) that I don't think this is meaningful. That said, I'm still going to run this change through our app as well, and if that looks more meaningful I'll report that below.

### With current Glimmer VM `master`

|                            source                             |  time   |
| ------------------------------------------------------------- | ------- |
| ember-source@3.24.5 (ember-source-3-24)                       | 1958.2  |
| ember-source@3.25.4 (ember-source-3-25)                       | 12742.2 |
| ember-source@3.28.1 (ember-source-3-28)                       | 12499.4 |
| @glimmer/compiler@0.65.3 (glimmer-compiler-ember-source-3-24) | 1981.2  |
| @glimmer/compiler@0.80.0 (glimmer-compiler-ember-source-3-28) | 13433.6 |
| @glimmer/compiler@0.80.0 (glimmer-compiler-experiment)        | 4201.4  |

### With `Object.assign`

This adds in `Object.assign` replacing `copy`.

|                            source                             |  time   |
| ------------------------------------------------------------- | ------- |
| ember-source@3.24.5 (ember-source-3-24)                       | 2147.2  |
| ember-source@3.25.4 (ember-source-3-25)                       | 19060.6 |
| ember-source@3.28.1 (ember-source-3-28)                       | 15271.6 |
| @glimmer/compiler@0.65.3 (glimmer-compiler-ember-source-3-24) | 2246    |
| @glimmer/compiler@0.80.0 (glimmer-compiler-ember-source-3-28) | 21358   |
| @glimmer/compiler@0.80.0 (glimmer-compiler-experiment)        | 4369    |