### PR TITLE
chore: use prettier as default code formatter to avoid formatting conflicts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,8 @@
       "changeProcessCWD": true
     }
   ],
-  "eslint.enable": true
+  "eslint.enable": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }


### PR DESCRIPTION
use prettier as default code formatter to avoid formatting conflicts in vscode