### PR TITLE
MakePrimitiveRef generic so that UNDEFINED_REFERENCE can be Reference<undefined> rather than Reference<unknown>

### DIFF
--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -56,8 +56,8 @@ class ReferenceImpl<T = unknown> implements Reference<T> {
   }
 }
 
-export function createPrimitiveRef(value: unknown): Reference {
-  const ref = new ReferenceImpl(UNBOUND);
+export function createPrimitiveRef<T = unknown>(value: T): Reference<T> {
+  const ref = new ReferenceImpl<T>(UNBOUND);
 
   ref.tag = CONSTANT_TAG;
   ref.lastValue = value;
@@ -71,8 +71,8 @@ export function createPrimitiveRef(value: unknown): Reference {
 
 export const UNDEFINED_REFERENCE = createPrimitiveRef(undefined);
 export const NULL_REFERENCE = createPrimitiveRef(null);
-export const TRUE_REFERENCE = createPrimitiveRef(true);
-export const FALSE_REFERENCE = createPrimitiveRef(false);
+export const TRUE_REFERENCE = createPrimitiveRef(true as const);
+export const FALSE_REFERENCE = createPrimitiveRef(false as const);
 
 export function createConstRef(value: unknown, debugLabel: false | string): Reference {
   const ref = new ReferenceImpl(CONSTANT);


### PR DESCRIPTION
ran in to this when trying to update glimmer-vm in ember-source, here: https://github.com/emberjs/ember.js/pull/20561

in particular: 
```
packages/@ember/-internals/glimmer/lib/renderer.ts:396:47 - error TS2345: Argument of type 'Reference<unknown>' is not assignable to parameter of type 'Reference<OutletState | undefined>'.
  Type 'unknown' is not assignable to type 'OutletState | undefined'.

396     let dynamicScope = new DynamicScope(null, UNDEFINED_REFERENCE);
                                                  ~~~~~~~~~~~~~~~~~~~
```

this should be resolved after this PR