### PR TITLE
Avoid using a nested WeakMap for manager instances for a given owner.

### DIFF
--- a/packages/@glimmer/runtime/lib/managers/index.ts
+++ b/packages/@glimmer/runtime/lib/managers/index.ts
@@ -40,10 +40,7 @@ const HELPER_MANAGERS = new WeakMap<
   ManagerFactory<Owner | undefined, HelperManager<unknown> | Helper>
 >();
 
-const OWNER_MANAGER_INSTANCES: WeakMap<
-  Owner,
-  WeakMap<ManagerFactory<Owner>, unknown>
-> = new WeakMap();
+const OWNER_MANAGER_INSTANCES: WeakMap<Owner, Map<ManagerFactory<Owner>, unknown>> = new WeakMap();
 const UNDEFINED_MANAGER_INSTANCES: WeakMap<ManagerFactory<Owner>, unknown> = new WeakMap();
 
 export type ManagerFactory<O, D extends ManagerDelegate = ManagerDelegate> = (owner: O) => D;
@@ -107,7 +104,7 @@ function getManagerInstanceForOwner<D extends ManagerDelegate>(
     managers = OWNER_MANAGER_INSTANCES.get(owner);
 
     if (managers === undefined) {
-      managers = new WeakMap();
+      managers = new Map();
       OWNER_MANAGER_INSTANCES.set(owner, managers);
     }
   }


### PR DESCRIPTION
The first level WeakMap is sufficient to prevent memory leaks. The only potential value that the second level WeakMap provides is to allow us to _unload_ code during the lifetime of a single owner instance, which is really not something that we support.

Having nested WeakMap's breaks some tooling around memory leak investigation that we commonly use.
