### PR TITLE
Failing test for printer bug

### DIFF
--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -21,6 +21,7 @@ let templates = [
   '<Foo />',
   '<Foo as |bar|>{{bar}}</Foo>',
   '{{#in-element this.someElement}}Content here{{/in-element}}',
+  '<Link></Link>',
 
   // void elements
   '<br>',


### PR DESCRIPTION
This PR is a failing test to illustrate a bug.

If you parse to ast and immediately print back out, it turns:

```hbs
<Link></Link>
```

into

```hbs
<Link>
```

This behavior is special for `<Link>`. Other names don't do this.

I suspect it's because, in strict HTML spec terms `<Link>` is the same as `<link>`, and `<link>` is supposed to not have a closing tag. But in Glimmer/Ember terms, `<Link>` is a component and dropping the closing tag introduces a syntax error.

This was found in https://github.com/embroider-build/embroider/issues/1176