### PR TITLE
fix arrow modifiers debug name

### DIFF
--- a/packages/@glimmer/manager/lib/public/modifier.ts
+++ b/packages/@glimmer/manager/lib/public/modifier.ts
@@ -119,9 +119,9 @@ export class CustomModifierManager<O extends Owner, ModifierInstance>
 
   getDebugName(definition: object) {
     if (typeof definition === 'function') {
-      return definition.name || definition.toString();
+      return definition.name || '<unknown>';
     } else {
-      return '<unknown>';
+      return definition.toString() || '<unknown>';
     }
   }
 


### PR DESCRIPTION
currently arrow functions or functions without name as displayed with their whole implementation