### PR TITLE
Implementation for RFC #756

### DIFF
--- a/packages/@glimmer/manager/lib/internal/defaults.ts
+++ b/packages/@glimmer/manager/lib/internal/defaults.ts
@@ -1,6 +1,10 @@
 import { buildCapabilities } from '../util/capabilities';
 
-import type { CapturedArguments as Arguments, HelperCapabilities } from '@glimmer/interfaces';
+import type {
+  CapturedArguments as Arguments,
+  HelperCapabilities,
+  HelperManagerWithValue,
+} from '@glimmer/interfaces';
 
 type FnArgs<Args extends Arguments = Arguments> =
   | [...Args['positional'], Args['named']]
@@ -20,11 +24,11 @@ export class FunctionHelperManager implements HelperManagerWithValue<State> {
     hasScheduledEffect: false,
   }) as HelperCapabilities;
 
-  createHelper(fn: AnyFunction, args: Arguments) {
+  createHelper(fn: AnyFunction, args: Arguments): State {
     return { fn, args };
   }
 
-  getValue({ fn, args }: State) {
+  getValue({ fn, args }: State): unknown {
     if (Object.keys(args.named).length > 0) {
       let argsForFn: FnArgs<Arguments> = [...args.positional, args.named];
 
@@ -34,7 +38,7 @@ export class FunctionHelperManager implements HelperManagerWithValue<State> {
     return fn(...args.positional);
   }
 
-  getDebugName(fn: AnyFunction) {
+  getDebugName(fn: AnyFunction): string {
     if (fn.name) {
       return `(helper function ${fn.name})`;
     }

--- a/packages/@glimmer/manager/lib/internal/defaults.ts
+++ b/packages/@glimmer/manager/lib/internal/defaults.ts
@@ -13,7 +13,7 @@ interface State {
   args: Arguments;
 }
 
-export class FunctionHelperManager {
+export class FunctionHelperManager implements HelperManagerWithValue<State> {
   capabilities = buildCapabilities({
     hasValue: true,
     hasDestroyable: false,

--- a/packages/@glimmer/manager/lib/internal/defaults.ts
+++ b/packages/@glimmer/manager/lib/internal/defaults.ts
@@ -1,0 +1,44 @@
+import { buildCapabilities } from '../util/capabilities';
+
+import type { CapturedArguments as Arguments, HelperCapabilities } from '@glimmer/interfaces';
+
+type FnArgs<Args extends Arguments = Arguments> =
+  | [...Args['positional'], Args['named']]
+  | [...Args['positional']];
+
+type AnyFunction = (...args: any[]) => unknown;
+
+interface State {
+  fn: AnyFunction;
+  args: Arguments;
+}
+
+export class FunctionHelperManager {
+  capabilities = buildCapabilities({
+    hasValue: true,
+    hasDestroyable: false,
+    hasScheduledEffect: false,
+  }) as HelperCapabilities;
+
+  createHelper(fn: AnyFunction, args: Arguments) {
+    return { fn, args };
+  }
+
+  getValue({ fn, args }: State) {
+    if (Object.keys(args.named).length > 0) {
+      let argsForFn: FnArgs<Arguments> = [...args.positional, args.named];
+
+      return fn(...argsForFn);
+    }
+
+    return fn(...args.positional);
+  }
+
+  getDebugName(fn: AnyFunction) {
+    if (fn.name) {
+      return `(helper function ${fn.name})`;
+    }
+
+    return '(anonymous helper function)';
+  }
+}

--- a/packages/@glimmer/manager/lib/internal/index.ts
+++ b/packages/@glimmer/manager/lib/internal/index.ts
@@ -7,6 +7,7 @@ import {
   Owner,
 } from '@glimmer/interfaces';
 import { CustomHelperManager } from '../public/helper';
+import { FunctionHelperManager } from './defaults';
 
 type InternalManager =
   | InternalComponentManager
@@ -119,6 +120,8 @@ export function setInternalHelperManager<T extends object, O extends Owner>(
   return setManager(HELPER_MANAGERS, manager, definition);
 }
 
+const DEFAULT_MANAGER = new CustomHelperManager(() => new FunctionHelperManager());
+
 export function getInternalHelperManager(definition: object): CustomHelperManager | Helper;
 export function getInternalHelperManager(
   definition: object,
@@ -138,7 +141,13 @@ export function getInternalHelperManager(
     );
   }
 
-  const manager = getManager(HELPER_MANAGERS, definition);
+  let manager = getManager(HELPER_MANAGERS, definition);
+
+  // Functions are special-cased because functions are defined
+  // as the "default" helper, per: https://github.com/emberjs/rfcs/pull/756
+  if (manager === undefined && typeof definition === 'function') {
+    manager = DEFAULT_MANAGER;
+  }
 
   if (manager) {
     return manager;

--- a/packages/@glimmer/manager/test/managers-test.ts
+++ b/packages/@glimmer/manager/test/managers-test.ts
@@ -183,9 +183,24 @@ module('Managers', () => {
       assert.ok(typeof instance === 'object', 'manager is an internal manager');
       assert.ok(
         typeof instance.getHelper({}) === 'function',
-        'manager can generatew helper function'
+        'manager can generate helper function'
       );
       assert.equal(instance['factory'], factory, 'manager has correct delegate factory');
+    });
+
+    test('it determines the default manager', (assert) => {
+      let myTestHelper = () => 0;
+      let instance = getInternalHelperManager(myTestHelper) as CustomHelperManager<object>;
+
+      assert.ok(typeof instance === 'object', 'manager is an internal manager');
+      assert.ok(
+        typeof instance.getHelper({}) === 'function',
+        'manager can generate helper function'
+      );
+      assert.strictEqual(
+        instance['factory']({})?.getDebugName?.(myTestHelper),
+        '(helper function myTestHelper)'
+      );
     });
 
     test('it works with internal helpers', (assert) => {


### PR DESCRIPTION
Implementation of https://github.com/emberjs/rfcs/pull/756


Todo:
- [x] PR to the RFC to add an example of existing behavior today where consuming a tracked value in the helper body entangles with helper execution