### PR TITLE
[BUGFIX] properly surface deprecation message

### DIFF
--- a/packages/@glimmer/syntax/lib/traversal/traverse.ts
+++ b/packages/@glimmer/syntax/lib/traversal/traverse.ts
@@ -1,4 +1,3 @@
-import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { deprecate, unwrap } from '@glimmer/util';
 
 import type * as ASTv1 from '../v1/api';
@@ -70,11 +69,9 @@ function getNodeHandler<N extends ASTv1.Node>(
 ): NodeTraversal<ASTv1.Node> | undefined {
   if (nodeType === 'Template' || nodeType === 'Block') {
     if (visitor.Program) {
-      if (LOCAL_DEBUG) {
-        deprecate(
-          `The 'Program' visitor node is deprecated. Use 'Template' or 'Block' instead (node was '${nodeType}') `
-        );
-      }
+      deprecate(
+        `The 'Program' visitor node is deprecated. Use 'Template' or 'Block' instead (node was '${nodeType}') `
+      );
 
       return visitor.Program as NodeTraversal<ASTv1.Node>;
     }

--- a/packages/@glimmer/syntax/lib/v1/public-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/public-builders.ts
@@ -1,5 +1,4 @@
 import type { Dict, Nullable } from '@glimmer/interfaces';
-import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { asPresentArray, assert, assign, deprecate, isPresentArray } from '@glimmer/util';
 
 import type { SourceLocation, SourcePosition } from '../source/location';
@@ -66,9 +65,7 @@ function buildBlock(
   let elseBlock: Nullable<ASTv1.Block> | undefined;
 
   if (_defaultBlock.type === 'Template') {
-    if (LOCAL_DEBUG) {
-      deprecate(`b.program is deprecated. Use b.blockItself instead.`);
-    }
+    deprecate(`b.program is deprecated. Use b.blockItself instead.`);
 
     defaultBlock = assign({}, _defaultBlock, { type: 'Block' }) as unknown as ASTv1.Block;
   } else {
@@ -76,9 +73,7 @@ function buildBlock(
   }
 
   if (_elseBlock !== undefined && _elseBlock !== null && _elseBlock.type === 'Template') {
-    if (LOCAL_DEBUG) {
-      deprecate(`b.program is deprecated. Use b.blockItself instead.`);
-    }
+    deprecate(`b.program is deprecated. Use b.blockItself instead.`);
 
     elseBlock = assign({}, _elseBlock, { type: 'Block' }) as unknown as ASTv1.Block;
   } else {


### PR DESCRIPTION
I think wrapping these in LOCAL_DEBUG ends up causing these to not actually be seen by anyone. It's also unnecessary, `deprecate` should already be pluggable/strippable in Ember, but it probably doesn't matter in this case anyway, because most of the time the compiler isn't shipped to the browser anyway and should be (???) running in dev mode by default? I hope?

Anyway if that last part isn't true and these still aren't being seen, then it would be something to fix in Ember.