### PR TITLE
Use terser in dev

### DIFF
--- a/packages/@glimmer-workspace/build/lib/config.js
+++ b/packages/@glimmer-workspace/build/lib/config.js
@@ -315,7 +315,28 @@ export class Package {
         commonjs(),
         nodeResolve(),
         ...this.replacements(env),
-        ...(env === 'prod' ? [terser()] : []),
+        ...(env === 'prod'
+          ? [
+              terser({
+                module: true,
+                compress: {
+                  passes: 3,
+                },
+              }),
+            ]
+          : [
+              terser({
+                module: true,
+                mangle: false,
+                compress: {
+                  passes: 3,
+                },
+                format: {
+                  comments: 'all',
+                  beautify: true,
+                },
+              }),
+            ]),
         postcss(),
         typescript(this.#package, {
           target: ScriptTarget.ES2022,


### PR DESCRIPTION
See this other PR which has more meaningful size differences: https://github.com/glimmerjs/glimmer-vm/pull/1601

------------

There are a number of flags that are meant to be internal to glimmer-vm and _not_ exposed to ember.js.

There are also flags that are meant to be exposed to ember.js (which are swapped out with DEBUG from '@glimmer/env' during the build)


Output size (using [dust](https://github.com/bootandy/dust))

<table><thead><tr><th></th><th>Dev</th><th>Prod</th></tr></thead>
<tbody>
<tr><td>This PR</td><td>

```bash
cd packages/\@glimmer
du --ignore_hidden \
   --reverse --apparent-size \
   --filter ".+\/dist\/dev\/index.js$" \
   --no-percent-bars --only-dir --depth 1

647K └─┬ .
175K   ├── runtime
168K   ├── syntax
104K   ├── compiler
 63K   ├── opcode-compiler
 30K   ├── debug
 23K   ├── manager
 19K   ├── validator
 17K   ├── util
 13K   ├── program
8.9K   ├── reference
6.0K   ├── destroyable
4.5K   ├── vm
4.1K   ├── node
3.7K   ├── global-context
2.5K   ├── wire-format
966B   ├── encoder
844B   ├── vm-babel-plugins
502B   └── owner
```

</td><td>

```bash
cd packages/\@glimmer
du --ignore_hidden \
   --reverse --apparent-size \
   --filter ".+\/dist\/prod\/index.js$" \
   --no-percent-bars --only-dir --depth 1

301K └─┬ .
 79K   ├── runtime
 74K   ├── syntax
 50K   ├── compiler
 25K   ├── opcode-compiler
 21K   ├── debug
 11K   ├── manager
8.7K   ├── util
7.6K   ├── validator
5.9K   ├── program
4.1K   ├── reference
3.0K   ├── destroyable
2.8K   ├── vm
2.1K   ├── node
1.6K   ├── wire-format
1.4K   ├── global-context
604B   ├── encoder
469B   ├── vm-babel-plugins
155B   └── owner
```


</td></tr><tr><td>main</td><td>

```bash
cd packages/\@glimmer
du --ignore_hidden \
   --reverse --apparent-size \
   --filter ".+\/dist\/dev\/index.js$" \
   --no-percent-bars --only-dir --depth 1
   
650K └─┬ .
181K   ├── runtime
162K   ├── syntax
104K   ├── compiler
 63K   ├── opcode-compiler
 29K   ├── debug
 23K   ├── manager
 19K   ├── validator
 17K   ├── util
 13K   ├── program
9.5K   ├── reference
6.2K   ├── destroyable
5.5K   ├── global-context
5.0K   ├── vm
4.2K   ├── node
2.4K   ├── wire-format
967B   ├── encoder
870B   ├── vm-babel-plugins
497B   └── owner
```

</td><td>

```bash
cd packages/\@glimmer
du --ignore_hidden \
   --reverse --apparent-size \
   --filter ".+\/dist\/prod\/index.js$" \
   --no-percent-bars --only-dir --depth 1

301K └─┬ .
 80K   ├── runtime
 74K   ├── syntax
 50K   ├── compiler
 25K   ├── opcode-compiler
 21K   ├── debug
 11K   ├── manager
8.7K   ├── util
7.6K   ├── validator
5.9K   ├── program
4.1K   ├── reference
3.0K   ├── destroyable
2.8K   ├── vm
2.1K   ├── node
1.6K   ├── wire-format
1.4K   ├── global-context
604B   ├── encoder
469B   ├── vm-babel-plugins
155B   └── owner
```

</td></tr></tbody></table>