### PR TITLE
When generating the release plan, we don't need to run the puppeteer install -- so we can use --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: wyvox/action@v1
         with:
+          pnpm-args: '--ignore-scripts'
           node-version: 20.1.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm turbo build
@@ -37,6 +38,7 @@ jobs:
     steps:
       - uses: wyvox/action@v1
         with:
+          pnpm-args: '--ignore-scripts'
           node-version: 20.1.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm lint

--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -54,6 +54,7 @@ jobs:
           ref: 'main'
       - uses: wyvox/action-setup-pnpm@v3
         with:
+          pnpm-args: '--ignore-scripts'
           node-version: 20.1.0
 
       - name: "Generate Explanation and Prep Changelogs"


### PR DESCRIPTION
As an aside, we should look in to telling puppeteer to never download browsers, and just use the browsers bundled with the GH runners