### PR TITLE
support modifier delegate manager in debug render tree

### DIFF
--- a/packages/@glimmer/manager/lib/public/modifier.ts
+++ b/packages/@glimmer/manager/lib/public/modifier.ts
@@ -125,8 +125,8 @@ export class CustomModifierManager<O extends Owner, ModifierInstance>
     }
   }
 
-  getDebugInstance({ modifier }: CustomModifierState<ModifierInstance>) {
-    return modifier;
+  getDebugInstance({ modifier, delegate }: CustomModifierState<ModifierInstance>) {
+    return modifier || delegate;
   }
 
   getTag({ tag }: CustomModifierState<ModifierInstance>) {


### PR DESCRIPTION
im currently trying out ember beta which has the included modifier support for inspector, but i'm not getting an instance for e.g. did-insert modifier.
 think CustomModifierManager.getDebugInstance should return the delegate