### PR TITLE
fix `exports` config for @glimmer/destroyable and @glimmer/debug

### DIFF
--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -15,7 +15,9 @@
     "exports": {
       ".": {
         "types": "./dist/dev/index.d.ts",
-        "development": {}
+        "development": {
+          "import": "./dist/dev/index.js"
+        },
       }
     },
     "main": null,

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -17,7 +17,7 @@
         "types": "./dist/dev/index.d.ts",
         "development": {
           "import": "./dist/dev/index.js"
-        },
+        }
       }
     },
     "main": null,

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -13,7 +13,9 @@
     "exports": {
       ".": {
         "types": "./dist/dev/index.d.ts",
-        "development": {}
+        "development": {
+          "import": "./dist/dev/index.js"
+        },
       }
     },
     "main": null,

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -15,7 +15,7 @@
         "types": "./dist/dev/index.d.ts",
         "development": {
           "import": "./dist/dev/index.js"
-        },
+        }
       }
     },
     "main": null,


### PR DESCRIPTION
In the midst of trying to figure out how to best link up dev versions of glimmer-vm, I noticed a discrepancy in the exports configs for debug and destroyable.