### PR TITLE
Fix a problem where plain functions can't be used as helper if they are not passed through the strict mode context object

### DIFF
--- a/packages/@glimmer/integration-tests/test/managers/helper-manager-test.ts
+++ b/packages/@glimmer/integration-tests/test/managers/helper-manager-test.ts
@@ -3,6 +3,7 @@ import {
   RenderTest,
   test,
   jitSuite,
+  GlimmerishComponent,
   tracked,
   defineComponent,
   trackedObj,
@@ -45,6 +46,58 @@ class HelperManagerTest extends RenderTest {
     };
 
     const Main = defineComponent({ hello }, '{{hello}}');
+
+    this.renderComponent(Main);
+
+    assert.equal(count, 1, 'rendered once');
+    this.assertHTML('plain function');
+
+    this.rerender();
+
+    assert.equal(count, 1, 'rendered once');
+    this.assertHTML('plain function');
+  }
+
+  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  '(Default Helper Manager) plain functions passed as component arguments work as helpers'(
+    assert: Assert
+  ) {
+    let count = 0;
+
+    const hello = () => {
+      count++;
+      return 'plain function';
+    };
+
+    const Main = defineComponent({}, '{{(@hello)}}');
+
+    this.renderComponent(Main, {
+      hello,
+    });
+
+    assert.equal(count, 1, 'rendered once');
+    this.assertHTML('plain function');
+
+    this.rerender();
+
+    assert.equal(count, 1, 'rendered once');
+    this.assertHTML('plain function');
+  }
+
+  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  '(Default Helper Manager) plain functions stored on component class properties work as helpers'(
+    assert: Assert
+  ) {
+    let count = 0;
+
+    const Main = defineComponent({}, '{{(this.hello)}}', {
+      definition: class extends GlimmerishComponent {
+        hello = () => {
+          count++;
+          return 'plain function';
+        };
+      },
+    });
 
     this.renderComponent(Main);
 

--- a/packages/@glimmer/manager/lib/internal/index.ts
+++ b/packages/@glimmer/manager/lib/internal/index.ts
@@ -213,13 +213,36 @@ export function getInternalComponentManager(
 ///////////
 
 export function hasInternalComponentManager(definition: object): boolean {
-  return getManager(COMPONENT_MANAGERS, definition) !== undefined;
+  return (
+    hasDefaultComponentManager(definition) ||
+    getManager(COMPONENT_MANAGERS, definition) !== undefined
+  );
 }
 
 export function hasInternalHelperManager(definition: object): boolean {
-  return getManager(HELPER_MANAGERS, definition) !== undefined;
+  return (
+    hasDefaultHelperManager(definition) || getManager(HELPER_MANAGERS, definition) !== undefined
+  );
 }
 
 export function hasInternalModifierManager(definition: object): boolean {
-  return getManager(MODIFIER_MANAGERS, definition) !== undefined;
+  return (
+    hasDefaultModifierManager(definition) || getManager(MODIFIER_MANAGERS, definition) !== undefined
+  );
+}
+
+function hasDefaultComponentManager(_definition: object): boolean {
+  return false;
+}
+
+function hasDefaultHelperManager(definition: object): boolean {
+  if (FEATURE_DEFAULT_HELPER_MANAGER) {
+    return typeof definition === 'function';
+  }
+
+  return false;
+}
+
+function hasDefaultModifierManager(_definition: object): boolean {
+  return false;
 }


### PR DESCRIPTION
While working on https://github.com/emberjs/ember.js/pull/20052 I noticed that an [error was thrown](https://github.com/glimmerjs/glimmer-vm/blob/07db0655c8d4b5c71792bf49ba3b547c196e460a/packages/%40glimmer/runtime/lib/compiled/opcodes/content.ts#L59) when using a function that was stored on a component class property. The [`hasInternalHelperManager` util](https://github.com/glimmerjs/glimmer-vm/blob/07db0655c8d4b5c71792bf49ba3b547c196e460a/packages/%40glimmer/manager/lib/internal/index.ts#L220) is used there but it doesn't pass through the default helper manager fallback behavior code so it returns false and the error is shown.

It seems functions passed as strict mode context values follow a different code path than component arguments and class properties so the error wasn't shown in the tests of the original PR.