### PR TITLE
[WIP]: [Bugfix] precompile* loses access to scope variables

### DIFF
--- a/packages/@glimmer/integration-tests/test/managers/helper-manager-test.ts
+++ b/packages/@glimmer/integration-tests/test/managers/helper-manager-test.ts
@@ -59,6 +59,17 @@ class HelperManagerTest extends RenderTest {
   }
 
   @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  '(Default Helper Manager) plain functions from globalThis work as helpers'() {
+    let data = { foo: 'bar' };
+
+    const Main = defineComponent({ data }, '{{JSON.stringify data}}');
+
+    this.renderComponent(Main);
+
+    this.assertHTML('{ "foo": "bar" }');
+  }
+
+  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
   '(Default Helper Manager) plain functions passed as component arguments work as helpers'(
     assert: Assert
   ) {

--- a/packages/@glimmer/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer/integration-tests/test/strict-mode-test.ts
@@ -342,6 +342,16 @@ class StaticStrictModeTest extends RenderTest {
   }
 
   @test
+  'Can use objects from globalThis'() {
+    const value = '{ "foo": "bar" }';
+    const Bar = defineComponent({ value }, '{{JSON.stringify (JSON.parse value)}}');
+
+    this.renderComponent(Bar);
+    this.assertHTML(value);
+    this.assertStableRerender();
+  }
+
+  @test
   'Can use constant values as arguments to components'() {
     const value = 'Hello, world!';
 

--- a/test/index.html
+++ b/test/index.html
@@ -39,12 +39,6 @@
     // assertion below
     require('@glimmer/util');
 
-    Object.assign = function () {
-      throw new Error(
-        'Unexpected use of Object.assign. Object.assign cannot be used because it is unavailable in IE11. This error was likely caused by using syntax like the spread operator ({ ...obj }) which transpiles to Object.assign. Please use alternate syntax that is compatible with IE11.'
-      );
-    };
-
     // Recursively merge all the dependencies for this configuration of
     // packages to ensure that we only inject each dependency once.
     // Testing dependencies are only injected for the packages being tested.


### PR DESCRIPTION
When doing compiling GJS, we get output like this:
```js
const data = { foo: 'bar' };

[GLIMMER_TEMPLATE(`
  {{JSON.stringify data}}
`, { scope() { return {JSON,data}; } })]
```

This _should_ be fine, as the preprocess step correctly identified that we used `JSON`.
But upon passing this through babel to convert `GLIMMER_TEMPLATE` to `setComponentTemplate(precompileTemplate(`, etc, the output becomes
<details><summary>runtime output</summary>

```js
"use strict";

exports.__esModule = true;
exports.default = void 0;
var _templateOnly = _interopRequireDefault(require("@ember/component/template-only"));
var _component = require("@ember/component");
var _templateFactory = require("@ember/template-factory");
function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
var data = {
  foo: 'bar'
};
var _default = (0, _component.setComponentTemplate)((0, _templateFactory.createTemplateFactory)(
/*
  
  {{JSON.stringify data}}

*/
{
  "id": null,
  "block": "[[[1,\"\\n  \"],[1,[28,[31,0,[\"stringify\"]],[[32,0]],null]],[1,\"\\n\"]],[],false,[\"JSON\"]]",
  "moduleName": "(unknown template module)",
  "scope": () => [data],
  "isStrictMode": true
}), (0, _templateOnly.default)("ember-repl-dbe32f3e-6b9e-5ae4-9afe-509aa137d4eb", "_emberReplDbe32f3e6b9e5ae49afe509aa137d4eb"));
exports.default = _default;
```

</details>

in particular, the `JSON` part is removed.

<details><summary>another example using ember-template-imports in a v2 addon</summary>

input:

```ts
import type { TOC } from '@ember/component/template-only';

export const Button: TOC<{
  Element: HTMLButtonElement;
  Blocks: { default: [] }
}> = <template>
  <button
    type="button"
    ...attributes
  >
    {{JSON.stringify (JSON.parse '{}')}}
    {{yield}}
  </button>
</template>;

```

output:

```js
import templateOnly from '@ember/component/template-only';
import { setComponentTemplate } from '@ember/component';
import { precompileTemplate } from '@ember/template-compilation';

const Button = setComponentTemplate(precompileTemplate(`
  <button
    type="button"
    ...attributes
  >
    {{JSON.stringify (JSON.parse '{}')}}
    {{yield}}
  </button>
`, {
  strictMode: true,
  scope: () => ({
    JSON
  })
}), templateOnly("button", "Button"));

export { Button };
//# sourceMappingURL=button.js.map
```

runtime:

```js
const Button = (0,_externals_ember_component__WEBPACK_IMPORTED_MODULE_2__.setComponentTemplate)((0,_externals_ember_template_factory__WEBPACK_IMPORTED_MODULE_0__.createTemplateFactory)(
/*
  
  <button
    type="button"
    class="
      inline-block items-center grid-flow-col
      text-white rounded bg-[var(--code-bg)] hover:bg-[var(--code-highlight-bg)]
      px-3 py-2
      border border-[var(--horizon-border)]
      focus:outline-none focus:ring
      focus-visible:outline-none focus-visible:ring
      shadow hover:shadow-sm
      grid gap-2
      disabled:opacity-30
    "
    ...attributes
  >
    {{JSON.stringify (JSON.parse '{}')}}
    {{yield}}
  </button>

*/
{
  "id": "UnyebmUW",
  "block": "[[[1,\"\\n  \"],[11,\"button\"],[24,4,\"button\"],[24,0,\"\\n      inline-block items-center grid-flow-col\\n      text-white rounded bg-[var(--code-bg)] hover:bg-[var(--code-highlight-bg)]\\n      px-3 py-2\\n      border border-[var(--horizon-border)]\\n      focus:outline-none focus:ring\\n      focus-visible:outline-none focus-visible:ring\\n      shadow hover:shadow-sm\\n      grid gap-2\\n      disabled:opacity-30\\n    \"],[17,1],[12],[1,\"\\n    \"],[1,[28,[32,0,[\"stringify\"]],[[28,[32,0,[\"parse\"]],[\"{}\"],null]],null]],[1,\"\\n    \"],[18,2,null],[1,\"\\n  \"],[13],[1,\"\\n\"]],[\"&attrs\",\"&default\"],false,[\"yield\"]]",
  "moduleName": "/tmp/embroider/53121b/packages/limber-ui/addon/dist/components/button.js",
  "scope": () => [JSON],
  "isStrictMode": true
}), _externals_ember_component_template_only__WEBPACK_IMPORTED_MODULE_1___default()("button", "Button"));
```
(I omitted the class stuff from the first two snippets)

So, this is suprising actually, JSON is present -- which means I shouldn't get a runtime error :thinking: 
So maybe something is terribly wrong with how I'm doing runtime transpilation :thinking: 

</details>

which.. this may be a babel issue instead of glimmer (but babel calls precompileTemplate from ember-source, so we're back at glimmer)