### PR TITLE
fix: buildElement options should be optional

### DIFF
--- a/packages/@glimmer/syntax/lib/v1/public-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/public-builders.ts
@@ -202,7 +202,7 @@ export interface BuildElementOptions {
   loc?: SourceSpan;
 }
 
-function buildElement(tag: TagDescriptor, options: BuildElementOptions): ASTv1.ElementNode {
+function buildElement(tag: TagDescriptor, options: BuildElementOptions = {}): ASTv1.ElementNode {
   let { attrs, blockParams, modifiers, comments, children, loc } = options;
 
   let tagName: string;


### PR DESCRIPTION
see https://github.com/ember-template-lint/ember-template-recast/issues/734 for more context