### PR TITLE
Add rollup to every package with a rollup config

### DIFF
--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -32,6 +32,7 @@
     "@glimmer/wire-format": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
     "@types/node": "^18.16.6"

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -28,6 +28,7 @@
     "@glimmer/vm": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "toml": "^3.0.0",
     "@glimmer-workspace/build-support": "workspace:^"

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -27,6 +27,7 @@
     "@glimmer/util": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/dom-change-list/package.json
+++ b/packages/@glimmer/dom-change-list/package.json
@@ -23,6 +23,7 @@
     "@glimmer/interfaces": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -28,6 +28,7 @@
     "build": "rollup -c rollup.config.mjs"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^"
   }
 }

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -24,6 +24,7 @@
     "build": "rollup -c rollup.config.mjs"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^"
   }
 }

--- a/packages/@glimmer/interfaces/package.json
+++ b/packages/@glimmer/interfaces/package.json
@@ -28,6 +28,7 @@
     "@simple-dom/interface": "^1.4.0"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^"
   }
 }

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -18,6 +18,7 @@
     "dist"
   ],
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -13,6 +13,7 @@
     "dist"
   ],
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@types/qunit": "^2.19.7",
     "@glimmer/compiler": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -19,6 +19,7 @@
     "dist"
   ],
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -12,6 +12,7 @@
     "dist"
   ],
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -17,6 +17,7 @@
     "@glimmer/vm": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -20,6 +20,7 @@
     "@glimmer/validator": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -35,6 +35,7 @@
     "@glimmer/wire-format": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer/opcode-compiler": "workspace:^",
     "@glimmer/debug": "workspace:^",

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -11,6 +11,7 @@
     "simple-html-tokenizer": "^0.5.11"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@types/qunit": "^2.19.7",
     "@glimmer-workspace/build-support": "workspace:^"

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -13,6 +13,7 @@
     "dist"
   ],
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@types/qunit": "^2.19.7",
     "@glimmer-workspace/build-support": "workspace:^"

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -19,6 +19,7 @@
     "@glimmer/util": "workspace:^"
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^"
   },

--- a/packages/@glimmer/vm-babel-plugins/package.json
+++ b/packages/@glimmer/vm-babel-plugins/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-plugin-tester": "^11.0.4",
     "mocha": "^10.2.0",
