### PR TITLE
Fix issues with "loose free variable" lookup by dropping unneeded `GetFreeAsFallback` op code

### DIFF
--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -171,9 +171,6 @@ export default class WireFormatDebugger {
         case Op.GetStrictFree:
           return ['get-strict-free', this.upvars[opcode[1]], opcode[2]];
 
-        case Op.GetFreeAsFallback:
-          return ['GetFreeAsFallback', this.upvars[opcode[1]], opcode[2]];
-
         case Op.GetFreeAsComponentOrHelperHeadOrThisFallback:
           return [
             'GetFreeAsComponentOrHelperHeadOrThisFallback',

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -20,7 +20,6 @@ export const enum VariableResolutionContext {
   AmbiguousAppend = 1,
   AmbiguousAppendInvoke = 2,
   AmbiguousInvoke = 3,
-  LooseFreeVariable = 4,
   ResolveAsCallHead = 5,
   ResolveAsModifierHead = 6,
   ResolveAsComponentHead = 7,
@@ -69,9 +68,6 @@ export const enum SexpOpcodes {
   // Free variables are only keywords in strict mode
   GetStrictFree = 31,
 
-  // falls back to `this.` (or locals in the case of partials), but
-  // never turns into a component or helper invocation
-  GetFreeAsFallback = 33,
   // `{{x}}` in append position (might be a helper or component invocation, otherwise fall back to `this`)
   GetFreeAsComponentOrHelperHeadOrThisFallback = 34,
   // a component or helper (`{{<expr> x}}` in append position)
@@ -117,7 +113,6 @@ export type GetContextualFreeOp =
   | SexpOpcodes.GetFreeAsHelperHead
   | SexpOpcodes.GetFreeAsModifierHead
   | SexpOpcodes.GetFreeAsComponentHead
-  | SexpOpcodes.GetFreeAsFallback
   | SexpOpcodes.GetStrictFree;
 
 export type AttrOp =
@@ -167,7 +162,6 @@ export namespace Expressions {
   export type GetSymbol = [SexpOpcodes.GetSymbol, number];
   export type GetTemplateSymbol = [SexpOpcodes.GetTemplateSymbol, number];
   export type GetStrictFree = [SexpOpcodes.GetStrictFree, number];
-  export type GetFreeAsFallback = [SexpOpcodes.GetFreeAsFallback, number];
   export type GetFreeAsComponentOrHelperHeadOrThisFallback = [
     SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback,
     number
@@ -186,7 +180,6 @@ export namespace Expressions {
   export type GetFreeAsComponentHead = [SexpOpcodes.GetFreeAsComponentHead, number];
 
   export type GetContextualFree =
-    | GetFreeAsFallback
     | GetFreeAsComponentOrHelperHeadOrThisFallback
     | GetFreeAsComponentOrHelperHead
     | GetFreeAsHelperHeadOrThisFallback
@@ -200,7 +193,6 @@ export namespace Expressions {
   export type GetPathSymbol = [SexpOpcodes.GetSymbol, number, Path];
   export type GetPathTemplateSymbol = [SexpOpcodes.GetTemplateSymbol, number, Path];
   export type GetPathStrictFree = [SexpOpcodes.GetStrictFree, number, Path];
-  export type GetPathFreeAsFallback = [SexpOpcodes.GetFreeAsFallback, number, Path];
   export type GetPathFreeAsComponentOrHelperHeadOrThisFallback = [
     SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback,
     number,
@@ -226,7 +218,6 @@ export namespace Expressions {
   export type GetPathFreeAsComponentHead = [SexpOpcodes.GetFreeAsComponentHead, number, Path];
 
   export type GetPathContextualFree =
-    | GetPathFreeAsFallback
     | GetPathFreeAsComponentOrHelperHeadOrThisFallback
     | GetPathFreeAsComponentOrHelperHead
     | GetPathFreeAsHelperHeadOrThisFallback

--- a/packages/@glimmer/opcode-compiler/lib/syntax/expressions.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/expressions.ts
@@ -56,10 +56,6 @@ EXPRESSIONS.add(SexpOpcodes.GetStrictFree, (op, [, sym, _path]) => {
   });
 });
 
-EXPRESSIONS.add(SexpOpcodes.GetFreeAsFallback, (op, [, , path]) => {
-  withPath(op, path);
-});
-
 EXPRESSIONS.add(SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback, () => {
   // TODO: The logic for this opcode currently exists in STATEMENTS.Append, since
   // we want different wrapping logic depending on if we are invoking a component,

--- a/packages/@glimmer/syntax/lib/v2-a/README.md
+++ b/packages/@glimmer/syntax/lib/v2-a/README.md
@@ -46,7 +46,7 @@ An element is a component if the part of its tag name before any `.`:
 
 # Simple Elements
 
-Elements that are not named blocks *and* do not satisfy the component heuristics are represented as `ASTv2.SimpleElement`.
+Elements that are not named blocks _and_ do not satisfy the component heuristics are represented as `ASTv2.SimpleElement`.
 
 # Strict vs. Loose Mode
 
@@ -60,12 +60,12 @@ In `ASTv2`, every variable name is represented as a `VariableReference`.
 
 > The first part of a `PathExpression` is a `VariableReference`.
 
-| type | description |
-| --- | --- |
-| `ThisReference` | the literal `this` |
-| `ArgReference` | a variable reference that begins with with `@` |
-| `LocalVarReference` | a reference to an in-scope variable binding |
-| `FreeVarReference` | a reference to a variable binding that was not introduced by block params (`as |foo|`) |
+| type                | description                                                                    |
+| ------------------- | ------------------------------------------------------------------------------ |
+| `ThisReference`     | the literal `this`                                                             |
+| `ArgReference`      | a variable reference that begins with with `@`                                 |
+| `LocalVarReference` | a reference to an in-scope variable binding                                    |
+| `FreeVarReference`  | a reference to a variable binding that was not introduced by block params (`as | foo | `) |
 
 **Important Note**: The remainder of this README is a description of the loose mode rules for free variable resolution. Strict mode free variable references always refer to an in-scope JavaScript binding, regardless of their syntactic position.
 
@@ -108,33 +108,33 @@ When a free variable resolution is said to have "fallback semantics", it means t
 When a free variable resolution has fallback semantics, it is also said to have "eval mode semantics", which means:
 
 1. If the template is evaluated in eval mode (i.e. as a partial), dynamically resolve the free variable in the context of the template that invoked the partial (the "invoker"):
-  1. If the variable name is in the local scope of the invoker, resolve it as a *local* variable in the invoker's local scope
-  2. Otherwise:
-    1. if the invoker is also in eval mode, repeat the process with the invoker's invoker
-    2. if the invoker is not in eval mode, resolve the free variable using fallback semantics in the invoker's scope
-2. Otherwise, resolve the free variable using fallback semantics in the current scope
+1. If the variable name is in the local scope of the invoker, resolve it as a _local_ variable in the invoker's local scope
+1. Otherwise:
+1. if the invoker is also in eval mode, repeat the process with the invoker's invoker
+1. if the invoker is not in eval mode, resolve the free variable using fallback semantics in the invoker's scope
+1. Otherwise, resolve the free variable using fallback semantics in the current scope
 
 ### Namespaced Variable Resolution
 
-| | |
-| - | - |
-| Syntax Positions | `SubExpression`, `Block`, `Modifier`, `Component` |
-| Path has dots? | ❌ |
-| Arguments? | Any |
-| | |
-| Namespace | see table below |
-| Fallback semantics? | ⛔ |
+|                     |                                                   |
+| ------------------- | ------------------------------------------------- |
+| Syntax Positions    | `SubExpression`, `Block`, `Modifier`, `Component` |
+| Path has dots?      | ❌                                                |
+| Arguments?          | Any                                               |
+|                     |                                                   |
+| Namespace           | see table below                                   |
+| Fallback semantics? | ⛔                                                |
 
 These resolutions occur in syntaxes that are definitely calls (e.g. subexpressions, blocks, modifiers, etc.).
 
 #### Applicable Situation
 
-| situation | variable | namespace |
-| - | - | - |
-| `(x y)` | `x` | `Helper` |
-| `{{#x y}}` | `x` | `Block` |
-| `<p {{x y}}>` | `x` | `Modifier` |
-| `X` in `<X />` | `X` | `Component` |
+| situation      | variable | namespace   |
+| -------------- | -------- | ----------- |
+| `(x y)`        | `x`      | `Helper`    |
+| `{{#x y}}`     | `x`      | `Block`     |
+| `<p {{x y}}>`  | `x`      | `Modifier`  |
+| `X` in `<X />` | `X`      | `Component` |
 
 #### Runtime Error Cases
 
@@ -142,22 +142,22 @@ If the variable reference cannot be resolved in its namespace.
 
 ### Namespaced Resolution: Ambiguous Component or Helper
 
-| | |
-| - | - |
-| Syntax Positions | append |
-| Path has dots? | ❌ |
-| Arguments? | ➕ |
-| | |
-| Namespace | `helper` or `component` |
-| Fallback semantics? | ⛔ |
+|                     |                         |
+| ------------------- | ----------------------- |
+| Syntax Positions    | append                  |
+| Path has dots?      | ❌                      |
+| Arguments?          | ➕                      |
+|                     |                         |
+| Namespace           | `helper` or `component` |
+| Fallback semantics? | ⛔                      |
 
 This resolution occurs in append nodes with at least one argument, and when the path does not have dots (e.g. `{{hello world}}`).
 
 #### Applicable Situation
 
-| situation | variable | namespace |
-| - | - | - |
-| `{{x y}}` as append | `x` | `ComponentOrHelper` |
+| situation           | variable | namespace           |
+| ------------------- | -------- | ------------------- |
+| `{{x y}}` as append | `x`      | `ComponentOrHelper` |
 
 In this situation, the `x` may refer to:
 
@@ -170,22 +170,22 @@ If the variable reference cannot be resolved in the `helper` or `component` name
 
 ### Ambiguous Resolution: Append Ambiguity
 
-| | |
-| - | - |
-| Syntax Positions | append |
-| Path has dots? | ❌ |
-| Arguments? | ❌ |
-| | |
-| Namespace | `helper`, `component` |
-| Fallback semantics? | ✅ |
+|                     |                       |
+| ------------------- | --------------------- |
+| Syntax Positions    | append                |
+| Path has dots?      | ❌                    |
+| Arguments?          | ❌                    |
+|                     |                       |
+| Namespace           | `helper`, `component` |
+| Fallback semantics? | ✅                    |
 
 This resolution occurs in append nodes with zero arguments, and when the path does not have dots (e.g. `{{hello}}`).
 
 #### Applicable Situations
 
-| situation | variable | ambiguity |
-| - | - | - |
-| `{{x}}` as append | `x` | `Append` |
+| situation         | variable | ambiguity |
+| ----------------- | -------- | --------- |
+| `{{x}}` as append | `x`      | `Append`  |
 
 In this situation, the `x` may refer to:
 
@@ -202,20 +202,20 @@ None.
 
 This resolution context occurs in attribute nodes with zero arguments, and when the path does not have dots.
 
-| | |
-| - | - |
-| Syntax Positions | attribute, interpolation |
-| Path has dots? | ❌ |
-| Arguments? | ❌ |
-| | |
-| Namespace | `helper` |
-| Fallback semantics? | ✅ |
+|                     |                          |
+| ------------------- | ------------------------ |
+| Syntax Positions    | attribute, interpolation |
+| Path has dots?      | ❌                       |
+| Arguments?          | ❌                       |
+|                     |                          |
+| Namespace           | `helper`                 |
+| Fallback semantics? | ✅                       |
 
 #### Applicable Situations
 
-| situation | variable | ambiguity |
-| - | - | - |
-| `<p attr={{x}}>` <br> `<a href="{{x}}.html">` | `x` | `Attr` |
+| situation                                     | variable | ambiguity |
+| --------------------------------------------- | -------- | --------- |
+| `<p attr={{x}}>` <br> `<a href="{{x}}.html">` | `x`      | `Attr`    |
 
 In this situation, the `x` may refer to:
 
@@ -226,32 +226,6 @@ In this situation, the `x` may refer to:
 #### Runtime Error Cases
 
 None.
-
-### Loose Free Variable Resolution
-
-These resolution contexts occur in append or attribute nodes with zero positional or named arguments, and when the path has dots.
-
-| | |
-| - | - |
-| Syntax Positions | append, attribute |
-| Path has dots? | ➕ |
-| Arguments? | ❌ |
-| | |
-| Namespace | None |
-| Fallback semantics? | ✅ |
-
-#### Runtime Error Cases
-
-None.
-
-#### Applicable Situations
-
-| situation | variable | resolution |
-| - | - | - |
-| `{{x.y}}` as append <br> `<p attr={{x.y}}>` <br> `<a href="{{x.y}}.html">` | `x` | `LooseFreeVariableResolution` |
-
-In these situations, the `x` may refer to a local variable in partial scope, or it may refer to `this.x`.
-
 
 ### Summary
 
@@ -265,36 +239,36 @@ Situations that meet all three of these criteria are syntax errors:
 2. The callee contains a `.`
 3. The head of the callee is a `FreeVarReference`
 
-| Syntax Position | Example | Dots? | Arguments? |
-| - | - | - | - |
-| `Component` | `<X.y />` | ➕ | Any |
-| `Modifier` | `<p {{x.y}} />` | ➕ | Any |
-| `SubExpression` | `(x.y)` | ➕ | Any |
-| `Block` | `{{#x.y}}` | ➕ | Any |
-| `Append`, `Attribute` | `{{x.y z}}` | ➕ | ➕ |
+| Syntax Position       | Example         | Dots? | Arguments? |
+| --------------------- | --------------- | ----- | ---------- |
+| `Component`           | `<X.y />`       | ➕    | Any        |
+| `Modifier`            | `<p {{x.y}} />` | ➕    | Any        |
+| `SubExpression`       | `(x.y)`         | ➕    | Any        |
+| `Block`               | `{{#x.y}}`      | ➕    | Any        |
+| `Append`, `Attribute` | `{{x.y z}}`     | ➕    | ➕         |
 
 #### Block, Component, Modifier, SubExpression
 
-| | |
-| - | - |
-| Path has dots? | ❌ |
-| Arguments? | Any |
-| Fallback semantics? | ⛔ |
+|                     |     |
+| ------------------- | --- |
+| Path has dots?      | ❌  |
+| Arguments?          | Any |
+| Fallback semantics? | ⛔  |
 
-| Syntax Position | Example || Namespace  |
-| - | - | - | - |
-| `Block` | `{{#x}}` || `block` |
-| `Component` | `<X />` || `component` |
-| `Modifier` | `<p {{x}} />`  || `modifier` |
-| `SubExpression` | `(x)` || `helper` |
+| Syntax Position | Example       |     | Namespace   |
+| --------------- | ------------- | --- | ----------- |
+| `Block`         | `{{#x}}`      |     | `block`     |
+| `Component`     | `<X />`       |     | `component` |
+| `Modifier`      | `<p {{x}} />` |     | `modifier`  |
+| `SubExpression` | `(x)`         |     | `helper`    |
 
 #### Append
 
-| Syntax Position | Example | Dots? | Args? |  | Namespace | Fallback? |
-| - | - | - | - | - | - | - |
-| `Append` | `{{x}}`  | ❌ | ❌|| `helper`, `component` | ✅ |
-| `Append` | `{{x.y}}`  | ➕ | ❌|| None | ✅ |
-| `Append` | `{{x y}}`  | ❌ | ➕|| `helper`, `component` | ⛔ |
+| Syntax Position | Example   | Dots? | Args? |     | Namespace             | Fallback? |
+| --------------- | --------- | ----- | ----- | --- | --------------------- | --------- |
+| `Append`        | `{{x}}`   | ❌    | ❌    |     | `helper`, `component` | ✅        |
+| `Append`        | `{{x.y}}` | ➕    | ❌    |     | None                  | ✅        |
+| `Append`        | `{{x y}}` | ❌    | ➕    |     | `helper`, `component` | ⛔        |
 
 #### Attributes
 
@@ -304,8 +278,8 @@ The `Attribute` syntax position includes:
 - the value of an element argument (`@title={{...}}`)
 - a part of an interpolation (`href="{{...}}.html"`)
 
-| Syntax Position | Example  | Dots? | Arguments?| | Namespace | Fallback? |
-| - | - | - | - | - | - | - |
-| `Attribute` | `href={{x}}`  | ❌ | ❌ || `helper` | ✅ |
-| `Attribute` | `href={{x.y}}`  | ➕ | ❌ || None | ✅ |
-| `Attribute` | `href={{x y}}`  | ❌ | ➕ || `helper` | ⛔ |
+| Syntax Position | Example        | Dots? | Arguments? |     | Namespace | Fallback? |
+| --------------- | -------------- | ----- | ---------- | --- | --------- | --------- |
+| `Attribute`     | `href={{x}}`   | ❌    | ❌         |     | `helper`  | ✅        |
+| `Attribute`     | `href={{x.y}}` | ➕    | ❌         |     | None      | ✅        |
+| `Attribute`     | `href={{x y}}` | ❌    | ➕         |     | `helper`  | ⛔        |

--- a/packages/@glimmer/syntax/lib/v2-a/objects/resolution.ts
+++ b/packages/@glimmer/syntax/lib/v2-a/objects/resolution.ts
@@ -145,7 +145,7 @@ export class LooseModeResolution {
 
   resolution(): GetContextualFreeOp {
     if (this.ambiguity.namespaces.length === 0) {
-      return SexpOpcodes.GetFreeAsFallback;
+      return SexpOpcodes.GetStrictFree;
     } else if (this.ambiguity.namespaces.length === 1) {
       if (this.ambiguity.fallback) {
         // simple namespaced resolution with fallback must be attr={{x}}


### PR DESCRIPTION
The `GetFreeAsFallback` opcode got broken by 179a388d69af6fcd1bc906de396bde55e4925933. As far as I can tell, it's never correct to call `withPath` by itself, it's always supposed to come after an opcode that leaves a value on the stack that needs path support.

Rather than fix it, I'm going to try to cut the rest of it out, since it exists only to support `this` fallback.

This still needs to get tested against Ember. I am unable to get Ember and glimmer-vm working correctly together locally, with or without these changes.