### PR TITLE
fix capture render tree fails when errors in args

### DIFF
--- a/packages/@glimmer/interfaces/lib/runtime/arguments.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/arguments.d.ts
@@ -60,3 +60,9 @@ export interface Arguments {
   positional: readonly unknown[];
   named: Record<string, unknown>;
 }
+
+export interface ArgumentsDebug {
+  positional: readonly unknown[];
+  named: Record<string, unknown>;
+  errors: Record<string, Error>;
+}

--- a/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
@@ -1,7 +1,7 @@
 import type { SimpleElement, SimpleNode } from '@simple-dom/interface';
 
 import type { Bounds } from '../dom/bounds';
-import type { Arguments, CapturedArguments } from './arguments';
+import type { ArgumentsDebug, CapturedArguments } from './arguments';
 
 export type RenderNodeType = 'outlet' | 'engine' | 'route-template' | 'component';
 
@@ -17,7 +17,7 @@ export interface CapturedRenderNode {
   id: string;
   type: RenderNodeType;
   name: string;
-  args: Arguments;
+  args: ArgumentsDebug;
   instance: unknown;
   template: string | null;
   bounds: null | {

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -7,7 +7,7 @@ import type {
 } from "@glimmer/interfaces";
 import { assign, expect, Stack } from '@glimmer/util';
 
-import { reifyArgs } from './vm/arguments';
+import { reifyArgsDebug } from './vm/arguments';
 
 interface InternalRenderNode<T extends object> extends RenderNode {
   bounds: Nullable<Bounds>;
@@ -181,7 +181,7 @@ export default class DebugRenderTreeImpl<TBucket extends object>
     let template = this.captureTemplate(node);
     let bounds = this.captureBounds(node);
     let children = this.captureRefs(refs);
-    return { id, type, name, args: reifyArgs(args), instance, template, bounds, children };
+    return { id, type, name, args: reifyArgsDebug(args), instance, template, bounds, children };
   }
 
   private captureTemplate({ template }: InternalRenderNode<TBucket>): Nullable<string> {

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -500,6 +500,48 @@ export function reifyArgs(args: CapturedArguments) {
   };
 }
 
+export function reifyNamedDebug(named: CapturedNamedArguments) {
+  let reified = dict();
+  let errors: Record<string, Error> = dict();
+
+  for (const [key, value] of Object.entries(named)) {
+    try {
+      reified[key] = valueForRef(value);
+    } catch (e) {
+      reified[key] = e;
+      errors[key] = e as Error;
+    }
+  }
+
+  return { reified, errors };
+}
+
+export function reifyPositionalDebug(positional: CapturedPositionalArguments) {
+  let errors: Error[] = [];
+  let reified = positional.map((p) => {
+    try {
+      return valueForRef(p);
+    } catch(e) {
+      errors.push(e as Error);
+      return e;
+    }
+  });
+  return {
+    reified,
+    errors
+  }
+}
+
+export function reifyArgsDebug(args: CapturedArguments) {
+  let named = reifyNamedDebug(args.named);
+  let positional = reifyPositionalDebug(args.positional);
+  return {
+    named: named.reified,
+    positional: positional.reified,
+    errors: {...named.errors, ...positional.errors} as unknown as Record<string, Error >
+  };
+}
+
 export const EMPTY_NAMED = Object.freeze(Object.create(null)) as CapturedNamedArguments;
 export const EMPTY_POSITIONAL = EMPTY_REFERENCES as CapturedPositionalArguments;
 export const EMPTY_ARGS = createCapturedArgs(EMPTY_NAMED, EMPTY_POSITIONAL);

--- a/packages/@glimmer/vm-babel-plugins/index.ts
+++ b/packages/@glimmer/vm-babel-plugins/index.ts
@@ -21,7 +21,7 @@ export default function generateVmPlugins(
   return [
     [
       __loadPlugins
-        ?  
+        ?
           require('babel-plugin-debug-macros')
         : require.resolve('babel-plugin-debug-macros'),
       {


### PR DESCRIPTION
better alternative to #1447  .

i''m actually not sure anymore how [meta.discource.](https://meta.discourse.org/) was in a state where it could render the components, but would fail when using inspector.
having errors in the args would cause rendering to fail as well.