### PR TITLE
Cache `head` getter in `PathExpressionImplV1`

### DIFF
--- a/packages/@glimmer/syntax/lib/v1/legacy-interop.ts
+++ b/packages/@glimmer/syntax/lib/v1/legacy-interop.ts
@@ -23,7 +23,14 @@ export class PathExpressionImplV1 implements PathExpression {
     this.parts = parts;
   }
 
+  // Cache for the head value.
+  _head?: PathHead = undefined;
+
   get head(): PathHead {
+    if (this._head) {
+      return this._head;
+    }
+
     let firstPart: string;
 
     if (this.this) {
@@ -38,7 +45,7 @@ export class PathExpressionImplV1 implements PathExpression {
       chars: firstPart.length,
     }).loc;
 
-    return b.head(firstPart, firstPartLoc);
+    return (this._head = b.head(firstPart, firstPartLoc));
   }
 
   get tail(): string[] {


### PR DESCRIPTION
This is one of the hot paths during normalization, and it in turn calls the *hottest* paths of normalization (`hbsPosFor` and `hbsCharFor`). Adding this cache improves performance againt the baseline by nearly 50% of the current delta:

|           variant            | average | min  | max  |
| ---------------------------- | ------- | ---- | ---- |
| @glimmer/compiler@0.65.3     | 6901.4  | 6812 | 6944 |
| @glimmer/compiler@master     | 9000.4  | 8925 | 9041 |
| @glimmer/compiler@experiment | 8144.8  | 8078 | 8240 |