### PR TITLE
[perf]: improve list retaining logic

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -202,14 +202,6 @@ export class ListItemOpcode extends TryOpcode {
     updateRef(this.value, item.value);
     updateRef(this.memo, item.memo);
   }
-
-  shouldRemove(): boolean {
-    return !this.retained;
-  }
-
-  reset() {
-    this.retained = false;
-  }
 }
 
 export class ListBlockOpcode extends BlockOpcode {
@@ -333,7 +325,7 @@ export class ListBlockOpcode extends BlockOpcode {
       if (opcode.retained === false) {
         this.deleteItem(opcode);
       } else {
-        opcode.reset();
+        opcode.retained = false;
       }
     }
   }
@@ -345,10 +337,7 @@ export class ListBlockOpcode extends BlockOpcode {
 
     let { children } = this;
 
-    updateRef(opcode.memo, item.memo);
-    updateRef(opcode.value, item.value);
-    opcode.retained = true;
-
+    opcode.updateReferences(item);
     opcode.index = children.length;
     children.push(opcode);
   }
@@ -387,9 +376,7 @@ export class ListBlockOpcode extends BlockOpcode {
   ) {
     let { children } = this;
 
-    updateRef(opcode.memo, item.memo);
-    updateRef(opcode.value, item.value);
-    opcode.retained = true;
+    opcode.updateReferences(item);
 
     let currentSibling, nextSibling;
 


### PR DESCRIPTION
I found that:

* `shouldRemove` function is not used in list-item opcode
*  it's `reset` function called in only one place and could be replaced with simple assignment

~In addition, it seems we do non-optimal thing here: `updateRef` is called if node is retained or moved, but it not necessary require tag update, adding `valueForRef` here to update tags that actually differs.~ And scope of `updateRef` usage reduced to `updateReferences` opcode function.

This PR a-bit conflicting with https://github.com/glimmerjs/glimmer-vm/pull/1529/files, but could be easily rebased.