### PR TITLE
[CLEANUP] Remove unused ASTv1 nodes

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/printer.ts
+++ b/packages/@glimmer/syntax/lib/generation/printer.ts
@@ -28,7 +28,7 @@ export function getVoidTags() {
 const NON_WHITESPACE = /^\S/u;
 
 export interface PrinterOptions {
-  entityEncoding: 'transformed' | 'raw';
+  entityEncoding: ASTv1.EntityEncodingState;
 
   /**
    * Used to override the mechanism of printing a given AST.Node.

--- a/packages/@glimmer/syntax/lib/v1/nodes-v1.ts
+++ b/packages/@glimmer/syntax/lib/v1/nodes-v1.ts
@@ -1,31 +1,6 @@
-import type { Dict, Nullable, PresentArray, WireFormat } from '@glimmer/interfaces';
+import type { Nullable, PresentArray } from '@glimmer/interfaces';
 
 import type * as src from '../source/api';
-
-export interface Symbols {
-  symbols: string[];
-
-  has(name: string): boolean;
-  get(name: string): number;
-
-  getLocalsMap(): Dict<number>;
-  getDebugInfo(): WireFormat.Core.DebugInfo;
-
-  allocateFree(name: string): number;
-  allocateNamed(name: string): number;
-  allocateBlock(name: string): number;
-  allocate(identifier: string): number;
-
-  child(locals: string[]): BlockSymbols;
-}
-
-export interface BlockSymbols extends Symbols {
-  slots: number[];
-}
-
-export interface ProgramSymbols extends Symbols {
-  freeVariables: string[];
-}
 
 export interface BaseNode {
   // Every leaf interface that extends BaseNode must specify a type property.
@@ -43,7 +18,6 @@ export interface CommonProgram extends BaseNode {
 
 export interface Program extends CommonProgram {
   type: 'Program';
-  symbols?: Symbols;
 }
 
 export interface Block extends CommonProgram {
@@ -128,12 +102,6 @@ export interface CommentStatement extends BaseNode {
 export interface MustacheCommentStatement extends BaseNode {
   type: 'MustacheCommentStatement';
   value: string;
-}
-
-export interface NamedBlockName {
-  type: 'NamedBlockName';
-  name: string;
-  loc: src.SourceLocation;
 }
 
 export interface ElementName {
@@ -237,18 +205,6 @@ export interface AtHead {
 
 export interface VarHead {
   type: 'VarHead';
-  name: string;
-  loc: src.SourceLocation;
-}
-
-export interface FreeVarHead {
-  type: 'FreeVarHead';
-  name: string;
-  loc: src.SourceLocation;
-}
-
-export interface LocalVarHead {
-  type: 'LocalVarHead';
   name: string;
   loc: src.SourceLocation;
 }

--- a/packages/@glimmer/syntax/lib/v1/public-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/public-builders.ts
@@ -374,14 +374,6 @@ function buildHeadFromString(head: string, loc: SourceLocation): ASTv1.PathHead 
   }
 }
 
-function buildNamedBlockName(name: string, loc?: SourceLocation): ASTv1.NamedBlockName {
-  return {
-    type: 'NamedBlockName',
-    name,
-    loc: buildLoc(loc || null),
-  };
-}
-
 function buildCleanPath(
   head: ASTv1.PathHead,
   tail: string[],
@@ -577,7 +569,6 @@ export default {
   at: buildAtName,
   var: buildVar,
   this: buildThis,
-  blockName: buildNamedBlockName,
 
   string: literal('StringLiteral') as (value: string) => ASTv1.StringLiteral,
   boolean: literal('BooleanLiteral') as (value: boolean) => ASTv1.BooleanLiteral,


### PR DESCRIPTION
Technically this is a breaking change, but as far as I/TypeScript can tell, these don't actually do anything, so presumably no one is using them. Most of these appear to be ideas and experiments that didn't pan out, or landed in a different form (e.g. in ASTv2).