### PR TITLE
[chore] remove ie11 `on` fallback

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/modifiers/on-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/modifiers/on-test.ts
@@ -25,13 +25,6 @@ const hasDom =
   self.navigator === navigator &&
   typeof navigator.userAgent === 'string';
 
-// do this to get around type issues for these values
-let global = window as any;
-const isChrome = hasDom
-  ? typeof global.chrome === 'object' && !(typeof global.opera === 'object')
-  : false;
-const isFirefox = hasDom ? /Firefox|FxiOS/u.test(navigator.userAgent) : false;
-
 interface Counters {
   adds: number;
   removes: number;
@@ -39,7 +32,6 @@ interface Counters {
 
 interface OnManager {
   counters: Counters;
-  SUPPORTS_EVENT_OPTIONS: boolean;
 }
 
 function getOnManager() {
@@ -73,15 +65,6 @@ if (hasDom) {
         },
         `counters have incremented by ${JSON.stringify(expected)}`
       );
-    }
-
-    @test
-    'SUPPORTS_EVENT_OPTIONS is correct (private API usage)'(assert: Assert) {
-      let { SUPPORTS_EVENT_OPTIONS } = getOnManager();
-
-      if (isChrome || isFirefox) {
-        assert.strictEqual(SUPPORTS_EVENT_OPTIONS, true, 'is true in chrome and firefox');
-      }
     }
 
     @test


### PR DESCRIPTION

<img width="771" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/05ead02c-be13-448a-9e83-409bca5efb94">


```
    Benchmark Results Summary    

duration phase no difference [-150ms to 47ms]
renderEnd phase no difference [0ms to 3ms]
render1000Items1End phase estimated improvement -16ms [-24ms to -1ms] OR -1.34% [-2.05% to -0.06%]
clearItems1End phase no difference [-2ms to 3ms]
render1000Items2End phase estimated improvement -15ms [-19ms to -2ms] OR -1.66% [-2.02% to -0.22%]
clearItems2End phase no difference [0ms to 0ms]
render5000Items1End phase no difference [-54ms to 11ms]
clearManyItems1End phase no difference [-4ms to 0ms]
render5000Items2End phase estimated improvement -23ms [-45ms to -1ms] OR -0.6% [-1.2% to -0.03%]
clearManyItems2End phase no difference [-1ms to 2ms]
render1000Items3End phase no difference [-16ms to 0ms]
append1000Items1End phase no difference [-15ms to 0ms]
append1000Items2End phase no difference [-4ms to 2ms]
updateEvery10thItem1End phase no difference [0ms to 0ms]
updateEvery10thItem2End phase no difference [0ms to 0ms]
selectFirstRow1End phase no difference [0ms to 0ms]
selectSecondRow1End phase no difference [0ms to 0ms]
removeFirstRow1End phase no difference [-1ms to 0ms]
removeSecondRow1End phase no difference [0ms to 0ms]
swapRows1End phase no difference [-1ms to 1ms]
swapRows2End phase no difference [-1ms to 1ms]
clearItems4End phase no difference [-2ms to 3ms]
paint phase no difference [0ms to 0ms]
```

[artifact-1.pdf](https://github.com/glimmerjs/glimmer-vm/files/13762835/artifact-1.pdf)
