### PR TITLE
Fix getTemplateLocals for yielded block params

### DIFF
--- a/packages/@glimmer/syntax/lib/get-template-locals.ts
+++ b/packages/@glimmer/syntax/lib/get-template-locals.ts
@@ -64,14 +64,17 @@ function addTokens(
 
   (Array.isArray(maybeTokens) ? maybeTokens : [maybeTokens]).forEach((maybeToken) => {
     if (maybeToken !== undefined && maybeToken[0] !== '@') {
-      tokensSet.add(maybeToken.split('.')[0]);
+      const maybeTokenFirstSegment = maybeToken.split('.')[0];
+      if (!scopedTokens.includes(maybeTokenFirstSegment)) {
+        tokensSet.add(maybeToken.split('.')[0]);
+      }
     }
   });
 }
 
 /**
  * Parses and traverses a given handlebars html template to extract all template locals
- * referenced that could possible come from the praent scope. Can exclude known keywords
+ * referenced that could possible come from the parent scope. Can exclude known keywords
  * optionally.
  */
 export function getTemplateLocals(

--- a/packages/@glimmer/syntax/test/template-locals-test.ts
+++ b/packages/@glimmer/syntax/test/template-locals-test.ts
@@ -35,6 +35,13 @@ QUnit.test('it works', function (assert) {
 
     <this.dynamicAngleComponent>
     </this.dynamicAngleComponent>
+
+    <ComponentYieldingContextual as |hash|>
+      <hash.some as |some|>
+        <some.other/>
+        {{some.value}}
+      </hash.some>
+    </ComponentYieldingContextual>
   `);
 
   assert.deepEqual(locals, [
@@ -45,6 +52,7 @@ QUnit.test('it works', function (assert) {
     'global-value',
     'some',
     'someOther',
+    'ComponentYieldingContextual',
   ]);
 });
 

--- a/packages/@glimmer/syntax/test/template-locals-test.ts
+++ b/packages/@glimmer/syntax/test/template-locals-test.ts
@@ -37,7 +37,9 @@ QUnit.test('it works', function (assert) {
     </this.dynamicAngleComponent>
 
     <ComponentYieldingContextual as |hash|>
+      <InsideHash />
       <hash.some as |some|>
+        {{inside-another-hash}}
         <some.other/>
         {{some.value}}
       </hash.some>
@@ -53,6 +55,8 @@ QUnit.test('it works', function (assert) {
     'some',
     'someOther',
     'ComponentYieldingContextual',
+    'InsideHash',
+    'inside-another-hash',
   ]);
 });
 


### PR DESCRIPTION
Given this template:

```hbs
<template>
  <HeadlessForm @data={{data}} as |form|>
    <form.field @name="firstName" as |field|>
      <field.label>First Name</field.label>
      <field.input data-test-first-name />
    </form.field>
    <form.field @name="lastName" as |field|>
      <field.label>Last Name</field.label>
      <field.input data-test-last-name />
    </form.field>
  </HeadlessForm>
</template>
  ```

... `eslint-plugin-ember` would complain about `form` and `field` violating `no-undef` (see https://github.com/ember-cli/eslint-plugin-ember/issues/1747). The root cause turned out to be that the scope function (after template-imports have been compiled away) would _falsely_ include those block params (like `scope: () => ['HeadlessForm', 'data', 'form', 'field']`), which are only local to the inner scopes of the template, not the outer/JS scope.

This PR should fix the root cause of those wrong locals returned by `getTemplateLocals()`.
