### PR TITLE
Explore performance 4 - don't use development assets

### DIFF
--- a/benchmark/benchmarks/krausest/vite.config.mts
+++ b/benchmark/benchmarks/krausest/vite.config.mts
@@ -11,7 +11,7 @@ const currentPath = path.dirname(fileURLToPath(self));
 const packagesPath = path.resolve(currentPath, '..', '..', './../packages');
 
 const packagePath = (name: string) => {
-  return path.join(packagesPath, name, 'dist/prod/index.js');
+  return path.join(packagesPath, name, 'dist/dev/index.js');
 };
 
 export default defineConfig({

--- a/packages/@glimmer-workspace/build/lib/config.js
+++ b/packages/@glimmer-workspace/build/lib/config.js
@@ -262,12 +262,12 @@ export class Package {
     let builds = [];
 
     if (formats.esm ?? true) {
-      builds.push(...this.rollupESM({ env: 'dev' }));
+      // builds.push(...this.rollupESM({ env: 'dev' }));
       builds.push(...this.rollupESM({ env: 'prod' }));
     }
 
     if (formats.cjs ?? true) {
-      builds.push(...this.rollupCJS({ env: 'dev' }));
+      builds.push(...this.rollupCJS({ env: 'prod' }));
     }
 
     return builds;
@@ -418,7 +418,7 @@ export class Package {
       return {
         input: resolve(root, ts),
         output: {
-          file: resolve(root, 'dist', env, file),
+          file: resolve(root, 'dist', 'dev', file),
           format,
           sourcemap: true,
           exports: format === 'cjs' ? 'named' : 'auto',


### PR DESCRIPTION
The ember build doesn't seem to properly swap to the production build of assets when bundling Glimmer.