### PR TITLE
Revert some VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,6 @@
       "mode": "auto"
     }
   ],
-  "explorer.excludeGitIgnore": true,
   "files.exclude": {
     "**/.DS_Store": true,
     "**/.git": true,

--- a/glimmer-vm.code-workspace
+++ b/glimmer-vm.code-workspace
@@ -17,7 +17,7 @@
       "path": "bin"
     },
     {
-      "name": "📦 /home/wycats/Code/Ember/glimmer-vm/packages",
+      "name": "📦 packages",
       "path": "packages"
     },
     {


### PR DESCRIPTION
In this particular case, it was the setting to hide ignored files in the explorer. It is often useful to go into those folders (like `node_modules` and `dist`) when troubleshooting, working on the build, trying to patch a package, etc.

In any case, if that is the desired behavior one can always add it to their global user settings, I don't think there is something bespoke about this repo that requires this setting any more so than other workspaces.

In general, the principle is probably things like these should stay out of the committed configs and belongs to the users's settings, and there are probably other settings like that which should be backed out as well, this is just the one I happen to notice and I don't have much time to go through the rest.