### PR TITLE
add debug alias for let

### DIFF
--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -82,7 +82,7 @@ export function createConstRef<T>(value: T, debugLabel: false | string): Referen
   ref.tag = CONSTANT_TAG;
 
   if (import.meta.env.DEV) {
-    ref.debugLabel = debugLabel as string;
+    ref.debugLabel = debugLabel as string || String(value);
   }
 
   return ref;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -26,6 +26,7 @@ import {
   TRUE_REFERENCE,
   UNDEFINED_REFERENCE,
   valueForRef,
+  createDebugAliasRef,
 } from '@glimmer/reference';
 import { assert, assign, debugToString, decodeHandle, isObject } from '@glimmer/util';
 import { $v0, CurriedTypes, Op } from '@glimmer/vm';
@@ -170,6 +171,11 @@ APPEND_OPCODES.add(Op.GetVariable, (vm, { op1: symbol }) => {
 
 APPEND_OPCODES.add(Op.SetVariable, (vm, { op1: symbol }) => {
   let expr = check(vm.stack.pop(), CheckReference);
+  if (import.meta.env.DEV) {
+    let state = vm.fetchValue($s0);
+    let symbols = state.table.symbols;
+    expr = createDebugAliasRef(`result of let ... as | ${symbols[symbol]} |`, expr);
+  }
   vm.scope().bindSymbol(symbol, expr);
 });
 


### PR DESCRIPTION
This helps especially on cases for e.g.
When one has a let var which collides with a html element 

```hbs 
{{#let x as |b|}}
  {{b}}
  <b\>
{{/let}}
```