### PR TITLE
Remove IE11 error when using Object.assign

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -39,12 +39,6 @@
     // assertion below
     require('@glimmer/util');
 
-    Object.assign = function () {
-      throw new Error(
-        'Unexpected use of Object.assign. Object.assign cannot be used because it is unavailable in IE11. This error was likely caused by using syntax like the spread operator ({ ...obj }) which transpiles to Object.assign. Please use alternate syntax that is compatible with IE11.'
-      );
-    };
-
     // Recursively merge all the dependencies for this configuration of
     // packages to ensure that we only inject each dependency once.
     // Testing dependencies are only injected for the packages being tested.


### PR DESCRIPTION
IE11 isn't supported, so let's start cleaning things up.

More in other PRs.