### PR TITLE
Improve lexical scope

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,12 @@
   "ignorePatterns": ["dist", "ts-dist", "node_modules", "tmp"],
   "rules": {
     "n/no-missing-import": "off",
+    "n/no-unsupported-features/es-builtins": [
+      "error",
+      {
+        "version": "16.0.0"
+      }
+    ],
     // disabled because we still have a few commented tests
     "qunit/no-commented-tests": "off",
     // disabled due to false positives

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /dist/
 /control-dist/
 node_modules/
+**/node_modules/
 tmp/
 ts-dist/
 .eslintcache
@@ -8,4 +9,3 @@ ts-dist/
 *.dot
 *.pdf
 instrumentation.*.json
-.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,5 +58,8 @@
   },
   "[shellscript]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "[ignore]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
   }
 }

--- a/build/broccoli/write-smoke-test.js
+++ b/build/broccoli/write-smoke-test.js
@@ -37,6 +37,8 @@ class TypesSmokeTestWriter extends Plugin {
           newLine: 'LF',
           noEmit: true,
 
+          skipLibCheck: true,
+
           paths: {
             '@glimmer/*': ['@glimmer/*/dist/types/index.d.ts'],
           },

--- a/packages/@glimmer/compiler/lib/builder/builder.ts
+++ b/packages/@glimmer/compiler/lib/builder/builder.ts
@@ -319,7 +319,9 @@ function buildKeyword(
   let childSymbols = symbols.child(normalized.blockParams || []);
 
   let block = buildBlock(normalized.blocks.default, childSymbols, childSymbols.paramSymbols);
-  let inverse = normalized.blocks.else ? buildBlock(normalized.blocks.else, symbols, []) : null;
+  let inverse = normalized.blocks['else']
+    ? buildBlock(normalized.blocks['else'], symbols, [])
+    : null;
 
   switch (name) {
     case 'with':
@@ -402,9 +404,7 @@ export function buildElementParams(
   let keys: string[] = [];
   let values: WireFormat.Expression[] = [];
 
-  Object.keys(attrs).forEach((key) => {
-    let value = attrs[key];
-
+  for (const [key, value] of Object.entries(attrs)) {
     if (value === HeadKind.Splat) {
       params.push([Op.AttrSplat, symbols.block('&attrs')]);
     } else if (key[0] === '@') {
@@ -421,7 +421,7 @@ export function buildElementParams(
         )
       );
     }
-  });
+  }
 
   return { params, args: isPresent(keys) && isPresent(values) ? [keys, values] : null };
 }
@@ -619,7 +619,7 @@ export function buildVar(
   switch (head.kind) {
     case VariableKind.Free:
       if (context === 'Strict') {
-        op = SexpOpcodes.GetStrictFree;
+        op = SexpOpcodes.GetStrictKeyword;
       } else if (context === 'AppendBare') {
         op = SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback;
       } else if (context === 'AppendInvoke') {
@@ -673,7 +673,7 @@ function getSymbolForVar(
 export function expressionContextOp(context: VariableResolutionContext): GetContextualFreeOp {
   switch (context) {
     case VariableResolutionContext.Strict:
-      return Op.GetStrictFree;
+      return Op.GetStrictKeyword;
     case VariableResolutionContext.AmbiguousAppend:
       return Op.GetFreeAsComponentOrHelperHeadOrThisFallback;
     case VariableResolutionContext.AmbiguousAppendInvoke:

--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -4,8 +4,13 @@ import {
   TemplateJavascript,
 } from '@glimmer/interfaces';
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
-import { normalize, PrecompileOptions, Source, TemplateIdFn } from '@glimmer/syntax';
-import { PrecompileOptionsWithLexicalScope } from '@glimmer/syntax/lib/parser/tokenizer-event-handlers';
+import {
+  normalize,
+  PrecompileOptions,
+  PrecompileOptionsWithLexicalScope,
+  Source,
+  TemplateIdFn,
+} from '@glimmer/syntax';
 import { LOCAL_LOGGER } from '@glimmer/util';
 
 import pass0 from './passes/1-normalization/index';

--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -5,6 +5,7 @@ import {
 } from '@glimmer/interfaces';
 import { LOCAL_SHOULD_LOG } from '@glimmer/local-debug-flags';
 import { normalize, PrecompileOptions, Source, TemplateIdFn } from '@glimmer/syntax';
+import { PrecompileOptionsWithLexicalScope } from '@glimmer/syntax/lib/parser/tokenizer-event-handlers';
 import { LOCAL_LOGGER } from '@glimmer/util';
 
 import pass0 from './passes/1-normalization/index';
@@ -66,10 +67,10 @@ const defaultOptions: PrecompileOptions = {
  */
 export function precompileJSON(
   string: string,
-  options: PrecompileOptions = defaultOptions
+  options: PrecompileOptions | PrecompileOptionsWithLexicalScope = defaultOptions
 ): [block: SerializedTemplateBlock, usedLocals: string[]] {
   let source = new Source(string, options.meta?.moduleName);
-  let [ast, locals] = normalize(source, options);
+  let [ast, locals] = normalize(source, { lexicalScope: () => false, ...options });
   let block = pass0(source, ast, options.strictMode ?? false).mapOk((pass2In) => {
     return pass2(pass2In);
   });
@@ -105,7 +106,7 @@ const SCOPE_PLACEHOLDER = '796d24e6-2450-4fb0-8cdf-b65638b5ef70';
  */
 export function precompile(
   source: string,
-  options: PrecompileOptions = defaultOptions
+  options: PrecompileOptions | PrecompileOptionsWithLexicalScope = defaultOptions
 ): TemplateJavascript {
   let [block, usedLocals] = precompileJSON(source, options);
 

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
@@ -97,7 +97,7 @@ export const APPEND_KEYWORDS = keywords('Append')
       node: ASTv2.AppendContent;
       state: NormalizationState;
     }): Result<mir.Statement> {
-      scope.setHasEval();
+      scope.setHasDebugger();
       return Ok(new mir.Debugger({ loc: node.loc, scope }));
     },
   })

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/utils/is-node.ts
@@ -47,9 +47,7 @@ export function isSimplePath(path: ASTv2.ExpressionNode): path is SimplePath {
   if (path.type === 'Path') {
     let { ref: head, tail: parts } = path;
 
-    return (
-      head.type === 'Free' && head.resolution !== ASTv2.STRICT_RESOLUTION && parts.length === 0
-    );
+    return head.type === 'Free' && !ASTv2.isStrictResolution(head.resolution) && parts.length === 0;
   } else {
     return false;
   }
@@ -64,7 +62,7 @@ export function isStrictHelper(expr: HasPath): boolean {
     return true;
   }
 
-  return expr.callee.ref.resolution === ASTv2.STRICT_RESOLUTION;
+  return ASTv2.isStrictResolution(expr.callee.ref.resolution);
 }
 
 export function assertIsValidModifier<N extends HasPath>(

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
@@ -43,7 +43,7 @@ export class ContentEncoder {
   private visitContent(stmt: mir.Statement): WireFormat.Statement | WireStatements {
     switch (stmt.type) {
       case 'Debugger':
-        return [SexpOpcodes.Debugger, stmt.scope.getEvalInfo()];
+        return [SexpOpcodes.Debugger, stmt.scope.getDebugInfo()];
       case 'AppendComment':
         return this.AppendComment(stmt);
       case 'AppendTextNode':

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
@@ -83,8 +83,8 @@ export class ExpressionEncoder {
     symbol,
   }: ASTv2.LocalVarReference):
     | WireFormat.Expressions.GetSymbol
-    | WireFormat.Expressions.GetTemplateSymbol {
-    return [isTemplateLocal ? SexpOpcodes.GetTemplateSymbol : SexpOpcodes.GetSymbol, symbol];
+    | WireFormat.Expressions.GetLexicalSymbol {
+    return [isTemplateLocal ? SexpOpcodes.GetLexicalSymbol : SexpOpcodes.GetSymbol, symbol];
   }
 
   GetWithResolver({ symbol }: mir.GetWithResolver): WireFormat.Expressions.GetContextualFree {

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/mir.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/mir.ts
@@ -110,14 +110,14 @@ export class StaticAttr extends node('StaticAttr').fields<{
   kind: { component: boolean };
   name: SourceSlice;
   value: SourceSlice;
-  namespace?: string;
+  namespace?: string | undefined;
 }>() {}
 
 export class DynamicAttr extends node('DynamicAttr').fields<{
   kind: AttrKind;
   name: SourceSlice;
   value: ExpressionNode;
-  namespace?: string;
+  namespace?: string | undefined;
 }>() {}
 
 export class SimpleElement extends node('SimpleElement').fields<{

--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -168,7 +168,7 @@ export default class WireFormatDebugger {
         case Op.Concat:
           return ['concat', this.formatParams(opcode[1] as WireFormat.Core.Params)];
 
-        case Op.GetStrictFree:
+        case Op.GetStrictKeyword:
           return ['get-strict-free', this.upvars[opcode[1]], opcode[2]];
 
         case Op.GetFreeAsComponentOrHelperHeadOrThisFallback:
@@ -204,7 +204,7 @@ export default class WireFormatDebugger {
           }
         }
 
-        case Op.GetTemplateSymbol: {
+        case Op.GetLexicalSymbol: {
           return ['get-template-symbol', opcode[1], opcode[2]];
         }
 

--- a/packages/@glimmer/debug/lib/opcode-metadata.ts
+++ b/packages/@glimmer/debug/lib/opcode-metadata.ts
@@ -1328,7 +1328,7 @@ METADATA[Op.Debugger] = {
       type: 'str-array',
     },
     {
-      name: 'evalInfo',
+      name: 'debugInfo',
       type: 'array',
     },
   ],

--- a/packages/@glimmer/dom-change-list/test/test-case.ts
+++ b/packages/@glimmer/dom-change-list/test/test-case.ts
@@ -16,11 +16,11 @@ function isTestFunction(value: any): value is TestFunction {
 }
 
 export function test(meta: Dict<unknown>): MethodDecorator;
-export function test(
+export function test<T>(
   _target: object,
   _name: string,
-  descriptor: PropertyDescriptor
-): PropertyDescriptor | void;
+  descriptor: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T> | void;
 export function test(...args: any[]) {
   if (args.length === 1) {
     let meta: Dict<unknown> = args[0];

--- a/packages/@glimmer/integration-tests/lib/render-delegate.ts
+++ b/packages/@glimmer/integration-tests/lib/render-delegate.ts
@@ -21,8 +21,8 @@ import { Reference } from '@glimmer/reference';
 import { EnvironmentDelegate } from '@glimmer/runtime';
 
 export interface RenderDelegateOptions {
-  doc?: SimpleDocument | Document;
-  env?: EnvironmentDelegate;
+  doc?: SimpleDocument | Document | undefined;
+  env?: EnvironmentDelegate | undefined;
 }
 
 export default interface RenderDelegate {

--- a/packages/@glimmer/integration-tests/lib/test-decorator.ts
+++ b/packages/@glimmer/integration-tests/lib/test-decorator.ts
@@ -9,11 +9,11 @@ export interface ComponentTestMeta {
 }
 
 export function test(meta: ComponentTestMeta): MethodDecorator;
-export function test(
+export function test<T>(
   _target: Object | ComponentTestMeta,
   _name?: string,
-  descriptor?: PropertyDescriptor
-): PropertyDescriptor | void;
+  descriptor?: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T> | void;
 export function test(...args: any[]) {
   if (args.length === 1) {
     let meta: ComponentTestMeta = args[0];

--- a/packages/@glimmer/integration-tests/lib/test-helpers/test.ts
+++ b/packages/@glimmer/integration-tests/lib/test-helpers/test.ts
@@ -3,11 +3,11 @@ import { Dict } from '@glimmer/interfaces';
 import { keys } from '@glimmer/util';
 
 export function test(meta: ComponentTestMeta): MethodDecorator;
-export function test(
+export function test<T>(
   _target: Object | ComponentTestMeta,
   _name?: string,
-  descriptor?: PropertyDescriptor
-): PropertyDescriptor | void;
+  descriptor?: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T> | void;
 export function test(...args: any[]) {
   if (args.length === 1) {
     let meta: ComponentTestMeta = args[0];

--- a/packages/@glimmer/interfaces/lib/compile/operands.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/operands.d.ts
@@ -5,7 +5,7 @@ import { CompilableTemplate } from '../template';
 export const enum HighLevelOperand {
   Label = 1,
   IsStrictMode = 2,
-  EvalSymbols = 3,
+  DebugSymbols = 3,
   Block = 4,
   StdLib = 5,
   NonSmallInt = 6,
@@ -23,8 +23,8 @@ export interface IsStrictModeOperand {
   value: undefined;
 }
 
-export interface EvalSymbolsOperand {
-  type: HighLevelOperand.EvalSymbols;
+export interface DebugSymbolsOperand {
+  type: HighLevelOperand.DebugSymbols;
   value: undefined;
 }
 
@@ -61,7 +61,7 @@ export interface LayoutOperand {
 export type HighLevelBuilderOperand =
   | LabelOperand
   | IsStrictModeOperand
-  | EvalSymbolsOperand
+  | DebugSymbolsOperand
   | StdLibOperand
   | BlockOperand
   | NonSmallIntOperand

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -63,10 +63,11 @@ export const enum SexpOpcodes {
   // Get
   // Get a local value via symbol
   GetSymbol = 30, // GetPath + 0-2,
-  // Template symbol are values that are in scope in the template in strict mode
-  GetTemplateSymbol = 32,
-  // Free variables are only keywords in strict mode
-  GetStrictFree = 31,
+  // Lexical symbols are values that are in scope in the template in strict mode
+  GetLexicalSymbol = 32,
+  // If a free variable is not a lexical symbol in strict mode, it must be a keyword.
+  // FIXME: Why does this make it to the wire format in the first place?
+  GetStrictKeyword = 31,
 
   // `{{x}}` in append position (might be a helper or component invocation, otherwise fall back to `this`)
   GetFreeAsComponentOrHelperHeadOrThisFallback = 34,
@@ -113,7 +114,7 @@ export type GetContextualFreeOp =
   | SexpOpcodes.GetFreeAsHelperHead
   | SexpOpcodes.GetFreeAsModifierHead
   | SexpOpcodes.GetFreeAsComponentHead
-  | SexpOpcodes.GetStrictFree;
+  | SexpOpcodes.GetStrictKeyword;
 
 export type AttrOp =
   | SexpOpcodes.StaticAttr
@@ -146,10 +147,10 @@ export namespace Core {
   export type Blocks = Option<[string[], SerializedInlineBlock[]]>;
   export type Args = [Params, Hash];
   export type NamedBlock = [string, SerializedInlineBlock];
-  export type EvalInfo = number[];
+  export type DebugInfo = number[];
   export type ElementParameters = Option<PresentArray<ElementParameter>>;
 
-  export type Syntax = Path | Params | ConcatParams | Hash | Blocks | Args | EvalInfo;
+  export type Syntax = Path | Params | ConcatParams | Hash | Blocks | Args | DebugInfo;
 }
 
 export type CoreSyntax = Core.Syntax;
@@ -160,8 +161,8 @@ export namespace Expressions {
   export type Hash = Core.Hash;
 
   export type GetSymbol = [SexpOpcodes.GetSymbol, number];
-  export type GetTemplateSymbol = [SexpOpcodes.GetTemplateSymbol, number];
-  export type GetStrictFree = [SexpOpcodes.GetStrictFree, number];
+  export type GetLexicalSymbol = [SexpOpcodes.GetLexicalSymbol, number];
+  export type GetStrictFree = [SexpOpcodes.GetStrictKeyword, number];
   export type GetFreeAsComponentOrHelperHeadOrThisFallback = [
     SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback,
     number
@@ -188,11 +189,11 @@ export namespace Expressions {
     | GetFreeAsModifierHead
     | GetFreeAsComponentHead;
   export type GetFree = GetStrictFree | GetContextualFree;
-  export type GetVar = GetSymbol | GetTemplateSymbol | GetFree;
+  export type GetVar = GetSymbol | GetLexicalSymbol | GetFree;
 
   export type GetPathSymbol = [SexpOpcodes.GetSymbol, number, Path];
-  export type GetPathTemplateSymbol = [SexpOpcodes.GetTemplateSymbol, number, Path];
-  export type GetPathStrictFree = [SexpOpcodes.GetStrictFree, number, Path];
+  export type GetPathTemplateSymbol = [SexpOpcodes.GetLexicalSymbol, number, Path];
+  export type GetPathStrictFree = [SexpOpcodes.GetStrictKeyword, number, Path];
   export type GetPathFreeAsComponentOrHelperHeadOrThisFallback = [
     SexpOpcodes.GetFreeAsComponentOrHelperHeadOrThisFallback,
     number,
@@ -319,18 +320,16 @@ export namespace Statements {
   export type OpenElementWithSplat = [SexpOpcodes.OpenElementWithSplat, string | WellKnownTagName];
   export type FlushElement = [SexpOpcodes.FlushElement];
   export type CloseElement = [SexpOpcodes.CloseElement];
-  export type StaticAttr = [
-    SexpOpcodes.StaticAttr,
-    string | WellKnownAttrName,
-    Expression,
-    string?
+
+  type Attr<Op extends AttrOp> = [
+    op: Op,
+    name: string | WellKnownAttrName,
+    value: Expreession,
+    namespace?: string | undefined
   ];
-  export type StaticComponentAttr = [
-    SexpOpcodes.StaticComponentAttr,
-    string | WellKnownAttrName,
-    Expression,
-    string?
-  ];
+
+  export type StaticAttr = Attr<SexpOpcodes.StaticAttr>;
+  export type StaticComponentAttr = Attr<SexpOpcodes.StaticComponentAttr>;
 
   export type AnyStaticAttr = StaticAttr | StaticComponentAttr;
 
@@ -339,30 +338,10 @@ export namespace Statements {
   export type DynamicArg = [SexpOpcodes.DynamicArg, string, Expression];
   export type StaticArg = [SexpOpcodes.StaticArg, string, Expression];
 
-  export type DynamicAttr = [
-    SexpOpcodes.DynamicAttr,
-    string | WellKnownAttrName,
-    Expression,
-    string?
-  ];
-  export type ComponentAttr = [
-    SexpOpcodes.ComponentAttr,
-    string | WellKnownAttrName,
-    Expression,
-    string?
-  ];
-  export type TrustingDynamicAttr = [
-    SexpOpcodes.TrustingDynamicAttr,
-    string | WellKnownAttrName,
-    Expression,
-    string?
-  ];
-  export type TrustingComponentAttr = [
-    SexpOpcodes.TrustingComponentAttr,
-    string | WellKnownAttrName,
-    Expression,
-    string?
-  ];
+  export type DynamicAttr = Attr<SexpOpcodes.DynamicAttr>;
+  export type ComponentAttr = Attr<SexpOpcodes.ComponentAttr>;
+  export type TrustingDynamicAttr = Attr<SexpOpcodes.TrustingDynamicAttr>;
+  export type TrustingComponentAttr = Attr<SexpOpcodes.TrustingComponentAttr>;
 
   export type AnyDynamicAttr =
     | DynamicAttr
@@ -370,7 +349,7 @@ export namespace Statements {
     | TrustingDynamicAttr
     | TrustingComponentAttr;
 
-  export type Debugger = [SexpOpcodes.Debugger, Core.EvalInfo];
+  export type Debugger = [SexpOpcodes.Debugger, Core.DebugInfo];
   export type InElement = [
     op: SexpOpcodes.InElement,
     block: SerializedInlineBlock,
@@ -492,7 +471,7 @@ export type SerializedTemplateBlock = [
   Statements.Statement[],
   // symbols
   string[],
-  // hasEval
+  // hasDebug
   boolean,
   // upvars
   string[]
@@ -519,7 +498,7 @@ export interface SerializedTemplateWithLazyBlock {
   id?: Option<string>;
   block: SerializedTemplateBlockJSON;
   moduleName: string;
-  scope: (() => unknown[]) | undefined | null;
+  scope?: (() => unknown[]) | undefined | null;
   isStrictMode: boolean;
 }
 

--- a/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format.d.ts
@@ -324,7 +324,7 @@ export namespace Statements {
   type Attr<Op extends AttrOp> = [
     op: Op,
     name: string | WellKnownAttrName,
-    value: Expreession,
+    value: Expression,
     namespace?: string | undefined
   ];
 

--- a/packages/@glimmer/interfaces/lib/core.d.ts
+++ b/packages/@glimmer/interfaces/lib/core.d.ts
@@ -3,9 +3,7 @@ export type Option<T> = T | null;
 export type Maybe<T> = Option<T> | undefined | void;
 export type FIXME<T, S extends string> = T;
 
-export interface Dict<T = unknown> {
-  [key: string]: T;
-}
+export type Dict<T = unknown> = Record<string, T>;
 
 export type DictValue<D extends Dict> = D extends Dict<infer V> ? V : never;
 

--- a/packages/@glimmer/interfaces/lib/references.d.ts
+++ b/packages/@glimmer/interfaces/lib/references.d.ts
@@ -23,7 +23,7 @@ export type ReferenceSymbol = typeof REFERENCE;
 
 export interface Reference<T = unknown> {
   [REFERENCE]: ReferenceType;
-  debugLabel?: string;
+  debugLabel?: string | undefined;
   compute: Option<() => T>;
   children: null | Map<string | Reference, Reference>;
 }

--- a/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
@@ -9,7 +9,7 @@ export interface RenderNode {
   name: string;
   args: CapturedArguments;
   instance: unknown;
-  template?: string;
+  template?: string | undefined;
 }
 
 export interface CapturedRenderNode {

--- a/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/environment.d.ts
@@ -40,5 +40,5 @@ export interface Environment {
   getAppendOperations(): GlimmerTreeConstruction;
 
   isInteractive: boolean;
-  debugRenderTree?: DebugRenderTree;
+  debugRenderTree?: DebugRenderTree | undefined;
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -206,7 +206,7 @@ export class EncoderImpl implements Encoder {
           case HighLevelOperand.IsStrictMode:
             return encodeHandle(constants.value(this.meta.isStrictMode));
 
-          case HighLevelOperand.EvalSymbols:
+          case HighLevelOperand.DebugSymbols:
             return encodeHandle(constants.array(this.meta.evalSymbols || EMPTY_STRING_ARRAY));
 
           case HighLevelOperand.Block:

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -23,14 +23,14 @@ function isGetLikeTuple(opcode: Expressions.Expression): opcode is Expressions.T
 function makeResolutionTypeVerifier(typeToVerify: SexpOpcodes) {
   return (
     opcode: Expressions.Expression
-  ): opcode is Expressions.GetFree | Expressions.GetTemplateSymbol => {
+  ): opcode is Expressions.GetFree | Expressions.GetLexicalSymbol => {
     if (!isGetLikeTuple(opcode)) return false;
 
     let type = opcode[0];
 
     return (
-      type === SexpOpcodes.GetStrictFree ||
-      type === SexpOpcodes.GetTemplateSymbol ||
+      type === SexpOpcodes.GetStrictKeyword ||
+      type === SexpOpcodes.GetLexicalSymbol ||
       type === typeToVerify
     );
   };
@@ -100,7 +100,7 @@ export function resolveComponent(
 
   let type = expr[0];
 
-  if (DEBUG && expr[0] === SexpOpcodes.GetStrictFree) {
+  if (DEBUG && expr[0] === SexpOpcodes.GetStrictKeyword) {
     throw new Error(
       `Attempted to resolve a component in a strict mode template, but that value was not in scope: ${
         meta.upvars![expr[1]]
@@ -108,7 +108,7 @@ export function resolveComponent(
     );
   }
 
-  if (type === SexpOpcodes.GetTemplateSymbol) {
+  if (type === SexpOpcodes.GetLexicalSymbol) {
     let { scopeValues, owner } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
@@ -150,14 +150,14 @@ export function resolveHelper(
 
   let type = expr[0];
 
-  if (type === SexpOpcodes.GetTemplateSymbol) {
+  if (type === SexpOpcodes.GetLexicalSymbol) {
     let { scopeValues } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
     then(constants.helper(definition as object));
-  } else if (type === SexpOpcodes.GetStrictFree) {
+  } else if (type === SexpOpcodes.GetStrictKeyword) {
     then(
       lookupBuiltInHelper(expr as Expressions.GetStrictFree, resolver, meta, constants, 'helper')
     );
@@ -192,14 +192,14 @@ export function resolveModifier(
 
   let type = expr[0];
 
-  if (type === SexpOpcodes.GetTemplateSymbol) {
+  if (type === SexpOpcodes.GetLexicalSymbol) {
     let { scopeValues } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
     then(constants.modifier(definition as object));
-  } else if (type === SexpOpcodes.GetStrictFree) {
+  } else if (type === SexpOpcodes.GetStrictKeyword) {
     let { upvars } = assertResolverInvariants(meta);
     let name = upvars[expr[1]];
     let modifier = resolver.lookupBuiltInModifier(name);
@@ -242,7 +242,7 @@ export function resolveComponentOrHelper(
 
   let type = expr[0];
 
-  if (type === SexpOpcodes.GetTemplateSymbol) {
+  if (type === SexpOpcodes.GetLexicalSymbol) {
     let { scopeValues, owner } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
@@ -270,7 +270,7 @@ export function resolveComponentOrHelper(
     }
 
     ifHelper(expect(helper, 'BUG: helper must exist'));
-  } else if (type === SexpOpcodes.GetStrictFree) {
+  } else if (type === SexpOpcodes.GetStrictKeyword) {
     ifHelper(
       lookupBuiltInHelper(
         expr as Expressions.GetStrictFree,
@@ -341,7 +341,7 @@ export function resolveOptionalComponentOrHelper(
 
   let type = expr[0];
 
-  if (type === SexpOpcodes.GetTemplateSymbol) {
+  if (type === SexpOpcodes.GetLexicalSymbol) {
     let { scopeValues, owner } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
@@ -375,7 +375,7 @@ export function resolveOptionalComponentOrHelper(
     }
 
     ifValue(constants.value(definition));
-  } else if (type === SexpOpcodes.GetStrictFree) {
+  } else if (type === SexpOpcodes.GetStrictKeyword) {
     ifHelper(
       lookupBuiltInHelper(expr as Expressions.GetStrictFree, resolver, meta, constants, 'value')
     );

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
@@ -1,7 +1,7 @@
 import {
   LabelOperand,
   SerializedInlineBlock,
-  EvalSymbolsOperand,
+  DebugSymbolsOperand,
   HighLevelOperand,
   BlockOperand,
   StdLibOperand,
@@ -19,8 +19,8 @@ export function labelOperand(value: string): LabelOperand {
   return { type: HighLevelOperand.Label, value };
 }
 
-export function evalSymbolsOperand(): EvalSymbolsOperand {
-  return { type: HighLevelOperand.EvalSymbols, value: undefined };
+export function debugSymbolsOperand(): DebugSymbolsOperand {
+  return { type: HighLevelOperand.DebugSymbols, value: undefined };
 }
 
 export function isStrictMode(): IsStrictModeOperand {

--- a/packages/@glimmer/opcode-compiler/lib/syntax/expressions.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/expressions.ts
@@ -43,14 +43,14 @@ EXPRESSIONS.add(SexpOpcodes.GetSymbol, (op, [, sym, path]) => {
   withPath(op, path);
 });
 
-EXPRESSIONS.add(SexpOpcodes.GetTemplateSymbol, (op, [, sym, path]) => {
+EXPRESSIONS.add(SexpOpcodes.GetLexicalSymbol, (op, [, sym, path]) => {
   op(HighLevelResolutionOpcode.ResolveTemplateLocal, sym, (handle: number) => {
     op(Op.ConstantReference, handle);
     withPath(op, path);
   });
 });
 
-EXPRESSIONS.add(SexpOpcodes.GetStrictFree, (op, [, sym, _path]) => {
+EXPRESSIONS.add(SexpOpcodes.GetStrictKeyword, (op, [, sym, _path]) => {
   op(HighLevelResolutionOpcode.ResolveFree, sym, (_handle: unknown) => {
     // TODO: Implement in strict mode
   });

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -31,7 +31,7 @@ import {
   DynamicScope,
   PushPrimitiveReference,
 } from '../opcode-builder/helpers/vm';
-import { evalSymbolsOperand, labelOperand, stdlibOperand } from '../opcode-builder/operands';
+import { debugSymbolsOperand, labelOperand, stdlibOperand } from '../opcode-builder/operands';
 import { Compilers, PushStatementOp } from './compilers';
 import {
   isGetFreeComponent,
@@ -133,8 +133,8 @@ STATEMENTS.add(SexpOpcodes.Yield, (op, [, to, params]) => YieldBlock(op, to, par
 
 STATEMENTS.add(SexpOpcodes.AttrSplat, (op, [, to]) => YieldBlock(op, to, null));
 
-STATEMENTS.add(SexpOpcodes.Debugger, (op, [, evalInfo]) =>
-  op(Op.Debugger, evalSymbolsOperand(), evalInfo)
+STATEMENTS.add(SexpOpcodes.Debugger, (op, [, debugInfo]) =>
+  op(Op.Debugger, debugSymbolsOperand(), debugInfo)
 );
 
 STATEMENTS.add(SexpOpcodes.Append, (op, [, value]) => {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -34,9 +34,9 @@ export function resetDebuggerCallback() {
 class ScopeInspector {
   private locals = dict<Reference>();
 
-  constructor(private scope: Scope, symbols: string[], evalInfo: number[]) {
-    for (let i = 0; i < evalInfo.length; i++) {
-      let slot = evalInfo[i];
+  constructor(private scope: Scope, symbols: string[], debugInfo: number[]) {
+    for (let i = 0; i < debugInfo.length; i++) {
+      let slot = debugInfo[i];
       let name = symbols[slot - 1];
       let ref = scope.getSymbol(slot);
       this.locals[name] = ref;
@@ -66,9 +66,9 @@ class ScopeInspector {
   }
 }
 
-APPEND_OPCODES.add(Op.Debugger, (vm, { op1: _symbols, op2: _evalInfo }) => {
+APPEND_OPCODES.add(Op.Debugger, (vm, { op1: _symbols, op2: _debugInfo }) => {
   let symbols = vm[CONSTANTS].getArray<string>(_symbols);
-  let evalInfo = vm[CONSTANTS].getArray<number>(decodeHandle(_evalInfo));
-  let inspector = new ScopeInspector(vm.scope(), symbols, evalInfo);
+  let debugInfo = vm[CONSTANTS].getArray<number>(decodeHandle(_debugInfo));
+  let inspector = new ScopeInspector(vm.scope(), symbols, debugInfo);
   callback(valueForRef(vm.getSelf()), (path) => valueForRef(inspector.get(path)));
 });

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -114,7 +114,7 @@ export class EnvironmentImpl implements Environment {
   [TRANSACTION]: Option<TransactionImpl> = null;
 
   protected declare appendOperations: GlimmerTreeConstruction;
-  protected updateOperations?: GlimmerTreeChanges;
+  protected updateOperations?: GlimmerTreeChanges | undefined;
 
   // Delegate methods and values
   public isInteractive = this.delegate.isInteractive;

--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -56,10 +56,10 @@ export class OnModifierState {
   public declare eventName: string;
   public declare callback: EventListener;
   private declare userProvidedCallback: EventListener;
-  public once?: boolean;
-  public passive?: boolean;
-  public capture?: boolean;
-  public options?: AddEventListenerOptions;
+  public once?: boolean | undefined;
+  public passive?: boolean | undefined;
+  public capture?: boolean | undefined;
+  public options?: AddEventListenerOptions | undefined;
   public shouldUpdate = true;
 
   constructor(element: Element, args: CapturedArguments) {
@@ -90,7 +90,7 @@ export class OnModifierState {
     // we want to handle both `true` and `false` because both have a meaning:
     // https://bugs.chromium.org/p/chromium/issues/detail?id=770208
     if (once !== undefined || passive !== undefined || capture !== undefined) {
-      options = this.options = { once, passive, capture };
+      options = this.options = { once, passive, capture } as AddEventListenerOptions;
     } else {
       this.options = undefined;
     }

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -36,8 +36,8 @@ export type DebugState = {
   type: number;
   isMachine: 0 | 1;
   size: number;
-  params?: Maybe<Dict>;
-  name?: string;
+  params?: Maybe<Dict> | undefined;
+  name?: string | undefined;
   state: unknown;
 };
 

--- a/packages/@glimmer/syntax/index.ts
+++ b/packages/@glimmer/syntax/index.ts
@@ -7,6 +7,7 @@ export {
   ASTPluginBuilder,
   ASTPluginEnvironment,
   PrecompileOptions,
+  PrecompileOptionsWithLexicalScope,
   preprocess,
   Syntax,
   TemplateIdFn,

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -345,7 +345,11 @@ export interface TemplateIdFn {
 
 export interface PrecompileOptions extends PreprocessOptions {
   id?: TemplateIdFn;
-  customizeComponentName?(input: string): string;
+  customizeComponentName?: ((input: string) => string) | undefined;
+}
+
+export interface PrecompileOptionsWithLexicalScope extends PrecompileOptions {
+  lexicalScope: (variable: string) => boolean;
 }
 
 export interface PreprocessOptions {

--- a/packages/@glimmer/syntax/lib/source/source.ts
+++ b/packages/@glimmer/syntax/lib/source/source.ts
@@ -3,10 +3,15 @@ import { DEBUG } from '@glimmer/env';
 import type { Option } from '@glimmer/interfaces';
 import { assert } from '@glimmer/util';
 
+import { PrecompileOptions } from '../parser/tokenizer-event-handlers';
 import { SourceLocation, SourcePosition } from './location';
 import { SourceOffset, SourceSpan } from './span';
 
 export class Source {
+  static from(source: string, options: PrecompileOptions = {}): Source {
+    return new Source(source, options.meta?.moduleName);
+  }
+
   constructor(readonly source: string, readonly module: string = 'an unknown module') {}
 
   /**

--- a/packages/@glimmer/syntax/lib/traversal/errors.ts
+++ b/packages/@glimmer/syntax/lib/traversal/errors.ts
@@ -7,6 +7,7 @@ export interface TraversalError extends Error {
   key: string;
   node: ASTv1.Node;
   parent: Option<ASTv1.Node>;
+  stack: string | undefined;
 }
 
 export interface TraversalErrorConstructor {
@@ -31,7 +32,7 @@ const TraversalError: TraversalErrorConstructor = (function () {
     this.message = message;
     this.node = node;
     this.parent = parent;
-    this.stack = error.stack;
+    this.stack = error.stack ?? '';
   }
 
   return TraversalError as unknown as TraversalErrorConstructor;

--- a/packages/@glimmer/syntax/lib/v1/nodes-v1.ts
+++ b/packages/@glimmer/syntax/lib/v1/nodes-v1.ts
@@ -10,7 +10,7 @@ export interface Symbols {
   get(name: string): number;
 
   getLocalsMap(): Dict<number>;
-  getEvalInfo(): WireFormat.Core.EvalInfo;
+  getDebugInfo(): WireFormat.Core.DebugInfo;
 
   allocateFree(name: string): number;
   allocateNamed(name: string): number;

--- a/packages/@glimmer/syntax/lib/v1/parser-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/parser-builders.ts
@@ -27,20 +27,20 @@ class Builders {
   }
 
   blockItself({
-    body,
-    blockParams,
+    body = [],
+    blockParams = [],
     chained = false,
     loc,
   }: {
-    body?: ASTv1.Statement[];
-    blockParams?: string[];
-    chained?: boolean;
+    body?: ASTv1.Statement[] | undefined;
+    blockParams?: string[] | undefined;
+    chained?: boolean | undefined;
     loc: SourceSpan;
   }): ASTv1.Block {
     return {
       type: 'Block',
-      body: body || [],
-      blockParams: blockParams || [],
+      body: body,
+      blockParams: blockParams,
       chained,
       loc,
     };

--- a/packages/@glimmer/syntax/lib/v2/loose-resolution.ts
+++ b/packages/@glimmer/syntax/lib/v2/loose-resolution.ts
@@ -13,7 +13,7 @@ export interface VarPath extends ASTv1.PathExpression {
 
 export function SexpSyntaxContext(node: ASTv1.SubExpression): ASTv2.FreeVarResolution | null {
   if (isSimpleCallee(node)) {
-    return ASTv2.LooseModeResolution.namespaced(ASTv2.FreeVarNamespace.Helper);
+    return ASTv2.LooseModeResolution.namespaced(ASTv2.HELPER_NAMESPACE);
   } else {
     return null;
   }
@@ -23,7 +23,7 @@ export function ModifierSyntaxContext(
   node: ASTv1.ElementModifierStatement
 ): ASTv2.FreeVarResolution | null {
   if (isSimpleCallee(node)) {
-    return ASTv2.LooseModeResolution.namespaced(ASTv2.FreeVarNamespace.Modifier);
+    return ASTv2.LooseModeResolution.namespaced(ASTv2.MODIFIER_NAMESPACE);
   } else {
     return null;
   }
@@ -31,7 +31,7 @@ export function ModifierSyntaxContext(
 
 export function BlockSyntaxContext(node: ASTv1.BlockStatement): ASTv2.FreeVarResolution | null {
   if (isSimpleCallee(node)) {
-    return ASTv2.LooseModeResolution.namespaced(ASTv2.FreeVarNamespace.Component);
+    return ASTv2.LooseModeResolution.namespaced(ASTv2.COMPONENT_NAMESPACE);
   } else {
     return ASTv2.LooseModeResolution.fallback();
   }
@@ -117,7 +117,9 @@ function isSimpleCallee(node: AstCallParts): boolean {
   return isSimplePath(path);
 }
 
-function isSimplePath(node: ASTv1.Expression): boolean {
+type SimplePath = ASTv1.PathExpression & { head: ASTv1.VarHead };
+
+function isSimplePath(node: ASTv1.Expression): node is SimplePath {
   if (node.type === 'PathExpression' && node.head.type === 'VarHead') {
     return node.tail.length === 0;
   } else {

--- a/packages/@glimmer/syntax/lib/v2/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2/normalize.ts
@@ -118,6 +118,10 @@ export class BlockContext<Table extends SymbolTable = SymbolTable> {
     }
   }
 
+  isLexicalVar(variable: string): boolean {
+    return this.table.hasLexical(variable);
+  }
+
   private isFreeVar(callee: ASTv1.CallNode | ASTv1.PathExpression): boolean {
     if (callee.type === 'PathExpression') {
       if (callee.head.type !== 'VarHead') {
@@ -706,8 +710,6 @@ class ElementNormalizer {
     // expression normalizer.
     let isComponent = inScope || uppercase;
 
-    console.log({ isComponent });
-
     let variableLoc = loc.sliceStartChars({ skipStart: 1, chars: variable.length });
 
     let tailLength = tail.reduce((accum, part) => accum + 1 + part.length, 0);
@@ -721,7 +723,9 @@ class ElementNormalizer {
         loc: pathLoc,
       });
 
-      let resolution = this.ctx.resolutionFor(path, ComponentSyntaxContext);
+      let resolution = this.ctx.isLexicalVar(variable)
+        ? { result: ASTv2.STRICT_RESOLUTION }
+        : this.ctx.resolutionFor(path, ComponentSyntaxContext);
 
       if (resolution.result === 'error') {
         throw generateSyntaxError(

--- a/packages/@glimmer/syntax/lib/v2/objects/resolution.ts
+++ b/packages/@glimmer/syntax/lib/v2/objects/resolution.ts
@@ -14,19 +14,24 @@ import { GetContextualFreeOp, SexpOpcodes } from '@glimmer/interfaces';
  * 1. in a strict mode template
  * 2. in an unambiguous invocation with dot paths
  */
-export class StrictResolution {
-  resolution(): GetContextualFreeOp {
-    return SexpOpcodes.GetStrictFree;
-  }
+export const STRICT_RESOLUTION = {
+  resolution: (): GetContextualFreeOp => SexpOpcodes.GetStrictKeyword,
+  serialize: (): SerializedResolution => 'Strict',
+  isAngleBracket: false as const,
+};
 
-  serialize(): SerializedResolution {
-    return 'Strict';
-  }
+export type StrictResolution = typeof STRICT_RESOLUTION;
 
-  readonly isAngleBracket = false;
+export const HTML_RESOLUTION = {
+  ...STRICT_RESOLUTION,
+  isAngleBracket: true as const,
+};
+
+export type HtmlResolution = typeof HTML_RESOLUTION;
+
+export function isStrictResolution(value: unknown): value is StrictResolution {
+  return value === STRICT_RESOLUTION;
 }
-
-export const STRICT_RESOLUTION = new StrictResolution();
 
 /**
  * A `LooseModeResolution` includes:
@@ -145,7 +150,7 @@ export class LooseModeResolution {
 
   resolution(): GetContextualFreeOp {
     if (this.ambiguity.namespaces.length === 0) {
-      return SexpOpcodes.GetStrictFree;
+      return SexpOpcodes.GetStrictKeyword;
     } else if (this.ambiguity.namespaces.length === 1) {
       if (this.ambiguity.fallback) {
         // simple namespaced resolution with fallback must be attr={{x}}
@@ -192,11 +197,15 @@ export class LooseModeResolution {
 
 export const ARGUMENT_RESOLUTION = LooseModeResolution.fallback();
 
-export const enum FreeVarNamespace {
+export enum FreeVarNamespace {
   Helper = 'Helper',
   Modifier = 'Modifier',
   Component = 'Component',
 }
+
+export const HELPER_NAMESPACE = FreeVarNamespace.Helper;
+export const MODIFIER_NAMESPACE = FreeVarNamespace.Modifier;
+export const COMPONENT_NAMESPACE = FreeVarNamespace.Component;
 
 /**
  * A `ComponentOrHelperAmbiguity` might be a component or a helper, with an optional fallback
@@ -268,7 +277,7 @@ type Ambiguity =
   | NamespacedAmbiguity
   | FallbackAmbiguity;
 
-export type FreeVarResolution = StrictResolution | LooseModeResolution;
+export type FreeVarResolution = StrictResolution | HtmlResolution | LooseModeResolution;
 
 // Serialization
 

--- a/packages/@glimmer/validator/lib/debug.ts
+++ b/packages/@glimmer/validator/lib/debug.ts
@@ -25,7 +25,7 @@ export let logTrackingStack: undefined | ((transaction?: Transaction) => string)
 
 interface Transaction {
   parent: Transaction | null;
-  debugLabel?: string;
+  debugLabel?: string | undefined;
 }
 
 if (DEBUG) {
@@ -64,7 +64,7 @@ if (DEBUG) {
 
     let debugLabel = _debugLabel || undefined;
 
-    let parent = TRANSACTION_STACK[TRANSACTION_STACK.length - 1] || null;
+    let parent = TRANSACTION_STACK[TRANSACTION_STACK.length - 1] ?? null;
 
     TRANSACTION_STACK.push({
       parent,

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -150,7 +150,7 @@ interface InternalCache<T = unknown> {
   [LAST_VALUE]: T | undefined;
   [TAG]: Tag | undefined;
   [SNAPSHOT]: Revision;
-  [DEBUG_LABEL]?: string | false;
+  [DEBUG_LABEL]?: string | false | undefined;
 }
 
 export function createCache<T>(fn: () => T, debuggingLabel?: string | false): Cache<T> {

--- a/packages/@glimmer/vm/lib/opcodes.toml
+++ b/packages/@glimmer/vm/lib/opcodes.toml
@@ -899,5 +899,5 @@ operand-stack = [
 
 [syscall.debugger]
 
-format = ["Debugger", "symbols:str-array", "evalInfo:array"]
+format = ["Debugger", "symbols:str-array", "debugInfo:array"]
 operation = "Activate the debugger"

--- a/packages/@glimmer/vm/tsconfig.json
+++ b/packages/@glimmer/vm/tsconfig.json
@@ -21,12 +21,9 @@
     "noImplicitReturns": true,
 
     "newLine": "LF",
-    "noEmit": true
+    "noEmit": true,
+
+    "skipLibCheck": true
   },
-  "include": ["lib/**/*.ts", "index.ts"],
-  "references": [
-    {
-      "path": "../interfaces"
-    }
-  ]
+  "include": ["lib/**/*.ts", "index.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,7 +8,8 @@
     "typeRoots": [],
     "types": [],
     "baseUrl": ".",
-    "noEmit": true
+    "noEmit": true,
+    "skipLibCheck": true
   },
   "include": [
     "benchmark/**/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,10 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "useDefineForClassFields": true,
+    "exactOptionalPropertyTypes": true,
+    // "noImplicitOverride": true,
+    // "noPropertyAccessFromIndexSignature": true,
+    // "noUncheckedIndexedAccess": true,
 
     "newLine": "LF",
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "useDefineForClassFields": true,
-    "exactOptionalPropertyTypes": true,
+    // "exactOptionalPropertyTypes": true,
     // "noImplicitOverride": true,
     // "noPropertyAccessFromIndexSignature": true,
     // "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
# Improved lexical scope

This is an initial implementation of an improved API for compiling a
template with lexical scope.

Instead of passing a list of locals to the precompileTemplate function,
you can pass a function that takes a variable name and returns a boolean
to indicate whether the variable is in scope.

## Details

This fixes an inconsistency with how HTML tags and keywords
behave when they refer to a Handlebars local variable vs. when they
refer to a JavaScript lexical variable.

```jsx
const component = <template><div>{{yield}}</div></template>;

<template>
  <component />
</template>
```

After this change, the `<component>` invocation correctly refers to the
surrounding scope variable, even though `component` is a keyword.

This makes it consistent with:

```jsx
const variable = <template><div>{{yield}}</div></template>;

<template>
{{#let variable as |component|}}
  <component />
{{/let}}
</template>
```

These semantics are an important future-proofing measure: they allow us
to add additional keywords in the future, since local variables (either
lexical JavaScript variables of Handlebars variables) will win over the
newly defined keywords.

If we allowed keywords to win over lexical JavaScript variables, every
new keyword would be a breaking change. The semantics we used for
`as |div|` and `as |component|` were carefully designed to avoid this
problem, and this change helps us implement the same behavior for
lexical JavaScript variables.