### PR TITLE
[perf] replace Math.max usage with reduce and pure compare

### DIFF
--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -137,19 +137,19 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
 
         if (subtag !== null) {
           if (Array.isArray(subtag)) {
-            for (const tag of subtag) {
-              let value = tag[COMPUTE]();
-              revision = Math.max(value, revision);
-            }
+            revision = subtag.reduce((prev, currentTag: Tag) => {
+              let current = currentTag[COMPUTE]();
+              return current > prev ? current : prev;
+            }, revision);
           } else {
             let subtagValue = subtag[COMPUTE]();
 
             if (subtagValue === this.subtagBufferCache) {
-              revision = Math.max(revision, this.lastValue);
+              revision = revision > this.lastValue ? revision : this.lastValue;
             } else {
               // Clear the temporary buffer cache
               this.subtagBufferCache = null;
-              revision = Math.max(revision, subtagValue);
+              revision = revision > subtagValue ? revision : subtagValue;
             }
           }
         }


### PR DESCRIPTION
It seems reduce is 5 times faster for our case https://jsben.ch/Qosu7 
<img width="665" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/3ab23127-f097-4d4c-ae41-e4756f50a36d">

Here is V8 `Math.Max` implementation: https://github.com/v8/v8/blob/cd81dd6d740ff82a1abbc68615e8769bd467f91e/src/js/math.js#L77-L102 (old)
https://github.com/v8/v8/blob/04f51bc70a38fbea743588e41290bea40830a486/src/builtins/math.tq#L135 (new)

<img width="602" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/31180c5e-c9ba-45aa-ac6a-c87841a46f8b">

It seems it uses more code paths than we actually need:
* extra function call
* count amount of arguments
* cast first arg to number
* cast second arg to number
* compare arg1 and arg2

In our case both args already numbers and we could take 1 step instead of 5

If we assume every step is an opcode and there is no caching, for case where we have 10 tags + 10 subtags, new comparison should took 100 opcodes, and old (with `Math.max`) - 500. This numbers quite relative to numbers we see in micro-bench.

---
Likely need to check macro-bench to verify

