### PR TITLE
Unify reference factory function signatures

### DIFF
--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -56,7 +56,7 @@ class ReferenceImpl<T = unknown> implements Reference<T> {
   }
 }
 
-export function createPrimitiveRef<T = unknown>(value: T): Reference<T> {
+export function createPrimitiveRef<T>(value: T): Reference<T> {
   const ref = new ReferenceImpl<T>(UNBOUND);
 
   ref.tag = CONSTANT_TAG;
@@ -74,8 +74,8 @@ export const NULL_REFERENCE = createPrimitiveRef(null);
 export const TRUE_REFERENCE = createPrimitiveRef(true as const);
 export const FALSE_REFERENCE = createPrimitiveRef(false as const);
 
-export function createConstRef(value: unknown, debugLabel: false | string): Reference {
-  const ref = new ReferenceImpl(CONSTANT);
+export function createConstRef<T>(value: T, debugLabel: false | string): Reference<T> {
+  const ref = new ReferenceImpl<T>(CONSTANT);
 
   ref.lastValue = value;
   ref.tag = CONSTANT_TAG;
@@ -87,8 +87,8 @@ export function createConstRef(value: unknown, debugLabel: false | string): Refe
   return ref;
 }
 
-export function createUnboundRef(value: unknown, debugLabel: false | string): Reference {
-  const ref = new ReferenceImpl(UNBOUND);
+export function createUnboundRef<T>(value: T, debugLabel: false | string): Reference<T> {
+  const ref = new ReferenceImpl<T>(UNBOUND);
 
   ref.lastValue = value;
   ref.tag = CONSTANT_TAG;


### PR DESCRIPTION
Previously done in: https://github.com/glimmerjs/glimmer-vm/pull/1481/
But for createPrimitiveRef, this PR applies the same treatment to the other ref functions as well.

This should fix the last remaining types issue in the ember-source upgrade:
```
packages/@ember/-internals/glimmer/lib/utils/curly-component-state-bucket.ts:38:5 - error TS2322: Type 'Reference<unknown>' is not assignable to type 'Reference<Component<unknown>>'.
  Type 'unknown' is not assignable to type 'Component<unknown>'.

38     this.rootRef = createConstRef(component, 'this');
       ~~~~~~~~~~~~
```