### PR TITLE
Add more tests for dynamic modifier invocation

### DIFF
--- a/packages/@glimmer/integration-tests/test/modifiers/dynamic-modifiers-test.ts
+++ b/packages/@glimmer/integration-tests/test/modifiers/dynamic-modifiers-test.ts
@@ -1,6 +1,7 @@
 import {
   RenderTest,
   test,
+  trackedObj,
   jitSuite,
   defineSimpleModifier,
   syntaxErrorFor,
@@ -167,6 +168,56 @@ class DynamicModifiersResolutionModeTest extends RenderTest {
     this.renderComponent(Bar);
     this.assertHTML('<div>Hello, world!</div>');
     this.assertStableRerender();
+  }
+
+  @test
+  'Can use a destructor in a dynamic modifier'() {
+    const lifecycle = [];
+    const bar = defineSimpleModifier((element: Element, value: string) => {
+      lifecycle.push('setup');
+
+      return () => lifecycle.push('cleanup');
+    });
+    const Bar = defineComponent({}, '<div {{this.bar}}></div>', {
+      definition: class extends GlimmerishComponent {
+        bar = bar;
+      },
+    });
+
+    this.renderComponent(Bar);
+    this.assertStableRerender();
+    this.destroy();
+    this.assert.deepEqual(lifecycle, ['setup', 'cleanup']);
+  }
+
+  @test
+  'Can use a destructor in a conditionally applied dynamic modifier'() {
+    const lifecycle = [];
+    const bar = defineSimpleModifier((element: Element, value: string) => {
+      lifecycle.push('setup');
+
+      return () => lifecycle.push('cleanup');
+    });
+
+    const state = trackedObj({ isVisible: false });
+    const Bar = defineComponent({}, '<div {{ (if this.state.isVisible this.bar) }}></div>', {
+      definition: class extends GlimmerishComponent {
+        bar = bar;
+        state = state;
+      },
+    });
+
+    this.renderComponent(Bar);
+    this.assertStableRerender();
+    this.assert.deepEqual(lifecycle, []);
+
+    state.isVisible = true;
+    this.rerender();
+    this.assert.deepEqual(lifecycle, ['setup']);
+
+    state.isVisible = false;
+    this.rerender();
+    this.assert.deepEqual(lifecycle, ['setup', 'cleanup']);
   }
 }
 


### PR DESCRIPTION
While investigating https://github.com/glimmerjs/glimmer-vm/issues/1410
Which is https://github.com/ember-modifier/ember-modifier/issues/613
I found that glimmer-vm, at least, seems to be handling this scenario correctly.
So while I debug elsewhere, I figured it may be good to have the extra tests, since I didn't see anything covering the this use case.