### PR TITLE
Revert "fix capture render tree fails when errors in args"

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -25,7 +25,7 @@ import {
   JitRenderDelegate,
   RenderTest,
   suite,
-  test, tracked,
+  test,
 } from '..';
 
 interface CapturedBounds {
@@ -90,7 +90,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -104,7 +104,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -113,7 +113,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'second' }, errors: {} },
+        args: { positional: [], named: { arg: 'second' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().lastChild),
@@ -127,7 +127,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -138,36 +138,19 @@ class DebugRenderTreeTest extends RenderTest {
 
   @test 'emberish curly components'() {
     this.registerComponent('Curly', 'HelloWorld', 'Hello World');
-    let error: Error|null = null;
-    class State {
-      @tracked doFail = false;
-      get getterWithError() {
-        if (!this.doFail) return;
-        error = new Error('error');
-        throw error;
-      }
-    }
-    const obj = new State();
 
     this.render(
-      `<HelloWorld @arg="first" @arg2={{this.obj.getterWithError}}/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      `<HelloWorld @arg="first"/>{{#if this.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
       {
         showSecond: false,
-        obj,
       }
     );
-
-    obj.doFail = true;
-
-    this.delegate.getCapturedRenderTree();
-
-    this.assert.ok(error !== null, 'expecting an Error');
 
     this.assertRenderTree([
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first', arg2: error }, errors: { arg2: error! } },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -175,15 +158,13 @@ class DebugRenderTreeTest extends RenderTest {
       },
     ]);
 
-    obj.doFail = false;
-
     this.rerender({ showSecond: true });
 
     this.assertRenderTree([
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first', arg2: undefined }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -192,7 +173,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'second' }, errors: {} },
+        args: { positional: [], named: { arg: 'second' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'second',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.lastChild),
@@ -206,7 +187,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first', arg2: undefined }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -229,7 +210,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -243,7 +224,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -252,7 +233,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'second' }, errors: {} },
+        args: { positional: [], named: { arg: 'second' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'second',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.lastChild),
@@ -266,7 +247,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'first',
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -326,7 +307,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld2',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -340,7 +321,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld2',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -349,7 +330,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'route-template',
         name: 'foo',
-        args: { positional: [], named: { arg: 'second' }, errors: {} },
+        args: { positional: [], named: { arg: 'second' } },
         instance: instance1,
         template: null,
         bounds: this.nodeBounds(this.element.lastChild),
@@ -357,7 +338,7 @@ class DebugRenderTreeTest extends RenderTest {
           {
             type: 'engine',
             name: 'bar',
-            args: { positional: [], named: {}, errors: {} },
+            args: { positional: [], named: {} },
             instance: instance2,
             template: null,
             bounds: this.nodeBounds(this.element.lastChild),
@@ -373,7 +354,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld2',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -406,7 +387,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld2',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
@@ -420,7 +401,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld2',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
@@ -434,7 +415,7 @@ class DebugRenderTreeTest extends RenderTest {
       {
         type: 'component',
         name: 'HelloWorld2',
-        args: { positional: [], named: { arg: 'first' }, errors: {} },
+        args: { positional: [], named: { arg: 'first' } },
         instance: null,
         template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),

--- a/packages/@glimmer/interfaces/lib/runtime/arguments.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/arguments.d.ts
@@ -60,9 +60,3 @@ export interface Arguments {
   positional: readonly unknown[];
   named: Record<string, unknown>;
 }
-
-export interface ArgumentsDebug {
-  positional: readonly unknown[];
-  named: Record<string, unknown>;
-  errors: Record<string, Error>;
-}

--- a/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
@@ -1,7 +1,7 @@
 import type { SimpleElement, SimpleNode } from '@simple-dom/interface';
 
 import type { Bounds } from '../dom/bounds';
-import type { ArgumentsDebug, CapturedArguments } from './arguments';
+import type { Arguments, CapturedArguments } from './arguments';
 
 export type RenderNodeType = 'outlet' | 'engine' | 'route-template' | 'component';
 
@@ -17,7 +17,7 @@ export interface CapturedRenderNode {
   id: string;
   type: RenderNodeType;
   name: string;
-  args: ArgumentsDebug;
+  args: Arguments;
   instance: unknown;
   template: string | null;
   bounds: null | {

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -7,7 +7,7 @@ import type {
 } from "@glimmer/interfaces";
 import { assign, expect, Stack } from '@glimmer/util';
 
-import { reifyArgsDebug } from './vm/arguments';
+import { reifyArgs } from './vm/arguments';
 
 interface InternalRenderNode<T extends object> extends RenderNode {
   bounds: Nullable<Bounds>;
@@ -181,7 +181,7 @@ export default class DebugRenderTreeImpl<TBucket extends object>
     let template = this.captureTemplate(node);
     let bounds = this.captureBounds(node);
     let children = this.captureRefs(refs);
-    return { id, type, name, args: reifyArgsDebug(args), instance, template, bounds, children };
+    return { id, type, name, args: reifyArgs(args), instance, template, bounds, children };
   }
 
   private captureTemplate({ template }: InternalRenderNode<TBucket>): Nullable<string> {

--- a/packages/@glimmer/runtime/lib/vm/arguments.ts
+++ b/packages/@glimmer/runtime/lib/vm/arguments.ts
@@ -500,48 +500,6 @@ export function reifyArgs(args: CapturedArguments) {
   };
 }
 
-export function reifyNamedDebug(named: CapturedNamedArguments) {
-  let reified = dict();
-  let errors: Record<string, Error> = dict();
-
-  for (const [key, value] of Object.entries(named)) {
-    try {
-      reified[key] = valueForRef(value);
-    } catch (e) {
-      reified[key] = e;
-      errors[key] = e as Error;
-    }
-  }
-
-  return { reified, errors };
-}
-
-export function reifyPositionalDebug(positional: CapturedPositionalArguments) {
-  let errors: Error[] = [];
-  let reified = positional.map((p) => {
-    try {
-      return valueForRef(p);
-    } catch(e) {
-      errors.push(e as Error);
-      return e;
-    }
-  });
-  return {
-    reified,
-    errors
-  }
-}
-
-export function reifyArgsDebug(args: CapturedArguments) {
-  let named = reifyNamedDebug(args.named);
-  let positional = reifyPositionalDebug(args.positional);
-  return {
-    named: named.reified,
-    positional: positional.reified,
-    errors: {...named.errors, ...positional.errors} as unknown as Record<string, Error >
-  };
-}
-
 export const EMPTY_NAMED = Object.freeze(Object.create(null)) as CapturedNamedArguments;
 export const EMPTY_POSITIONAL = EMPTY_REFERENCES as CapturedPositionalArguments;
 export const EMPTY_ARGS = createCapturedArgs(EMPTY_NAMED, EMPTY_POSITIONAL);

--- a/packages/@glimmer/vm-babel-plugins/index.ts
+++ b/packages/@glimmer/vm-babel-plugins/index.ts
@@ -21,7 +21,7 @@ export default function generateVmPlugins(
   return [
     [
       __loadPlugins
-        ?
+        ?  
           require('babel-plugin-debug-macros')
         : require.resolve('babel-plugin-debug-macros'),
       {


### PR DESCRIPTION
Reverts glimmerjs/glimmer-vm#1460

This is being reverted to help progress https://github.com/emberjs/ember.js/pull/20561 and address some design stuff around errors in args.

Sorry, @patricklx We'll do a take 3 soon!
(sorry I'm slow at the the ember.js PR! it's reeeeaaaalllly close, I promise!!)

(Also, we probably want to build this work on top of https://github.com/glimmerjs/glimmer-vm/pull/1462 )