### PR TITLE
Allow publishing from detached HEAD state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
       #
       # > It will skip the private packages, presumably?
       # yes
-      - run: pnpm -r publish --access public
+      - run: pnpm -r publish --access public --no-git-checks
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Addresses:
```
Run pnpm -r publish --access public
 ERR_PNPM_GIT_UNKNOWN_BRANCH  The Git HEAD may not attached to any branch, but your "publish-branch" is set to "master|main".
```

We don't care about the git branch in this case, because we're running off of a tag.


Docs here: https://pnpm.io/cli/publish#configuration