### PR TITLE
Prevent use of ...attributes in invalid places

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -220,6 +220,13 @@ export abstract class HandlebarsNodeVisitors extends Parser {
     let mustache: ASTv1.MustacheStatement;
     const { escaped, loc, strip } = rawMustache;
 
+    if ('original' in rawMustache.path && rawMustache.path.original === '...attributes') {
+      throw generateSyntaxError(
+        'Cannot use ...attributes in a MustacheStatement',
+        this.source.spanFor(rawMustache.path.loc)
+      );
+    }
+
     if (isHBSLiteral(rawMustache.path)) {
       mustache = b.mustache({
         path: this.acceptNode<(typeof rawMustache.path)['type']>(rawMustache.path),

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -121,6 +121,54 @@ test('a piece of Handlebars with HTML', () => {
   );
 });
 
+test('attributes are not allowed as values', (assert) => {
+  let t = '{{...attributes}}';
+  assert.throws(
+    () => {
+      parse(t, { meta: { moduleName: 'test-module' } });
+    },
+    syntaxErrorFor(
+      'Cannot use ...attributes in a MustacheStatement',
+      '...attributes',
+      'test-module',
+      1,
+      2
+    )
+  );
+});
+
+test('attributes are not allowed as modifiers', (assert) => {
+  let t = '<div {{...attributes}}></div>';
+  assert.throws(
+    () => {
+      parse(t, { meta: { moduleName: 'test-module' } });
+    },
+    syntaxErrorFor(
+      'Cannot use ...attributes in a MustacheStatement',
+      '...attributes',
+      'test-module',
+      1,
+      7
+    )
+  );
+});
+
+test('attributes are not allowed as attribute values', (assert) => {
+  let t = '<div class={{...attributes}}></div>';
+  assert.throws(
+    () => {
+      parse(t, { meta: { moduleName: 'test-module' } });
+    },
+    syntaxErrorFor(
+      'Cannot use ...attributes in a MustacheStatement',
+      '...attributes',
+      'test-module',
+      1,
+      13
+    )
+  );
+});
+
 test('Handlebars embedded in an attribute (quoted)', () => {
   let t = 'some <div class="{{foo}}">content</div> done';
   astEqual(


### PR DESCRIPTION
This should allow us to delete some code in ember.js, as `...attributes` in `{{}}` is _always_ invalid