### PR TITLE
Fix another issue with getTemplateLocals and block params

### DIFF
--- a/packages/@glimmer/syntax/lib/get-template-locals.ts
+++ b/packages/@glimmer/syntax/lib/get-template-locals.ts
@@ -43,6 +43,19 @@ function tokensFromType(
       return;
     }
 
+    // the tag may be from a yielded object
+    // example:
+    //   <x.button>
+    // An ElementNode does not parse the "tag" in to a PathExpression
+    // so we have to split on `.`, just like how `this` presence is checked.
+    if (tag.indexOf('.') !== -1) {
+      let [potentialLocal] = tag.split('.');
+
+      if (scopedTokens.indexOf(potentialLocal) === -1) {
+        return;
+      }
+    }
+
     if (scopedTokens.indexOf(tag) !== -1) {
       return;
     }

--- a/packages/@glimmer/syntax/lib/get-template-locals.ts
+++ b/packages/@glimmer/syntax/lib/get-template-locals.ts
@@ -51,7 +51,7 @@ function tokensFromType(
     if (tag.indexOf('.') !== -1) {
       let [potentialLocal] = tag.split('.');
 
-      if (scopedTokens.indexOf(potentialLocal) === -1) {
+      if (scopedTokens.indexOf(potentialLocal) !== -1) {
         return;
       }
     }

--- a/packages/@glimmer/syntax/test/template-locals-test.ts
+++ b/packages/@glimmer/syntax/test/template-locals-test.ts
@@ -76,6 +76,18 @@ QUnit.test('it does not include locals', function (assert) {
   assert.deepEqual(locals, ['SomeComponent']);
 });
 
+QUnit.test('it can include object-locals', function (assert) {
+  let locals = getTemplateLocals(
+    `
+      <SomeComponent as |b|>
+        <b.button />
+      </SomeComponent>
+    `
+  );
+
+  assert.deepEqual(locals, ['SomeComponent']);
+});
+
 QUnit.test('it can include keywords', function (assert) {
   let locals = getTemplateLocals(
     `

--- a/packages/@glimmer/syntax/test/template-locals-test.ts
+++ b/packages/@glimmer/syntax/test/template-locals-test.ts
@@ -76,11 +76,27 @@ QUnit.test('it does not include locals', function (assert) {
   assert.deepEqual(locals, ['SomeComponent']);
 });
 
-QUnit.test('it can include object-locals', function (assert) {
+QUnit.test('it excludes object locals', function (assert) {
   let locals = getTemplateLocals(
     `
       <SomeComponent as |b|>
         <b.button />
+      </SomeComponent>
+    `
+  );
+
+  assert.deepEqual(locals, ['SomeComponent']);
+});
+
+QUnit.test('it excludes object locals from nested blocks', function (assert) {
+  let locals = getTemplateLocals(
+    `
+      <SomeComponent as |some|>
+        <some.foo as |foo|>
+          <foo.bar as |bar|>
+            <bar.baz />
+          </foo.bar>
+        </some.foo>
       </SomeComponent>
     `
   );


### PR DESCRIPTION
This one stems from `ElementNode` not having a parsed tag name -- it's just a string, instead of potentially a PathExpression, like it would/should be in the case of:
```hbs
<Wrapper as |w|>
    <w.button />
{{! ^ ElementNode
     ^ PathExpression { parts: ['w', 'button' ] }
}}

</Wrapper>
```