### PR TITLE
Followup for loose-mode lexical scope

### DIFF
--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -124,19 +124,17 @@ export function precompile(
     isStrictMode: options.strictMode ?? false,
   };
 
-  if (!options.strictMode) {
+  if (usedLocals.length === 0) {
     delete templateJSONObject.scope;
   }
 
   // JSON is javascript
   let stringified = JSON.stringify(templateJSONObject);
 
-  if (options.strictMode && usedLocals.length > 0) {
+  if (usedLocals.length > 0) {
     let scopeFn = `()=>[${usedLocals.join(',')}]`;
 
     stringified = stringified.replace(`"${SCOPE_PLACEHOLDER}"`, scopeFn);
-  } else {
-    stringified = stringified.replace(`"${SCOPE_PLACEHOLDER}"`, 'null');
   }
 
   return stringified;


### PR DESCRIPTION
#1351 was incomplete, and the test suite didn't make that clear because it doesn't exercise real template precompilation.

This time I've manually tested end-to-end in a real app (alongside ember canary).