### PR TITLE
Setup the cache server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,7 @@ jobs:
         with:
           node-version: 20.1.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pnpm build
-      - run: pnpm test:types
+      - run: pnpm turbo test:types
 
   floating-dependencies:
     name: Floating Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,22 @@ on:
   schedule:
     - cron: '0 3 * * *' # daily, at 3am
 
+env:
+  TURBO_API: http://127.0.0.1:9080
+  TURBO_TOKEN: this-is-not-a-secret
+  TURBO_TEAM: myself
+
 jobs:
   install_dependencies:
-    name: 'Install Dependencies'
+    name: 'Setup'
     runs-on: 'ubuntu-latest'
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: wyvox/action-setup-pnpm@v2
+      - uses: wyvox/action@v1
         with:
           node-version: 20.1.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: pnpm turbo build
 
   lint:
     name: Linting
@@ -29,10 +35,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: wyvox/action-setup-pnpm@v2
+      - uses: wyvox/action@v1
         with:
           node-version: 20.1.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm lint
 
   test-chrome:
@@ -52,10 +58,10 @@ jobs:
             libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 \
             libxss1 libxtst6 ca-certificates fonts-liberation libnss3 lsb-release \
             xdg-utils wget libcairo2
-      - uses: actions/checkout@v3
-      - uses: wyvox/action-setup-pnpm@v2
+      - uses: wyvox/action@v1
         with:
           node-version: 20.1.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm test
 
   # test-browserstack:
@@ -101,10 +107,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: wyvox/action-setup-pnpm@v2
+      - uses: wyvox/action@v1
         with:
           node-version: 20.1.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm build
       - run: pnpm test:types
 
@@ -115,9 +121,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: wyvox/action-setup-pnpm@v2
+      - uses: wyvox/action@v1
         with:
-          args: '--no-lockfile'
+          pnpm-args: '--no-lockfile'
           node-version: 20.1.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm test

