### PR TITLE
Fix source checking when parsing {{~!~}} and the like.

### DIFF
--- a/packages/@glimmer/compiler/test/compiler-test.ts
+++ b/packages/@glimmer/compiler/test/compiler-test.ts
@@ -317,6 +317,8 @@ test('top-level comments', `<!-- {{foo}} -->`, c` {{foo}} `);
 
 test('handlebars comments', `<div>{{! Better not break! }}content</div>`, ['<div>', [s`content`]]);
 
+test('handlebars comments with whitespace removal', '<div>  {{~! some comment ~}}  content</div>', ['<div>', [s`content`]]);
+
 test('namespaced attribute', `<svg xlink:title='svg-title'>content</svg>`, [
   '<svg>',
   { 'xlink:title': s`svg-title` },

--- a/packages/@glimmer/syntax/lib/v2/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2/normalize.ts
@@ -353,11 +353,17 @@ class StatementNormalizer {
     let loc = this.block.loc(node.loc);
     let textLoc: SourceSpan;
 
-    if (loc.asString().slice(0, 5) === '{{!--') {
-      textLoc = loc.slice({ skipStart: 5, skipEnd: 4 });
-    } else {
-      textLoc = loc.slice({ skipStart: 3, skipEnd: 2 });
+    let locStr = loc.asString();
+
+    let skipStart = locStr.startsWith('{{~') ? 4 : 3;
+    let skipEnd = locStr.endsWith('~}}') ? 3 : 2;
+
+    if (locStr.slice(skipStart-1).startsWith('!--')) {
+      skipStart += 2;
+      skipEnd += 2;
     }
+
+    textLoc = loc.slice({ skipStart, skipEnd });
 
     return new ASTv2.GlimmerComment({
       loc,

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -524,6 +524,14 @@ test('a Handlebars comment', function () {
   );
 });
 
+test('a Handlebars comment with whitespace removal', function () {
+  let t = 'before {{~! some comment ~}} after';
+  astEqual(
+    t,
+    b.program([b.text('before'), b.mustacheComment(' some comment '), b.text('after')])
+  );
+});
+
 test('a Handlebars comment in proper element space', function () {
   let t = 'before <div {{! some comment }} data-foo="bar" {{! other comment }}></div> after';
   astEqual(


### PR DESCRIPTION
This fixes a warning that derives from several of these statements in `ember-prism`, which are intended to strip whitespace without otherwise doing anything:
```
{{~! ~}}
```
Presently these result in a compiler warning when building `ember-prism` or any addon which consumes it:
```
unexpectedly found "! ~" when slicing source, but expected " "
unexpectedly found "! ~" when slicing source, but expected " "
unexpectedly found "! ~" when slicing source, but expected " "
unexpectedly found "! ~" when slicing source, but expected " "
```

Fixes one cause of https://github.com/emberjs/ember.js/issues/19392

When fixing this I decided some tests would be nice to add even though they don't cover this fix.  Not really thinking it is worth a test specifically targeting this case, though.
