### PR TITLE
[Cleanup] remove default helper manager feature flag.

### DIFF
--- a/packages/@glimmer/global-context/index.ts
+++ b/packages/@glimmer/global-context/index.ts
@@ -17,10 +17,6 @@ import { DEBUG } from '@glimmer/env';
 
 //////////
 
-export let FEATURE_DEFAULT_HELPER_MANAGER = true;
-
-//////////
-
 /**
  * Interfaces
  *
@@ -186,10 +182,6 @@ export default function setGlobalContext(context: GlobalContext) {
   warnIfStyleNotTrusted = context.warnIfStyleNotTrusted;
   assert = context.assert;
   deprecate = context.deprecate;
-
-  if (typeof context.FEATURES?.DEFAULT_HELPER_MANAGER === 'boolean') {
-    FEATURE_DEFAULT_HELPER_MANAGER = context.FEATURES.DEFAULT_HELPER_MANAGER;
-  }
 }
 
 export let assertGlobalContextWasSet: (() => void) | undefined;

--- a/packages/@glimmer/integration-tests/test/managers/helper-manager-test.ts
+++ b/packages/@glimmer/integration-tests/test/managers/helper-manager-test.ts
@@ -11,9 +11,6 @@ import {
   TestHelperManager,
 } from '../..';
 import { Arguments, Owner } from '@glimmer/interfaces';
-import { FEATURE_DEFAULT_HELPER_MANAGER } from '@glimmer/global-context';
-
-const SKIP_DEFAULT_HELPER_MANAGER_TESTS = !FEATURE_DEFAULT_HELPER_MANAGER;
 
 class HelperManagerTest extends RenderTest {
   static suiteName = 'Helper Managers';
@@ -36,7 +33,7 @@ class HelperManagerTest extends RenderTest {
     this.assertHTML('hello');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain functions work as helpers'(assert: Assert) {
     let count = 0;
 
@@ -58,7 +55,7 @@ class HelperManagerTest extends RenderTest {
     this.assertHTML('plain function');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain functions passed as component arguments work as helpers'(
     assert: Assert
   ) {
@@ -84,7 +81,7 @@ class HelperManagerTest extends RenderTest {
     this.assertHTML('plain function');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain functions stored on component class properties work as helpers'(
     assert: Assert
   ) {
@@ -110,7 +107,7 @@ class HelperManagerTest extends RenderTest {
     this.assertHTML('plain function');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain functions track positional args'(assert: Assert) {
     let count = 0;
 
@@ -138,7 +135,7 @@ class HelperManagerTest extends RenderTest {
     this.assertHTML('there');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain functions entangle with any tracked data'(assert: Assert) {
     let count = 0;
     let trackedState = trackedObj({ value: 'hello' });
@@ -159,7 +156,7 @@ class HelperManagerTest extends RenderTest {
     assert.strictEqual(count, 2, 'rendered twice');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain functions do not track unused named args'(assert: Assert) {
     let count = 0;
 
@@ -180,7 +177,7 @@ class HelperManagerTest extends RenderTest {
     this.assertHTML('hello');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain functions tracked used named args'(assert: Assert) {
     let count = 0;
 
@@ -202,7 +199,7 @@ class HelperManagerTest extends RenderTest {
     this.assertHTML('there');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain function helpers can have default values (missing data)'(
     assert: Assert
   ) {
@@ -219,7 +216,7 @@ class HelperManagerTest extends RenderTest {
     assert.strictEqual(count, 1, 'rendered once');
   }
 
-  @test({ skip: SKIP_DEFAULT_HELPER_MANAGER_TESTS })
+  @test
   '(Default Helper Manager) plain function helpers can have overwritten default values'(
     assert: Assert
   ) {

--- a/packages/@glimmer/manager/lib/internal/index.ts
+++ b/packages/@glimmer/manager/lib/internal/index.ts
@@ -1,6 +1,5 @@
 import { DEBUG } from '@glimmer/env';
 import { debugToString, _WeakSet } from '@glimmer/util';
-import { FEATURE_DEFAULT_HELPER_MANAGER } from '@glimmer/global-context';
 import {
   InternalComponentManager,
   InternalModifierManager,
@@ -144,12 +143,10 @@ export function getInternalHelperManager(
 
   let manager = getManager(HELPER_MANAGERS, definition);
 
-  if (FEATURE_DEFAULT_HELPER_MANAGER) {
-    // Functions are special-cased because functions are defined
-    // as the "default" helper, per: https://github.com/emberjs/rfcs/pull/756
-    if (manager === undefined && typeof definition === 'function') {
-      manager = DEFAULT_MANAGER;
-    }
+  // Functions are special-cased because functions are defined
+  // as the "default" helper, per: https://github.com/emberjs/rfcs/pull/756
+  if (manager === undefined && typeof definition === 'function') {
+    manager = DEFAULT_MANAGER;
   }
 
   if (manager) {
@@ -236,11 +233,7 @@ function hasDefaultComponentManager(_definition: object): boolean {
 }
 
 function hasDefaultHelperManager(definition: object): boolean {
-  if (FEATURE_DEFAULT_HELPER_MANAGER) {
-    return typeof definition === 'function';
-  }
-
-  return false;
+  return typeof definition === 'function';
 }
 
 function hasDefaultModifierManager(_definition: object): boolean {

--- a/packages/@glimmer/manager/test/managers-test.ts
+++ b/packages/@glimmer/manager/test/managers-test.ts
@@ -1,5 +1,4 @@
 import { DEBUG } from '@glimmer/env';
-import { FEATURE_DEFAULT_HELPER_MANAGER } from '@glimmer/global-context';
 import {
   ComponentManager,
   HelperManager,
@@ -182,23 +181,21 @@ module('Managers', () => {
       assert.strictEqual(instance['factory'], factory, 'manager has correct delegate factory');
     });
 
-    if (FEATURE_DEFAULT_HELPER_MANAGER) {
-      test('it determines the default manager', (assert) => {
-        let myTestHelper = () => 0;
-        let instance = getInternalHelperManager(myTestHelper) as CustomHelperManager<object>;
+    test('it determines the default manager', (assert) => {
+      let myTestHelper = () => 0;
+      let instance = getInternalHelperManager(myTestHelper) as CustomHelperManager<object>;
 
-        assert.strictEqual(typeof instance, 'object', 'manager is an internal manager');
-        assert.strictEqual(
-          typeof instance.getHelper({}),
-          'function',
-          'manager can generate helper function'
-        );
-        assert.strictEqual(
-          instance['factory']({})?.getDebugName?.(myTestHelper),
-          '(helper function myTestHelper)'
-        );
-      });
-    }
+      assert.strictEqual(typeof instance, 'object', 'manager is an internal manager');
+      assert.strictEqual(
+        typeof instance.getHelper({}),
+        'function',
+        'manager can generate helper function'
+      );
+      assert.strictEqual(
+        instance['factory']({})?.getDebugName?.(myTestHelper),
+        '(helper function myTestHelper)'
+      );
+    });
 
     test('it works with internal helpers', (assert) => {
       let helper = () => {


### PR DESCRIPTION
The feature has been shipped for aaallllmooost a year now, so it's probably time to clean up the feature flag that was used while this feature was in development. :tada: 