### PR TITLE
Remove deprecated versions of modifier/component manager capabilities from error messages

### DIFF
--- a/packages/@glimmer/manager/lib/public/component.ts
+++ b/packages/@glimmer/manager/lib/public/component.ts
@@ -121,7 +121,7 @@ export class CustomComponentManager<O extends Owner, ComponentInstance>
       if (DEBUG && !FROM_CAPABILITIES!.has(delegate.capabilities)) {
         // TODO: This error message should make sense in both Ember and Glimmer https://github.com/glimmerjs/glimmer-vm/issues/1200
         throw new Error(
-          `Custom component managers must have a \`capabilities\` property that is the result of calling the \`capabilities('3.4' | '3.13')\` (imported via \`import { capabilities } from '@ember/component';\`). Received: \`${JSON.stringify(
+          `Custom component managers must have a \`capabilities\` property that is the result of calling the \`capabilities('3.13')\` (imported via \`import { capabilities } from '@ember/component';\`). Received: \`${JSON.stringify(
             delegate.capabilities
           )}\` for: \`${delegate}\``
         );

--- a/packages/@glimmer/manager/lib/public/modifier.ts
+++ b/packages/@glimmer/manager/lib/public/modifier.ts
@@ -80,7 +80,7 @@ export class CustomModifierManager<O extends Owner, ModifierInstance>
       if (DEBUG && !FROM_CAPABILITIES!.has(delegate.capabilities)) {
         // TODO: This error message should make sense in both Ember and Glimmer https://github.com/glimmerjs/glimmer-vm/issues/1200
         throw new Error(
-          `Custom modifier managers must have a \`capabilities\` property that is the result of calling the \`capabilities('3.13' | '3.22')\` (imported via \`import { capabilities } from '@ember/modifier';\`). Received: \`${JSON.stringify(
+          `Custom modifier managers must have a \`capabilities\` property that is the result of calling the \`capabilities('3.22')\` (imported via \`import { capabilities } from '@ember/modifier';\`). Received: \`${JSON.stringify(
             delegate.capabilities
           )}\` for: \`${delegate}\``
         );


### PR DESCRIPTION
Error messages were incorrect, plus they're causing tests in ember.js to fail that check the error messages