### PR TITLE
Declare @glimmer/local-debug-flags

### DIFF
--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -22,13 +22,13 @@
   },
   "dependencies": {
     "@glimmer/interfaces": "workspace:^",
+    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer/util": "workspace:^",
     "@glimmer/syntax": "workspace:^",
     "@glimmer/vm": "workspace:^",
     "@glimmer/wire-format": "workspace:^"
   },
   "devDependencies": {
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
     "@types/node": "^18.16.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,6 +567,9 @@ importers:
       '@glimmer/interfaces':
         specifier: workspace:^
         version: link:../interfaces
+      '@glimmer/local-debug-flags':
+        specifier: workspace:^
+        version: link:../local-debug-flags
       '@glimmer/syntax':
         specifier: workspace:^
         version: link:../syntax
@@ -583,9 +586,6 @@ importers:
       '@glimmer-workspace/build-support':
         specifier: workspace:^
         version: link:../../@glimmer-workspace/build
-      '@glimmer/local-debug-flags':
-        specifier: workspace:^
-        version: link:../local-debug-flags
       '@types/node':
         specifier: ^18.16.6
         version: 18.16.6


### PR DESCRIPTION
Ran in to this while trying to upgrade the vm in ember: https://github.com/emberjs/ember.js/pull/20561

We can't import packages without declaring them in `dependencies` or `peerDependencies`. Since the local-debug-flags package is entirely wrapped in `import.meta.env` guards, then we can include it and rely on build to remove / svelte away the unused blocks.