### PR TITLE
[perf] batch-destroy

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/suites/initial-render.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/initial-render.ts
@@ -1034,6 +1034,39 @@ export class InitialRenderSuite extends RenderTest {
   }
 
   @test
+  'Lists could be updated'() {
+    const people = [
+      { handle: 'tomdale', name: 'Tom Dale' },
+      { handle: 'chancancode', name: 'Godfrey Chan' },
+      { handle: 'wycats', name: 'Yehuda Katz' },
+    ];
+    this.render(
+      '<div>{{#each this.people key="handle" as |p|}}<span>{{p.handle}}</span> - {{p.name}}{{/each}}</div>',
+      {
+        people,
+      }
+    );
+
+    this.assertHTML(
+      '<div><span>tomdale</span> - Tom Dale<span>chancancode</span> - Godfrey Chan<span>wycats</span> - Yehuda Katz</div>'
+    );
+
+    this.rerender({
+      people: [people[2], people[0]],
+    });
+
+    this.assertHTML('<div><span>wycats</span> - Yehuda Katz<span>tomdale</span> - Tom Dale</div>');
+
+    this.rerender({
+      people,
+    });
+
+    this.assertHTML(
+      '<div><span>tomdale</span> - Tom Dale<span>chancancode</span> - Godfrey Chan<span>wycats</span> - Yehuda Katz</div>'
+    );
+  }
+
+  @test
   'Simple helpers'() {
     this.registerHelper('testing', ([id]) => id);
     this.render('<div>{{testing this.title}}</div>', { title: 'hello' });


### PR DESCRIPTION
Main idea here is to remove unnecessary work if we need to sync rendered list with new list with `0` length (list removal case, may be found in real-life applications where we switching between categories, or filtering / searching items).

Proposed changes reduce function nesting for this case, and at least remove `2` code branches per `opcode` (list item).


### Possible improvement: (require vm updates)
if we had "list-start", "list-end" DOM marks, we could improve clear function, and instead of iterating over per-opcode bounds, we could just remove all from "list-start" node to "list-end" node 
https://github.com/glimmerjs/glimmer-vm/blob/main/packages/%40glimmer/runtime/lib/bounds.ts#L54

### UPD: looks like we could clear bounds itself.
Gives us in total `3` branches improvements per opcode.

---

Guessing here - since we don't remove `expensive` operations, such as destructors and one-to-one node list removal (instead of parent node), I would expect up to 5% in remove all case boost.