+    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^"
   },
   "main": "index.ts",

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -28,6 +28,7 @@
     }
   },
   "devDependencies": {
+    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^"
   }
 }

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -30,6 +30,7 @@
     }
   },
   "devDependencies": {
-    "@glimmer-workspace/build-support": "workspace:^"
+    "@glimmer-workspace/build-support": "workspace:^",
+    "rollup": "^3.21.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,7 +208,7 @@ importers:
         version: 4.3.9(@types/node@18.16.6)
       xo:
         specifier: ^0.54.2
-        version: 0.54.2(@typescript-eslint/parser@5.59.5)(eslint-import-resolver-typescript@3.5.5)(webpack@5.88.2)
+        version: 0.54.2(eslint-import-resolver-typescript@3.5.5)(webpack@5.88.2)
 
   benchmark:
     dependencies:
@@ -589,6 +589,9 @@ importers:
       '@types/node':
         specifier: ^18.16.6
         version: 18.16.6
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/compiler/test:
     dependencies:
@@ -623,6 +626,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
       toml:
         specifier: ^3.0.0
         version: 3.0.0
@@ -648,6 +654,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/destroyable/test:
     dependencies:
@@ -676,6 +685,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/dom-change-list/test:
     dependencies:
@@ -710,12 +722,18 @@ importers:
       '@glimmer-workspace/build-support':
         specifier: workspace:^
         version: link:../../@glimmer-workspace/build
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/global-context:
     devDependencies:
       '@glimmer-workspace/build-support':
         specifier: workspace:^
         version: link:../../@glimmer-workspace/build
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/interfaces:
     dependencies:
@@ -726,6 +744,9 @@ importers:
       '@glimmer-workspace/build-support':
         specifier: workspace:^
         version: link:../../@glimmer-workspace/build
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/local-debug-flags: {}
 
@@ -765,6 +786,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/manager/test:
     dependencies:
@@ -808,6 +832,9 @@ importers:
       '@types/qunit':
         specifier: ^2.19.7
         version: 2.19.7
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/opcode-compiler:
     dependencies:
@@ -848,6 +875,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/owner:
     dependencies:
@@ -861,6 +891,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/owner/test:
     dependencies:
@@ -901,6 +934,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/program/test:
     dependencies:
@@ -932,6 +968,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/reference/test:
     dependencies:
@@ -1005,6 +1044,9 @@ importers:
       '@types/qunit':
         specifier: ^2.19.7
         version: 2.19.7
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/syntax:
     dependencies:
@@ -1033,6 +1075,9 @@ importers:
       '@types/qunit':
         specifier: ^2.19.7
         version: 2.19.7
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/syntax/test:
     dependencies:
@@ -1070,6 +1115,9 @@ importers:
       '@types/qunit':
         specifier: ^2.19.7
         version: 2.19.7
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/util/test:
     dependencies:
@@ -1098,6 +1146,9 @@ importers:
       '@glimmer/local-debug-flags':
         specifier: workspace:^
         version: link:../local-debug-flags
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/validator/test:
     dependencies:
@@ -1123,6 +1174,9 @@ importers:
       '@glimmer-workspace/build-support':
         specifier: workspace:^
         version: link:../../@glimmer-workspace/build
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/vm-babel-plugins:
     dependencies:
@@ -1139,6 +1193,9 @@ importers:
       mocha:
         specifier: ^10.2.0
         version: 10.2.0
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@glimmer/wire-format:
     dependencies:
@@ -1152,6 +1209,9 @@ importers:
       '@glimmer-workspace/build-support':
         specifier: workspace:^
         version: link:../../@glimmer-workspace/build
+      rollup:
+        specifier: ^3.21.6
+        version: 3.21.6
 
   packages/@types/js-reporters: {}
 
@@ -6598,6 +6658,21 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       eslint: 8.40.0
+
+  /eslint-config-xo-typescript@0.57.0(@typescript-eslint/eslint-plugin@5.59.5)(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-u+qcTaADHn2/+hbDqZHRWiAps8JS6BcRsJKAADFxYHIPpYqQeQv9mXuhRe/1+ikfZAIz9hlG1V+Lkj8J7nf34A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '>=5.57.0'
+      '@typescript-eslint/parser': '>=5.57.0'
+      eslint: '>=8.0.0'
+      typescript: '>=4.4 || 5'
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.5(eslint@8.40.0)(typescript@5.0.4)
+      eslint: 8.40.0
+      typescript: 5.0.4
+    dev: true
 
   /eslint-config-xo@0.43.1(eslint@8.40.0):
     resolution: {integrity: sha512-azv1L2PysRA0NkZOgbndUpN+581L7wPqkgJOgxxw3hxwXAbJgD6Hqb/SjHRiACifXt/AvxCzE/jIKFAlI7XjvQ==}
@@ -14745,7 +14820,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /xo@0.54.2(@typescript-eslint/parser@5.59.5)(eslint-import-resolver-typescript@3.5.5)(webpack@5.88.2):
+  /xo@0.54.2(eslint-import-resolver-typescript@3.5.5)(webpack@5.88.2):
     resolution: {integrity: sha512-1S3r+ecCg8OVPtu711as+cgwxOg+WQNRgSzqZ+OHzYlsa8CpW3ych0Ve9k8Q2QG6gqO3HSpaS5AXi9D0yPUffg==}
     engines: {node: '>=14.16'}
     hasBin: true
@@ -14756,12 +14831,15 @@ packages:
         optional: true
     dependencies:
       '@eslint/eslintrc': 1.4.1
+      '@typescript-eslint/eslint-plugin': 5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.5(eslint@8.40.0)(typescript@5.0.4)
       arrify: 3.0.0
       cosmiconfig: 8.3.6(typescript@5.0.4)
       define-lazy-prop: 3.0.0
       eslint: 8.40.0
       eslint-config-prettier: 8.8.0(eslint@8.40.0)
       eslint-config-xo: 0.43.1(eslint@8.40.0)
+      eslint-config-xo-typescript: 0.57.0(@typescript-eslint/eslint-plugin@5.59.5)(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.0.4)
       eslint-formatter-pretty: 5.0.0
       eslint-import-resolver-webpack: 0.13.2(eslint-plugin-import@2.27.5)(webpack@5.88.2)
       eslint-plugin-ava: 14.0.0(eslint@8.40.0)
@@ -14790,7 +14868,6 @@ packages:
       typescript: 5.0.4
       webpack: 5.88.2
     transitivePeerDependencies:
-      - '@typescript-eslint/parser'
       - eslint-import-resolver-typescript
       - supports-color
     dev: true


### PR DESCRIPTION
This is required when doing debugging of individual packages, like even `pnpm turbo build --filter @glimmer/validator`

Without this change, build can only be ran across the whole monorepo.
And to prep for creating a rollup plugin, I want to be able to just work with a single package.