### PR TITLE
rename local token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
       # yes
       - run: pnpm -r publish --access public --no-git-checks
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
NODE_AUTH_TOKEN is special,
note: https://github.com/embroider-build/embroider/blob/main/.github/workflows/publish-unstable.yml#L27-L31

while we're using a meta-action, we still ultimately use setup-node, which:
![image](https://github.com/glimmerjs/glimmer-vm/assets/199018/f60a34cb-2669-4bc7-8a30-dac45bda9456)

I likely confused this for `NPM_TOKEN` from `Changesets` release strategy / config, which is what I use on my personal projects.
