### PR TITLE
Compile away local debug for publish

### DIFF
--- a/packages/@glimmer-workspace/build/lib/config.js
+++ b/packages/@glimmer-workspace/build/lib/config.js
@@ -354,6 +354,7 @@ export class Package {
             values: {
               'import.meta.env.DEV': 'DEBUG',
               'import.meta.env.PROD': '!DEBUG',
+              'import.meta.env.VM_LOCAL_DEV': 'false',
             },
           }),
           insert.transform((_magicString, code, _id) => {

--- a/packages/@glimmer-workspace/build/lib/import-meta.js
+++ b/packages/@glimmer-workspace/build/lib/import-meta.js
@@ -10,9 +10,13 @@ const STARBEAM_TRACE = process.env['STARBEAM_TRACE'] ?? false;
 export default createReplacePlugin(
   (id) => /\.[jt]sx?$/u.test(id),
   {
+    // Intended to be left in the build during publish
+    // currently compiled away to `@glimmer/debug`
     'import.meta.env.MODE': process.env['MODE'] ?? 'development',
     'import.meta.env.DEV': DEV ? 'true' : 'false',
     'import.meta.env.PROD': PROD ? 'true' : 'false',
+    // Not exposed at publish, compiled away
+    'import.meta.env.VM_LOCAL_DEV': DEV ? 'true' : 'false',
     'import.meta.env.STARBEAM_TRACE': STARBEAM_TRACE ? 'true' : 'false',
   },
   true

--- a/packages/@glimmer/local-debug-flags/index.ts
+++ b/packages/@glimmer/local-debug-flags/index.ts
@@ -1,4 +1,8 @@
+
+
 export const LOCAL_DEBUG: true | false =
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   import.meta.env.VM_LOCAL_DEV &&
   (() => {
     let location = typeof window !== 'undefined' && window.location;
@@ -9,6 +13,8 @@ export const LOCAL_DEBUG: true | false =
   })();
 
 export const LOCAL_SHOULD_LOG: true | false =
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   import.meta.env.VM_LOCAL_DEV &&
   (() => {
     let location = typeof window !== 'undefined' && window.location;

--- a/packages/@glimmer/local-debug-flags/index.ts
+++ b/packages/@glimmer/local-debug-flags/index.ts
@@ -1,5 +1,5 @@
 export const LOCAL_DEBUG: true | false =
-  import.meta.env.DEV &&
+  import.meta.env.VM_LOCAL_DEV &&
   (() => {
     let location = typeof window !== 'undefined' && window.location;
     if (location && /[&?]disable_local_debug/u.test(window.location.search)) {
@@ -9,7 +9,7 @@ export const LOCAL_DEBUG: true | false =
   })();
 
 export const LOCAL_SHOULD_LOG: true | false =
-  import.meta.env.DEV &&
+  import.meta.env.VM_LOCAL_DEV &&
   (() => {
     let location = typeof window !== 'undefined' && window.location;
     if (location && /[&?]enable_local_should_log/u.test(window.location.search)) {


### PR DESCRIPTION
Until our primary consumer of the VM natively supports import.meta.env and can incrementally opt in to features via that macro system, we must compile away certain things as they were before in 0.84.x and prior.
Instead of compiling away all DEV to false (which would hide a bunch of info from ember), i made a new flag 

Here is evidence of the local debug stuff being compiled away:
![image](https://github.com/glimmerjs/glimmer-vm/assets/199018/84ff5385-33ee-43a3-843f-99942218d96e)
(top: compiled, buttom: source)