### PR TITLE
fix: ensure child node is a child of parent before removing

### DIFF
--- a/packages/@glimmer/runtime/lib/bounds.ts
+++ b/packages/@glimmer/runtime/lib/bounds.ts
@@ -75,7 +75,17 @@ export function clear(bounds: Bounds): Nullable<SimpleNode> {
   while (true) {
     let next = current.nextSibling;
 
-    parent.removeChild(current);
+    if (parent === current.parentNode) {
+      current.parentNode.removeChild(current);
+    } else if (import.meta.env.DEV) {
+      if (current.parentNode === null) {
+        // eslint-disable-next-line no-console
+        console.warn("Attempted to clear a child node that doesn't have a parent node.");
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn('Attempted to clear a child node that has been moved.');
+      }
+    }
 
     if (current === last) {
       return next;


### PR DESCRIPTION
Fixes GH-1401

If `current` isn't a child of `parent` calling `parent.removeChild(current)` will result in the error: `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`. This commonly occurs when the DOM is externally modified by a browser, such as when translating a page. The `nextSibling` may not be a child node of `parent`.

`current.parentNode?.removeChild(current)` ensures we are only removing a child node of a parent node.