### PR TITLE
Allow passing `false` to the `on` modifier's options

### DIFF
--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -83,7 +83,9 @@ export class OnModifierState {
     }
 
     let options: AddEventListenerOptions;
-    if (once || passive || capture) {
+    // we want to handle both `true` and `false` because both have a meaning:
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=770208
+    if (once !== undefined || passive !== undefined || capture !== undefined) {
       options = this.options = { once, passive, capture };
     } else {
       this.options = undefined;


### PR DESCRIPTION
I have no idea how to test this. Passing `false` will prevent Chrome from printing a violation warning to the console (see [here](https://bugs.chromium.org/p/chromium/issues/detail?id=770208)) but that's not something you can programmatically get. By [default](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners) browsers will set `passive` to `true` for events on document-level nodes but there is no (easy) way to use `on` on these.

I'm happy to hear suggestions.