### PR TITLE
[perf] remove extra combine logic

### DIFF
--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -11,7 +11,6 @@ import { combine, CONSTANT_TAG, isConstTag, validateTag, valueForTag } from './v
  */
 class Tracker {
   private tags = new Set<Tag>();
-  private last: Tag | null = null;
 
   add(tag: Tag) {
     if (tag === CONSTANT_TAG) return;
@@ -21,20 +20,10 @@ class Tracker {
     if (import.meta.env.DEV) {
       unwrap(debug.markTagAsConsumed)(tag);
     }
-
-    this.last = tag;
   }
 
   combine(): Tag {
-    let { tags } = this;
-
-    if (tags.size === 0) {
-      return CONSTANT_TAG;
-    } else if (tags.size === 1) {
-      return this.last as Tag;
-    } else {
-      return combine(Array.from(this.tags));
-    }
+    return combine(Array.from(this.tags));
   }
 }
 


### PR DESCRIPTION
`combine` function already handle 0, 1 cases:

<img width="922" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/ec55a486-f014-496a-950e-e546acb2f828">

I think it's safe to remove pre-checks here


```
    Benchmark Results Summary    

duration phase estimated improvement -90ms [-173ms to -7ms] OR -0.56% [-1.08% to -0.04%]
renderEnd phase no difference [-2ms to 1ms]
render1000Items1End phase no difference [-15ms to 10ms]
clearItems1End phase no difference [-1ms to 2ms]
render1000Items2End phase estimated improvement -12ms [-18ms to -1ms] OR -1.21% [-1.73% to -0.07%]
clearItems2End phase no difference [0ms to 0ms]
render5000Items1End phase no difference [-66ms to 0ms]
clearManyItems1End phase no difference [-4ms to 1ms]
render5000Items2End phase estimated improvement -44ms [-66ms to -22ms] OR -1.08% [-1.61% to -0.52%]
clearManyItems2End phase estimated improvement -3ms [-6ms to 0ms] OR -1.32% [-2.54% to -0.14%]
render1000Items3End phase no difference [-16ms to 0ms]
append1000Items1End phase no difference [-4ms to 7ms]
append1000Items2End phase no difference [-15ms to 0ms]
updateEvery10thItem1End phase estimated improvement -1ms [-5ms to 0ms] OR -0.82% [-2.88% to -0.27%]
updateEvery10thItem2End phase no difference [-1ms to 0ms]
selectFirstRow1End phase no difference [0ms to 0ms]
selectSecondRow1End phase estimated regression +1ms [0ms to 6ms] OR +0.43% [0.06% to 4.4%]
removeFirstRow1End phase no difference [0ms to 1ms]
removeSecondRow1End phase estimated regression +14ms [7ms to 16ms] OR +5.93% [3.2% to 7.05%]
swapRows1End phase estimated improvement -3ms [-7ms to 0ms] OR -1.77% [-4.55% to -0.15%]
swapRows2End phase no difference [-1ms to 0ms]
clearItems4End phase estimated regression +4ms [1ms to 7ms] OR +3.01% [0.9% to 5.14%]
paint phase no difference [0ms to 0ms]

```

<img width="776" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/4b44b084-e6de-429e-abc5-e431cd77a70f">

[artifact-1.pdf](https://github.com/glimmerjs/glimmer-vm/files/13762844/artifact-1.pdf)




---

<details>
  <summary>Set check ideas (not actual anymore)</summary>
  
In addition, we check if item already in set, it seems 20% faster (https://jsben.ch/ti5Ts) than enforce set to override.

<img width="639" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/daca729f-511b-4265-8f6b-7c60c133a2db">

  
</details>

