### PR TITLE
Cache `hbsPosFor(offset)` in `Source`

### DIFF
--- a/packages/@glimmer/syntax/lib/source/source.ts
+++ b/packages/@glimmer/syntax/lib/source/source.ts
@@ -31,11 +31,19 @@ export class Source {
     });
   }
 
+  private _hbsPosesFor = new Map<number, SourcePosition | null>();
+
   hbsPosFor(offset: number): Option<SourcePosition> {
+    const current = this._hbsPosesFor.get(offset);
+    if (current !== undefined) {
+      return current;
+    }
+
     let seenLines = 0;
     let seenChars = 0;
 
     if (offset > this.source.length) {
+      this._hbsPosesFor.set(offset, null);
       return null;
     }
 
@@ -43,10 +51,12 @@ export class Source {
       let nextLine = this.source.indexOf('\n', seenChars);
 
       if (offset <= nextLine || nextLine === -1) {
-        return {
+        let position = {
           line: seenLines + 1,
           column: offset - seenChars,
         };
+        this._hbsPosesFor.set(offset, position);
+        return position;
       } else {
         seenLines += 1;
         seenChars = nextLine + 1;


### PR DESCRIPTION
`hbsPosFor` is currently the hottest path in the current implementation of the template compiler in terms of self time. Adding this cache for it improves throughput by about half a second in [one rough benchmark][bench] (against a collection of about 1,500 templates totaling about 54,000 lines of Handlebars), run 5 times against each version of the compiler:

[bench]: https://github.com/brendenpalmer/repro-ember-3-25-template-regression/pull/2

|           variant            | average | min  | max  |
| ---------------------------- | ------- | ---- | ---- |
| @glimmer/compiler@0.65.3     | 7002.2  | 6976 | 7031 |
| @glimmer/compiler@master     | 9181.4  | 9159 | 9202 |
| @glimmer/compiler@experiment | 8445.2  | 8400 | 8507 |

Additionally, `hbsPosFor` *stops* being the largest self time; in the same rough benchmark, it dropped from ~560ms to ~97ms of self time.