### PR TITLE
declare type=module

### DIFF
--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/compiler",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/compiler",
   "exports": {

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/debug",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/debug",
   "main": "index.ts",

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/destroyable",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/destroyable",
   "description": "Utilities for creating and managing a destroyable hierarchy of objects",

--- a/packages/@glimmer/dom-change-list/package.json
+++ b/packages/@glimmer/dom-change-list/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/dom-change-list",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/dom-change-list",
   "main": "index.ts",

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/encoder",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/encoder",
   "main": "index.ts",

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/global-context",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/global-context",
   "main": "index.ts",

--- a/packages/@glimmer/interfaces/package.json
+++ b/packages/@glimmer/interfaces/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/interfaces",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/interfaces",
   "types": "index.ts",

--- a/packages/@glimmer/local-debug-flags/package.json
+++ b/packages/@glimmer/local-debug-flags/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/local-debug-flags",
+  "type": "module",
   "version": "0.85.3",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/manager",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/program",
   "dependencies": {

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/node",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/node",
   "dependencies": {

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/opcode-compiler",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/opcode-compiler",
   "dependencies": {

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/owner",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/owner",
   "description": "Implementation for the owner in Glimmer apps",

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/program",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/program",
   "dependencies": {

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/reference",
+  "type": "module",
   "version": "0.85.3",
   "description": "Objects used to track values and their dirtiness in Glimmer",
   "license": "MIT",

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/runtime",
+  "type": "module",
   "version": "0.85.3",
   "description": "Minimal runtime needed to render Glimmer templates",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/runtime",

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/syntax",
+  "type": "module",
   "version": "0.85.3",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/syntax",
   "dependencies": {

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/util",
+  "type": "module",
   "version": "0.85.3",
   "description": "Common utilities used in Glimmer",
   "repository": "https://github.com/tildeio/glimmer/tree/master/packages/@glimmer/util",

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/validator",
+  "type": "module",
   "version": "0.85.3",
   "description": "Objects used to track values and their dirtiness in Glimmer",
   "license": "MIT",

--- a/packages/@glimmer/vm-babel-plugins/package.json
+++ b/packages/@glimmer/vm-babel-plugins/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/vm-babel-plugins",
+  "type": "module",
   "version": "0.85.3",
   "description": "Compiles out VM assertion and deprecation utilities and debug tooling based on environment",
   "repository": "https://github.com/glimmerjs/glimmer.js",

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@glimmer/vm",
   "version": "0.85.3",
+  "type": "module",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/vm",
   "dependencies": {
     "@glimmer/util": "workspace:^",

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@glimmer/wire-format",
+  "type": "module",
   "version": "0.85.3",
   "description": "",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/master/packages/@glimmer/wire-format",


### PR DESCRIPTION
Resolves: https://github.com/glimmerjs/glimmer-vm/issues/1464

the glimmer-vm repo has been going through some much needed maintenance.
During the last release, an ESM-only build was built.

In prior glimmer-vm releases, we had compiled all the way to ES5 in some cases for Ie11 support. but we no longer support IE11.

This has technically been a breaking change (as is every 0.x release, per semver, sorta).