### PR TITLE
Revert "fix: capture render tree can fail if args cannot be obtained"

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -138,29 +138,19 @@ class DebugRenderTreeTest extends RenderTest {
 
   @test 'emberish curly components'() {
     this.registerComponent('Curly', 'HelloWorld', 'Hello World');
-    let error: Error|null = null;
-    const obj = {
-      get getterWithError() {
-        error = new Error('error');
-        throw error;
-      }
-    }
 
     this.render(
-      `<HelloWorld @arg="first" @arg2={{this.obj.getterWithError}}/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      `<HelloWorld @arg="first"/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
       {
         showSecond: false,
-        obj,
       }
     );
-
-    this.assert.ok(error !== null, 'expecting an Error');
 
     this.assertRenderTree([
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first', arg2: error } },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -174,7 +164,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first', arg2: error } },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -197,7 +187,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first', arg2: error } },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -483,24 +483,14 @@ export function reifyNamed(named: CapturedNamedArguments) {
   let reified = dict();
 
   for (const [key, value] of Object.entries(named)) {
-    try {
-      reified[key] = valueForRef(value);
-    } catch(e) {
-      reified[key] = e;
-    }
+    reified[key] = valueForRef(value);
   }
 
   return reified;
 }
 
 export function reifyPositional(positional: CapturedPositionalArguments) {
-  return positional.map((p) => {
-    try {
-      return valueForRef(p);
-    } catch(e) {
-      return e;
-    }
-  });
+  return positional.map(valueForRef);
 }
 
 export function reifyArgs(args: CapturedArguments) {


### PR DESCRIPTION
Reverts glimmerjs/glimmer-vm#1447

this also affects other parts, unrelated to capture render tree