### PR TITLE
Add CJS back to glimmer/syntax,compiler

### DIFF
--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -22,8 +22,10 @@
       ".": {
         "types": "./dist/dev/index.d.ts",
         "development": {
+          "require": "./dist/dev/index.cjs",
           "default": "./dist/dev/index.js"
         },
+        "require": "./dist/dev/index.cjs",
         "default": "./dist/prod/index.js"
       }
     }

--- a/packages/@glimmer/compiler/rollup.config.mjs
+++ b/packages/@glimmer/compiler/rollup.config.mjs
@@ -1,3 +1,3 @@
 import { Package } from '@glimmer-workspace/build-support';
 
-export default Package.config(import.meta);
+export default Package.config(import.meta, { esm: true, cjs: true });

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -37,8 +37,10 @@
       ".": {
         "types": "./dist/dev/index.d.ts",
         "development": {
+          "require": "./dist/dev/index.cjs",
           "default": "./dist/dev/index.js"
         },
+        "require": "./dist/dev/index.cjs",
         "default": "./dist/prod/index.js"
       }
     }

--- a/packages/@glimmer/syntax/rollup.config.mjs
+++ b/packages/@glimmer/syntax/rollup.config.mjs
@@ -1,3 +1,3 @@
 import { Package } from '@glimmer-workspace/build-support';
 
-export default Package.config(import.meta);
+export default Package.config(import.meta, { esm: true, cjs: true });


### PR DESCRIPTION
ember-source, and eslint-plugin-ember `require()` a couple packages in a classic node environment and not in an async context -- so require/cjs is still needed for a couple packages.