### PR TITLE
[perf] tags pool experiment

### DIFF
--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -137,7 +137,9 @@ export class EnvironmentImpl implements Environment {
       'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.'
     );
 
-    prepareTagsIfNeeded();
+    setTimeout(() => {
+      prepareTagsIfNeeded();
+    });
     this.debugRenderTree?.begin();
 
     this[TRANSACTION] = new TransactionImpl();

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -14,7 +14,7 @@ import type {
 } from '@glimmer/interfaces';
 import { RuntimeProgramImpl } from '@glimmer/program';
 import { assert, expect } from '@glimmer/util';
-import { track, updateTag } from '@glimmer/validator';
+import { prepareTagsIfNeeded, track, updateTag } from '@glimmer/validator';
 
 import DebugRenderTree from './debug-render-tree';
 import { DOMChangesImpl, DOMTreeConstruction } from './dom/helper';
@@ -137,6 +137,7 @@ export class EnvironmentImpl implements Environment {
       'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.'
     );
 
+    prepareTagsIfNeeded();
     this.debugRenderTree?.begin();
 
     this[TRANSACTION] = new TransactionImpl();

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -44,6 +44,7 @@ export {
   DIRTY_TAG as dirtyTag,
   INITIAL,
   isConstTag,
+  prepareTagsIfNeeded,
   type Revision,
   UPDATE_TAG as updateTag,
   validateTag,

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -6,6 +6,11 @@ import { debug } from './debug';
 import { unwrap } from './utils';
 import { combine, CONSTANT_TAG, isConstTag, validateTag, valueForTag } from './validators';
 
+const TRACKING_WARM_STACK_SIZE = 20000;
+
+function getTracker() {
+  return trackingStack.pop() ?? new Tracker();
+}
 /**
  * An object that that tracks @tracked properties that were consumed.
  */
@@ -36,7 +41,15 @@ class Tracker {
       return combine(Array.from(this.tags));
     }
   }
+  recycle() {
+    this.tags.clear();
+    trackingStack.push(this);
+  }
 }
+
+const trackingStack: Tracker[] = new Array(TRACKING_WARM_STACK_SIZE)
+  .fill(null)
+  .map(() => new Tracker());
 
 /**
  * Whenever a tracked computed property is entered, the current tracker is
@@ -58,7 +71,7 @@ const OPEN_TRACK_FRAMES: (Tracker | null)[] = [];
 export function beginTrackFrame(debuggingContext?: string | false): void {
   OPEN_TRACK_FRAMES.push(CURRENT_TRACKER);
 
-  CURRENT_TRACKER = new Tracker();
+  CURRENT_TRACKER = getTracker();
 
   if (import.meta.env.DEV) {
     unwrap(debug.beginTrackingTransaction)(debuggingContext);
@@ -78,7 +91,11 @@ export function endTrackFrame(): Tag {
 
   CURRENT_TRACKER = OPEN_TRACK_FRAMES.pop() || null;
 
-  return unwrap(current).combine();
+  try {
+    return unwrap(current).combine();
+  } finally {
+    current!.recycle();
+  }
 }
 
 export function beginUntrackFrame(): void {


### PR DESCRIPTION
This PR is create to check GC behaviour on framework benchmark if we start using tags and transactions pools.
Where transaction pool is retainable and tags pool is predefined

Idea here is:
* trying to reuse `Tracker` classes, including it's `Sets` and prepare initial pool (reusable)
* Prepare `DirtyableTag` initial  pool (not reusble)
* Prepare `UpdatableTag` initial pool (not reusable)

In abstract ember app we always need some amount of `Tracker`, `DirtyableTag` and `UpdatableTag` classes.
And it may be a case where we will see GC improvements. And will be able to ship default pool sizes or allow developers to customize it from global variable or code replace functionality or babel plugin.