--- a/bin/run-types-tests.mjs
+++ b/bin/run-types-tests.mjs
@@ -9,7 +9,7 @@ const __dirname = new URL('.', import.meta.url).pathname;
 const root = resolve(__dirname, '..');
 
 async function main() {
-  const packages = getPackages();
+  const packages = getPackages().filter((pkg) => pkg.name !== '@glimmer/vm-babel-plugins');
 
   /**
    * Runs a smoke test of the generated type definitions by importing every module

--- a/bin/run-types-tests.mjs
+++ b/bin/run-types-tests.mjs
@@ -23,10 +23,14 @@ async function main() {
   for (const pkg of packages) {
     try {
       console.log(`# Smoke testing ${pkg.name}`);
-      await execa('tsc', ['-p', resolve(root, 'tsconfig.dist.json')], {
-        cwd: resolve(pkg.path, 'dist'),
-        preferLocal: true,
-      });
+      await execa(
+        resolve(root, 'node_modules/.bin/tsc'),
+        ['-p', resolve(root, 'tsconfig.dist.json')],
+        {
+          cwd: resolve(pkg.path, 'dist'),
+          preferLocal: true,
+        }
+      );
       console.log(`ok ${testNo++} - ${pkg.name} types passed`);
     } catch (err) {
       let message = getMessage(err);

--- a/bin/run-types-tests.mjs
+++ b/bin/run-types-tests.mjs
@@ -9,7 +9,11 @@ const __dirname = new URL('.', import.meta.url).pathname;
 const root = resolve(__dirname, '..');
 
 async function main() {
-  const packages = getPackages().filter((pkg) => pkg.name !== '@glimmer/vm-babel-plugins');
+  // vm-babel-plugins is exclusively used by ember.
+  // dom-change-list isn't used by anyone, even in this repo.
+  const packages = getPackages().filter(
+    (pkg) => pkg.name !== '@glimmer/vm-babel-plugins' && pkg.name !== '@glimmer/dom-change-list'
+  );
 
   /**
    * Runs a smoke test of the generated type definitions by importing every module

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "test:node": "node bin/run-node-tests.mjs",
     "test:babel-plugins": "yarn workspace @glimmer/vm-babel-plugins test",
     "test:smoke": "SMOKE_TESTS=true ember test",
-    "test:types": "node bin/run-types-tests.mjs",
-    "test:typecheck": "tsc -b"
+    "test:types": "node bin/run-types-tests.mjs"
   },
   "pnpm": {
     "overrides": {

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -39,12 +39,13 @@
     "@glimmer/wire-format": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
+    "@glimmer/local-debug-flags": "workspace:^",
     "@types/node": "^18.16.6",
-    "publint": "^0.2.5"
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "build": "rollup -c rollup.config.mjs",

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -30,12 +30,13 @@
     "@glimmer/vm": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
-    "toml": "^3.0.0",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "toml": "^3.0.0",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -29,11 +29,12 @@
     "@glimmer/util": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/dom-change-list/package.json
+++ b/packages/@glimmer/dom-change-list/package.json
@@ -30,11 +30,12 @@
     "@glimmer/interfaces": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -36,9 +36,10 @@
     "test:publint": "publint"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   }
 }

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -32,9 +32,10 @@
     "test:publint": "publint"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   }
 }

--- a/packages/@glimmer/interfaces/package.json
+++ b/packages/@glimmer/interfaces/package.json
@@ -25,9 +25,10 @@
     "@simple-dom/interface": "^1.4.0"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   }
 }

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -18,11 +18,12 @@
     "dist"
   ],
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "main": "index.ts",
   "types": "index.ts",

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -13,12 +13,13 @@
     "dist"
   ],
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@types/qunit": "^2.19.7",
-    "@glimmer/compiler": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/compiler": "workspace:^",
+    "@types/qunit": "^2.19.7",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -19,11 +19,12 @@
     "dist"
   ],
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -12,11 +12,12 @@
     "dist"
   ],
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -17,11 +17,12 @@
     "@glimmer/vm": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "main": "index.ts",
   "types": "index.ts",

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -20,11 +20,12 @@
     "@glimmer/validator": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -39,14 +39,15 @@
     "@glimmer/wire-format": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
+    "@glimmer-workspace/build-support": "workspace:^",
+    "@glimmer/debug": "workspace:^",
     "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer/opcode-compiler": "workspace:^",
-    "@glimmer/debug": "workspace:^",
     "@types/qunit": "^2.19.7",
-    "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -11,12 +11,13 @@
     "simple-html-tokenizer": "^0.5.11"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
+    "@glimmer-workspace/build-support": "workspace:^",
     "@glimmer/local-debug-flags": "workspace:^",
     "@types/qunit": "^2.19.7",
-    "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -13,12 +13,13 @@
     "dist"
   ],
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
+    "@glimmer-workspace/build-support": "workspace:^",
     "@glimmer/local-debug-flags": "workspace:^",
     "@types/qunit": "^2.19.7",
-    "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "main": "index.ts",
   "types": "index.ts",

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -19,11 +19,12 @@
     "@glimmer/util": "workspace:^"
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
-    "rollup": "^3.21.6",
-    "@glimmer/local-debug-flags": "workspace:^",
     "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "@glimmer/local-debug-flags": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
+    "rollup": "^3.21.6",
+    "typescript": "*"
   },
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer/vm-babel-plugins/package.json
+++ b/packages/@glimmer/vm-babel-plugins/package.json
@@ -24,12 +24,13 @@
     "babel-plugin-debug-macros": "^0.3.4"
   },
   "devDependencies": {
+    "@glimmer-workspace/build-support": "workspace:^",
     "babel-plugin-tester": "^11.0.4",
     "eslint": "^8.52.0",
     "mocha": "^10.2.0",
+    "publint": "^0.2.5",
     "rollup": "^3.21.6",
-    "@glimmer-workspace/build-support": "workspace:^",
-    "publint": "^0.2.5"
+    "typescript": "*"
   },
   "main": "index.ts",
   "types": "index.ts",

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -39,6 +39,7 @@
     "@glimmer-workspace/build-support": "workspace:^",
     "eslint": "^8.52.0",
     "publint": "^0.2.5",
-    "rollup": "^3.21.6"
+    "rollup": "^3.21.6",
+    "typescript": "*"
   }
 }

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -38,9 +38,10 @@
     "module": null
   },
   "devDependencies": {
-    "eslint": "^8.52.0",
     "@glimmer-workspace/build-support": "workspace:^",
+    "eslint": "^8.52.0",
+    "publint": "^0.2.5",
     "rollup": "^3.21.6",
-    "publint": "^0.2.5"
+    "typescript": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 3.6.1(@typescript-eslint/parser@6.9.0)(eslint-plugin-import@2.29.0)(eslint@8.52.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+        version: 2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
       eslint-plugin-n:
         specifier: ^16.2.0
         version: 16.2.0(eslint@8.52.0)
@@ -208,7 +208,7 @@ importers:
         version: 4.3.9(@types/node@18.16.6)
       xo:
         specifier: ^0.54.2
-        version: 0.54.2(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(webpack@5.89.0)
+        version: 0.54.2(eslint-import-resolver-typescript@3.6.1)(webpack@5.89.0)
 
   benchmark:
     dependencies:
@@ -405,7 +405,7 @@ importers:
         version: 8.52.0
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+        version: 2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
       eslint-plugin-json:
         specifier: ^3.1.0
         version: 3.1.0
@@ -472,7 +472,7 @@ importers:
         version: 2.0.0(eslint@8.52.0)(typescript@5.2.2)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+        version: 2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
       eslint-plugin-n:
         specifier: ^16.2.0
         version: 16.2.0(eslint@8.52.0)
@@ -630,6 +630,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/compiler/test:
     dependencies:
@@ -676,6 +679,9 @@ importers:
       toml:
         specifier: ^3.0.0
         version: 3.0.0
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/destroyable:
     dependencies:
@@ -707,6 +713,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/destroyable/test:
     dependencies:
@@ -744,6 +753,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/dom-change-list/test:
     dependencies:
@@ -787,6 +799,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/global-context:
     devDependencies:
@@ -802,6 +817,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/interfaces:
     dependencies:
@@ -821,6 +839,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/local-debug-flags:
     devDependencies:
@@ -873,6 +894,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/manager/test:
     dependencies:
@@ -925,6 +949,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/opcode-compiler:
     dependencies:
@@ -974,6 +1001,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/owner:
     dependencies:
@@ -996,6 +1026,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/owner/test:
     dependencies:
@@ -1045,6 +1078,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/program/test:
     dependencies:
@@ -1085,6 +1121,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/reference/test:
     dependencies:
@@ -1164,6 +1203,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/syntax:
     dependencies:
@@ -1201,6 +1243,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/syntax/test:
     dependencies:
@@ -1247,6 +1292,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/util/test:
     dependencies:
@@ -1284,6 +1332,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/validator/test:
     dependencies:
@@ -1318,6 +1369,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/vm-babel-plugins:
     dependencies:
@@ -1343,6 +1397,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@glimmer/wire-format:
     dependencies:
@@ -1365,6 +1422,9 @@ importers:
       rollup:
         specifier: ^3.21.6
         version: 3.21.6
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
 
   packages/@types/js-reporters: {}
 
@@ -3594,6 +3654,34 @@ packages:
       '@types/node': 18.16.6
     optional: true
 
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.52.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin@6.9.0(@typescript-eslint/parser@6.9.0)(eslint@8.52.0)(typescript@5.0.4):
     resolution: {integrity: sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -3651,6 +3739,25 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/parser@5.62.0(eslint@8.52.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.52.0
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+
   /@typescript-eslint/parser@6.9.0(eslint@8.52.0)(typescript@5.0.4):
     resolution: {integrity: sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -3670,6 +3777,7 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/parser@6.9.0(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==}
@@ -3691,12 +3799,39 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/scope-manager@5.62.0:
+    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+
   /@typescript-eslint/scope-manager@6.9.0:
     resolution: {integrity: sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.9.0
       '@typescript-eslint/visitor-keys': 6.9.0
+
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.52.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.52.0
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/type-utils@6.9.0(eslint@8.52.0)(typescript@5.0.4):
     resolution: {integrity: sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==}
@@ -3737,9 +3872,33 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/types@5.62.0:
+    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   /@typescript-eslint/types@6.9.0:
     resolution: {integrity: sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
 
   /@typescript-eslint/typescript-estree@6.9.0(typescript@5.0.4):
     resolution: {integrity: sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==}
@@ -3760,6 +3919,7 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/typescript-estree@6.9.0(typescript@5.2.2):
     resolution: {integrity: sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==}
@@ -3780,6 +3940,26 @@ packages:
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
+
+  /@typescript-eslint/utils@5.62.0(eslint@8.52.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.52.0)
+      '@types/json-schema': 7.0.14
+      '@types/semver': 7.5.4
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      eslint: 8.52.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
 
   /@typescript-eslint/utils@6.9.0(eslint@8.52.0)(typescript@5.0.4):
     resolution: {integrity: sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==}
@@ -3817,6 +3997,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /@typescript-eslint/visitor-keys@5.62.0:
+    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      eslint-visitor-keys: 3.4.3
 
   /@typescript-eslint/visitor-keys@6.9.0:
     resolution: {integrity: sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==}
@@ -6974,6 +7161,21 @@ packages:
     dependencies:
       eslint: 8.52.0
 
+  /eslint-config-xo-typescript@0.57.0(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-u+qcTaADHn2/+hbDqZHRWiAps8JS6BcRsJKAADFxYHIPpYqQeQv9mXuhRe/1+ikfZAIz9hlG1V+Lkj8J7nf34A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '>=5.57.0'
+      '@typescript-eslint/parser': '>=5.57.0'
+      eslint: '>=8.0.0'
+      typescript: '>=4.4 || 5'
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
+      eslint: 8.52.0
+      typescript: 5.2.2
+    dev: true
+
   /eslint-config-xo@0.43.1(eslint@8.52.0):
     resolution: {integrity: sha512-azv1L2PysRA0NkZOgbndUpN+581L7wPqkgJOgxxw3hxwXAbJgD6Hqb/SjHRiACifXt/AvxCzE/jIKFAlI7XjvQ==}
     engines: {node: '>=12'}
@@ -7017,8 +7219,8 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.15.0
       eslint: 8.52.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -7039,7 +7241,7 @@ packages:
       array-find: 1.0.0
       debug: 3.2.7
       enhanced-resolve: 0.9.1
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
       find-root: 1.1.0
       has: 1.0.4
       interpret: 1.4.0
@@ -7052,7 +7254,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7073,7 +7275,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.9.0(eslint@8.52.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
       debug: 3.2.7
       eslint: 8.52.0
       eslint-import-resolver-node: 0.3.9
@@ -7146,7 +7348,7 @@ packages:
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0):
+  /eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0):
     resolution: {integrity: sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7156,7 +7358,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.9.0(eslint@8.52.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -7165,7 +7367,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.52.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10940,6 +11142,10 @@ packages:
       - supports-color
     dev: true
 
+  /natural-compare-lite@1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
+    dev: true
+
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -14395,6 +14601,7 @@ packages:
       typescript: '>=4.2.0 || 5'
     dependencies:
       typescript: 5.0.4
+    dev: true
 
   /ts-api-utils@1.0.3(typescript@5.2.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
@@ -14466,7 +14673,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.2.2
-    dev: false
 
   /tsx@3.12.7:
     resolution: {integrity: sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==}
@@ -15312,7 +15518,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /xo@0.54.2(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(webpack@5.89.0):
+  /xo@0.54.2(eslint-import-resolver-typescript@3.6.1)(webpack@5.89.0):
     resolution: {integrity: sha512-1S3r+ecCg8OVPtu711as+cgwxOg+WQNRgSzqZ+OHzYlsa8CpW3ych0Ve9k8Q2QG6gqO3HSpaS5AXi9D0yPUffg==}
     engines: {node: '>=14.16'}
     hasBin: true
@@ -15323,17 +15529,20 @@ packages:
         optional: true
     dependencies:
       '@eslint/eslintrc': 1.4.1
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.2.2)
       arrify: 3.0.0
       cosmiconfig: 8.3.6(typescript@5.2.2)
       define-lazy-prop: 3.0.0
       eslint: 8.52.0
       eslint-config-prettier: 8.10.0(eslint@8.52.0)
       eslint-config-xo: 0.43.1(eslint@8.52.0)
+      eslint-config-xo-typescript: 0.57.0(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.2.2)
       eslint-formatter-pretty: 5.0.0
       eslint-import-resolver-webpack: 0.13.2(eslint-plugin-import@2.29.0)(webpack@5.89.0)
       eslint-plugin-ava: 14.0.0(eslint@8.52.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.52.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.52.0)
       eslint-plugin-n: 15.7.0(eslint@8.52.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.52.0)(prettier@2.8.8)
@@ -15357,7 +15566,6 @@ packages:
       typescript: 5.2.2
       webpack: 5.89.0
     transitivePeerDependencies:
-      - '@typescript-eslint/parser'
       - eslint-import-resolver-typescript
       - supports-color
     dev: true

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -21,7 +21,7 @@
 
     "paths": {
       "@glimmer/interfaces": ["./packages/@glimmer/interfaces/index.d.ts"],
-      "@glimmer/*": ["./packages/@glimmer/*/dist/index.d.ts"]
+      "@glimmer/*": ["./packages/@glimmer/*/dist/dev/index.d.ts"]
     }
   },
   "include": ["packages/@glimmer/*/dist/**/*.d.ts"],

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,7 @@
       "dependsOn": ["build"]
     },
     "//#test:types": {
+      "inputs": ["**/dist/**", "tsconfig.dist.json"],
       "dependsOn": ["^build"]
     }
   },

--- a/turbo.json
+++ b/turbo.json
@@ -30,11 +30,9 @@
     "test:publint": {
       "dependsOn": ["build"]
     },
-    "typecheck": {
-      "inputs": ["dist/**"],
-      "dependsOn": ["^build", "test:types"]
-    },
-    "test:types": {}
+    "//#test:types": {
+      "dependsOn": ["^build"]
+    }
   },
   "globalDependencies": [
     "tsconfig.json",


### PR DESCRIPTION
Because we now build each package 3 times (prod (ESM), dev (ESM), and (CJS)), and because building is required before linting, the `lint` job takes a while. 

By using the cache server, we can hopefully speed up parts of CI.

For example, previously, in: https://github.com/glimmerjs/glimmer-vm/pull/1481 -- https://github.com/glimmerjs/glimmer-vm/actions/runs/6721577834/usage

- Total Runtime is 19m43s
- Human perceived time is 9m 42s

With this PRs changes, we see: https://github.com/glimmerjs/glimmer-vm/actions/runs/6726246999/usage
- Total runtime is about the same
- human percieved time on no-cache hits is slower, but as I was iterating on this, we have the potential to be 2x as fast, I think.