### PR TITLE
Skip checking the source for synthetic attributes to prevent warning.

### DIFF
--- a/packages/@glimmer/syntax/lib/v2/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2/normalize.ts
@@ -8,6 +8,7 @@ import {
   preprocess,
 } from '../parser/tokenizer-event-handlers';
 import type { SourceLocation } from '../source/location';
+import { SYNTHETIC_LOCATION } from '../source/location';
 import { SourceSlice } from '../source/slice';
 import type { Source } from '../source/source';
 import type { SourceSpan } from '../source/span';
@@ -593,7 +594,20 @@ class ElementNormalizer {
     }
 
     let offsets = this.ctx.loc(m.loc);
-    let nameSlice = offsets.sliceStartChars({ chars: m.name.length }).toSlice(m.name);
+
+    let synthetic_loc = JSON.stringify(SYNTHETIC_LOCATION);
+
+    let nameSlice;
+
+    // Don't try to pull synthetic attributes from the source
+    if (JSON.stringify(offsets) === JSON.stringify(synthetic_loc)) {
+      nameSlice = new SourceSlice({
+        loc: offsets,
+        chars: m.name
+      });
+    } else {
+      nameSlice = offsets.sliceStartChars({ chars: m.name.length }).toSlice(m.name);
+    }
 
     let value = this.attrValue(m.value);
     return this.ctx.builder.attr(
@@ -661,7 +675,20 @@ class ElementNormalizer {
     assert(arg.name[0] === '@', 'An arg name must start with `@`');
 
     let offsets = this.ctx.loc(arg.loc);
-    let nameSlice = offsets.sliceStartChars({ chars: arg.name.length }).toSlice(arg.name);
+
+    let synthetic_loc = JSON.stringify(SYNTHETIC_LOCATION);
+
+    let nameSlice;
+
+    // Don't try to pull synthetic arguments from the source
+    if (JSON.stringify(offsets) === JSON.stringify(synthetic_loc)) {
+      nameSlice = new SourceSlice({
+        loc: offsets,
+        chars: arg.name
+      });
+    } else {
+      nameSlice = offsets.sliceStartChars({ chars: arg.name.length }).toSlice(arg.name);
+    }
 
     let value = this.maybeDeprecatedCall(nameSlice, arg.value) || this.attrValue(arg.value);
     return this.ctx.builder.arg(


### PR DESCRIPTION
This fixes a warning caused when template parsing encounters a synthetic attribute (i.e., inserted by a plugin).  For example, building the `ember-maybe-in-element` addon outputs these warnings:

```
unexpectedly found "<div id=\"original-p" when slicing source, but expected "@destinationElement"
unexpectedly found "<div id=\"origi" when slicing source, but expected "@renderInPlace"
unexpectedly found "    \n      <div id=" when slicing source, but expected "@destinationElement"
unexpectedly found "    \n      <di" when slicing source, but expected "@renderInPlace"
```

and the same will happen for any app that uses the `ember-basic-dropdown` addon (which uses the above addon).

These should fix the remaining causes of https://github.com/emberjs/ember.js/issues/19392 that are not already fixed by https://github.com/glimmerjs/glimmer-vm/pull/1430.

I tried to add a test that would be even vaguely useful and couldn't really come up with anything.