### PR TITLE
[perf] avoid megamorphic case in destroyables

### DIFF
--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -27,8 +27,10 @@ let DESTROYABLE_META:
   | Map<Destroyable, DestroyableMeta<Destroyable>>
   | WeakMap<Destroyable, DestroyableMeta<Destroyable>> = new WeakMap();
 
-function push<T extends object>(collection: OneOrMany<T>, newItem: T): OneOrMany<T> {
-  if (collection === null) {
+function push<T extends object>(collection: OneOrMany<T>, newItem: T | null): OneOrMany<T> {
+  if (newItem === null) {
+    return collection;
+  } else if (collection === null) {
     return newItem;
   } else if (Array.isArray(collection)) {
     collection.push(newItem);
@@ -116,10 +118,8 @@ export function registerDestructor<T extends Destroyable>(
 
   let meta = getDestroyableMeta(destroyable);
 
-  let destructorsKey: 'eagerDestructors' | 'destructors' =
-    eager === true ? 'eagerDestructors' : 'destructors';
-
-  meta[destructorsKey] = push(meta[destructorsKey], destructor);
+  meta.eagerDestructors = push(meta.eagerDestructors, eager ? destructor : null);
+  meta.destructors = push(meta.destructors, eager ? null : destructor);
 
   return destructor;
 }


### PR DESCRIPTION
Before: 
![telegram-cloud-photo-size-2-5438145921155190802-y](https://github.com/glimmerjs/glimmer-vm/assets/1360552/58fac2aa-87ce-4f11-ac20-86a1ef1d81ce)

After:
<img width="1347" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/e5c730f3-6820-4365-a035-bff9f07a7397">


Using https://github.com/andrewiggins/v8-deopt-viewer 

```
t1:

yarn build
yarn vite

t2:
npx v8-deopt-viewer http://localhost:5173/?hidepassed
npx http-server v8-deopt-viewer
```

check `http://127.0.0.1:8080/`


```
