### PR TITLE
[chore] test prod terser config

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@release-it-plugins/workspaces": "^4.0.0",
     "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-strip": "^3.0.4",
     "@types/babel-plugin-macros": "^3.1.3",
     "@types/babel__core": "^7.20.5",
     "@types/babel__traverse": "^7.20.4",
@@ -103,8 +104,6 @@
     "eslint-plugin-unused-imports": "^3.0.0",
     "esyes": "^1.0.1",
     "execa": "^7.1.1",
-    "tracerbench": "^8.0.1",
-    "zx": "^7.2.3",
     "fast-glob": "^3.2.12",
     "glob": "^10.2.3",
     "js-yaml": "^4.1.0",
@@ -122,11 +121,13 @@
     "semver": "^7.5.2",
     "testem-failure-only-reporter": "^1.0.0",
     "toml": "^3.0.0",
+    "tracerbench": "^8.0.1",
     "ts-node": "^10.9.1",
     "turbo": "^1.9.3",
     "typescript": "^5.0.4",
     "vite": "^5.0.10",
-    "xo": "^0.54.2"
+    "xo": "^0.54.2",
+    "zx": "^7.2.3"
   },
   "release-it": {
     "plugins": {

--- a/packages/@glimmer-workspace/build/package.json
+++ b/packages/@glimmer-workspace/build/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-strip": "^3.0.4",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "eslint": "^8.52.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@release-it-plugins/workspaces':
         specifier: ^4.0.0
         version: 4.0.0(patch_hash=lhefrznz336tkf55irfqm4hld4)(release-it@16.2.1)
+      '@rollup/plugin-strip':
+        specifier: ^3.0.4
+        version: 3.0.4(rollup@4.5.1)
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.5.1)
@@ -354,6 +357,9 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.5.1)
+      '@rollup/plugin-strip':
+        specifier: ^3.0.4
+        version: 3.0.4(rollup@4.5.1)
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.5.1)
@@ -3538,6 +3544,20 @@ packages:
       rollup: 4.5.1
     dev: false
 
+  /@rollup/plugin-strip@3.0.4(rollup@4.5.1):
+    resolution: {integrity: sha512-LDRV49ZaavxUo2YoKKMQjCxzCxugu1rCPQa0lDYBOWLj6vtzBMr8DcoJjsmg+s450RbKbe3qI9ZLaSO+O1oNbg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || 3
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.5(rollup@4.5.1)
+      estree-walker: 2.0.2
+      magic-string: 0.30.5
+      rollup: 4.5.1
+
   /@rollup/plugin-terser@0.4.4(rollup@4.5.1):
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
     engines: {node: '>=14.0.0'}
@@ -3565,7 +3585,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 4.5.1
-    dev: false
 
   /@rollup/rollup-android-arm-eabi@4.5.1:
     resolution: {integrity: sha512-YaN43wTyEBaMqLDYeze+gQ4ZrW5RbTEGtT5o1GVDkhpdNcsLTnLRcLccvwy3E9wiDKWg9RIhuoy3JQKDRBfaZA==}
@@ -8467,7 +8486,6 @@ packages:
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: false
 
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}


### PR DESCRIPTION
as addition, we could remove `unwrap` and `expect` functions for prod.

https://astexplorer.net/#/gist/7d94e28a646e052ff8c6d1df72cc69d1/adcac2a89c58847b7ddd302154e41c224aa7f27f

```
     Benchmark Results Summary    

duration phase no difference [-94ms to 109ms]
renderEnd phase estimated improvement -2ms [-4ms to 0ms] OR -2.49% [-5.54% to -0.3%]
render1000Items1End phase estimated improvement -15ms [-24ms to -1ms] OR -1.18% [-1.89% to -0.05%]
clearItems1End phase no difference [-1ms to 3ms]
render1000Items2End phase no difference [-8ms to 10ms]
clearItems2End phase no difference [-1ms to 0ms]
render5000Items1End phase no difference [-9ms to 53ms]
clearManyItems1End phase estimated improvement -3ms [-6ms to 0ms] OR -1.22% [-2.45% to -0.21%]
render5000Items2End phase no difference [-36ms to 2ms]
clearManyItems2End phase no difference [-3ms to 1ms]
render1000Items3End phase no difference [-1ms to 15ms]
append1000Items1End phase no difference [-16ms to 0ms]
append1000Items2End phase no difference [-7ms to 3ms]
updateEvery10thItem1End phase no difference [0ms to 4ms]
updateEvery10thItem2End phase no difference [0ms to 1ms]
selectFirstRow1End phase no difference [0ms to 0ms]
selectSecondRow1End phase no difference [0ms to 1ms]
removeFirstRow1End phase no difference [-2ms to 1ms]
removeSecondRow1End phase no difference [-4ms to 0ms]
swapRows1End phase no difference [-3ms to 2ms]
swapRows2End phase no difference [0ms to 7ms]
clearItems4End phase no difference [-4ms to 3ms]
paint phase no difference [0ms to 0ms]
```

<img width="770" alt="image" src="https://github.com/glimmerjs/glimmer-vm/assets/1360552/b8194c11-8c06-4c31-a56d-83e760ea628e">

[artifact-1.pdf](https://github.com/glimmerjs/glimmer-vm/files/13762854/artifact-1.pdf)
