### PR TITLE
Plumb debug symbols when using lexical scope

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/compile.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/compile.ts
@@ -4,7 +4,7 @@ import type {
   Template,
   TemplateFactory,
 } from '@glimmer/interfaces';
-import type { PrecompileOptions } from '@glimmer/syntax';
+import type { PrecompileOptions, PrecompileOptionsWithLexicalScope } from '@glimmer/syntax';
 import { precompileJSON } from '@glimmer/compiler';
 import { templateFactory } from '@glimmer/opcode-compiler';
 
@@ -19,12 +19,16 @@ let templateId = 0;
 
 export function createTemplate(
   templateSource: Nullable<string>,
-  options: PrecompileOptions = {},
+  options: PrecompileOptions | PrecompileOptionsWithLexicalScope = {},
   scopeValues: Record<string, unknown> = {}
 ): TemplateFactory {
   options.locals = options.locals ?? Object.keys(scopeValues ?? {});
   let [block, usedLocals] = precompileJSON(templateSource, options);
   let reifiedScopeValues = usedLocals.map((key) => scopeValues[key]);
+
+  if ('emit' in options && options.emit?.debugSymbols) {
+    block.push(usedLocals);
+  }
 
   let templateBlock: SerializedTemplateWithLazyBlock = {
     id: String(templateId++),

--- a/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
@@ -5,6 +5,7 @@ import type {
   ModifierManager,
   Owner,
 } from '@glimmer/interfaces';
+import type { PrecompileOptionsWithLexicalScope } from '@glimmer/syntax';
 import { registerDestructor } from '@glimmer/destroyable';
 import {
   helperCapabilities,
@@ -99,6 +100,8 @@ export interface DefineComponentOptions {
 
   // additional strict-mode keywords
   keywords?: string[];
+
+  emit?: PrecompileOptionsWithLexicalScope['emit'];
 }
 
 export function defineComponent(
@@ -116,7 +119,7 @@ export function defineComponent(
   let keywords = options.keywords ?? [];
 
   let definition = options.definition ?? templateOnlyComponent();
-  let templateFactory = createTemplate(templateSource, { strictMode, keywords }, scopeValues ?? {});
+  let templateFactory = createTemplate(templateSource, { strictMode, keywords, emit: options.emit }, scopeValues ?? {});
   setComponentTemplate(templateFactory, definition);
   return definition;
 }

--- a/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
@@ -104,6 +104,31 @@ export interface DefineComponentOptions {
   emit?: PrecompileOptionsWithLexicalScope['emit'];
 }
 
+export function defComponent(
+  templateSource: string,
+  options?: {
+    component?: object | undefined;
+    scope?: Record<string, unknown> | undefined;
+    emit?: {
+      moduleName?: string;
+      debugSymbols?: boolean;
+    };
+  }
+) {
+  let definition = options?.component ?? templateOnlyComponent();
+  let templateFactory = createTemplate(
+    templateSource,
+    {
+      strictMode: true,
+      meta: { moduleName: options?.emit?.moduleName },
+      emit: { debugSymbols: options?.emit?.debugSymbols ?? true },
+    },
+    options?.scope ?? {}
+  );
+  setComponentTemplate(templateFactory, definition);
+  return definition;
+}
+
 export function defineComponent(
   scopeValues: Record<string, unknown> | null,
   templateSource: string,
@@ -119,7 +144,11 @@ export function defineComponent(
   let keywords = options.keywords ?? [];
 
   let definition = options.definition ?? templateOnlyComponent();
-  let templateFactory = createTemplate(templateSource, { strictMode, keywords, emit: options.emit }, scopeValues ?? {});
+  let templateFactory = createTemplate(
+    templateSource,
+    { strictMode, keywords, emit: options.emit },
+    scopeValues ?? {}
+  );
   setComponentTemplate(templateFactory, definition);
   return definition;
 }

--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -119,6 +119,10 @@ export function precompile(
 ): TemplateJavascript {
   const [block, usedLocals] = precompileJSON(source, options);
 
+  if ('emit' in options && options.emit?.debugSymbols && usedLocals.length > 0) {
+    block.push(usedLocals);
+  }
+
   const moduleName = options.meta?.moduleName;
   const idFn = options.id || defaultId;
   const blockJSON = JSON.stringify(block);

--- a/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
@@ -49,8 +49,8 @@ import type {
   YieldOpcode,
 } from './opcodes.js';
 
-export * from './opcodes.js';
-export * from './resolution.js';
+export type * from './opcodes.js';
+export type * from './resolution.js';
 
 export type TupleSyntax = Statement | TupleExpression;
 
@@ -66,7 +66,7 @@ export type ExpressionSexpOpcodeMap = {
   [TSexpOpcode in TupleExpression[0]]: Extract<TupleExpression, { 0: TSexpOpcode }>;
 };
 
-export interface SexpOpcodeMap extends ExpressionSexpOpcodeMap, StatementSexpOpcodeMap {}
+export interface SexpOpcodeMap extends ExpressionSexpOpcodeMap, StatementSexpOpcodeMap { }
 export type SexpOpcode = keyof SexpOpcodeMap;
 
 export namespace Core {
@@ -365,13 +365,14 @@ export type SerializedInlineBlock = [statements: Statements.Statement[], paramet
  */
 export type SerializedTemplateBlock = [
   // statements
-  Statements.Statement[],
+  statements: Statements.Statement[],
   // symbols
-  string[],
+  symbols: string[],
   // hasDebug
-  boolean,
+  hasDebug: boolean,
   // upvars
-  string[],
+  upvars: string[],
+  lexicalSymbols?: string[]
 ];
 
 /**

--- a/packages/@glimmer/interfaces/lib/components.d.ts
+++ b/packages/@glimmer/interfaces/lib/components.d.ts
@@ -24,6 +24,7 @@ export interface ComponentDefinition<
   manager: M;
   capabilities: CapabilityMask;
   compilable: CompilableProgram | null;
+  debugName?: string | undefined;
 }
 
 export interface ComponentInstance<

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -118,12 +118,14 @@ export interface ResolutionTimeConstants {
   component(
     definitionState: ComponentDefinitionState,
     owner: object,
-    isOptional?: false
+    isOptional?: false,
+    debugName?: string
   ): ComponentDefinition;
   component(
     definitionState: ComponentDefinitionState,
     owner: object,
-    isOptional?: boolean
+    isOptional?: boolean,
+    debugName?: string
   ): ComponentDefinition | null;
 
   resolvedComponent(

--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -96,6 +96,7 @@ export interface NamedBlocks {
 export interface ContainingMetadata {
   evalSymbols: Nullable<string[]>;
   upvars: Nullable<string[]>;
+  debugSymbols?: string[];
   scopeValues: unknown[] | null;
   isStrictMode: boolean;
   moduleName: string;

--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -96,7 +96,7 @@ export interface NamedBlocks {
 export interface ContainingMetadata {
   evalSymbols: Nullable<string[]>;
   upvars: Nullable<string[]>;
-  debugSymbols?: string[];
+  debugSymbols?: string[] | undefined;
   scopeValues: unknown[] | null;
   isStrictMode: boolean;
   moduleName: string;

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -183,12 +183,12 @@ export function resolveModifier(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetLexicalSymbol) {
-    let { scopeValues } = meta;
+    let { scopeValues, debugSymbols } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
 
-    then(constants.modifier(definition as object));
+    then(constants.modifier(definition as object, debugSymbols?.at(expr[1]) ?? undefined));
   } else if (type === SexpOpcodes.GetStrictKeyword) {
     let { upvars } = assertResolverInvariants(meta);
     let name = unwrap(upvars[expr[1]]);

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -216,7 +216,7 @@ export function resolveModifier(
       );
     }
 
-    then(constants.modifier(modifier, name));
+    then(constants.modifier(modifier));
   }
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -87,14 +87,13 @@ export function resolveComponent(
     assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
     throw new Error(
-      `Attempted to resolve a component in a strict mode template, but that value was not in scope: ${
-        meta.upvars![expr[1]] ?? '{unknown variable}'
+      `Attempted to resolve a component in a strict mode template, but that value was not in scope: ${meta.upvars![expr[1]] ?? '{unknown variable}'
       }`
     );
   }
 
   if (type === SexpOpcodes.GetLexicalSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues, owner, debugSymbols } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
@@ -102,7 +101,9 @@ export function resolveComponent(
     then(
       constants.component(
         definition as object,
-        expect(owner, 'BUG: expected owner when resolving component definition')
+        expect(owner, 'BUG: expected owner when resolving component definition'),
+        false,
+        debugSymbols?.at(expr[1])
       )
     );
   } else {
@@ -236,7 +237,7 @@ export function resolveComponentOrHelper(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetLexicalSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues, owner, debugSymbols } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
@@ -244,7 +245,8 @@ export function resolveComponentOrHelper(
     let component = constants.component(
       definition as object,
       expect(owner, 'BUG: expected owner when resolving component definition'),
-      true
+      true,
+      debugSymbols?.at(expr[1])
     );
 
     if (component !== null) {
@@ -316,7 +318,7 @@ export function resolveOptionalComponentOrHelper(
   let type = expr[0];
 
   if (type === SexpOpcodes.GetLexicalSymbol) {
-    let { scopeValues, owner } = meta;
+    let { scopeValues, owner, debugSymbols } = meta;
     let definition = expect(scopeValues, 'BUG: scopeValues must exist if template symbol is used')[
       expr[1]
     ];
@@ -333,7 +335,8 @@ export function resolveOptionalComponentOrHelper(
     let component = constants.component(
       definition,
       expect(owner, 'BUG: expected owner when resolving component definition'),
-      true
+      true,
+      debugSymbols?.at(expr[1])
     );
 
     if (component !== null) {
@@ -390,8 +393,7 @@ function lookupBuiltInHelper(
     // Keyword helper did not exist, which means that we're attempting to use a
     // value of some kind that is not in scope
     throw new Error(
-      `Attempted to resolve a ${type} in a strict mode template, but that value was not in scope: ${
-        meta.upvars![expr[1]] ?? '{unknown variable}'
+      `Attempted to resolve a ${type} in a strict mode template, but that value was not in scope: ${meta.upvars![expr[1]] ?? '{unknown variable}'
       }`
     );
   }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
@@ -106,12 +106,13 @@ export function CompilePositional(
 }
 
 export function meta(layout: LayoutWithContext): ContainingMetadata {
-  let [, symbols, , upvars] = layout.block;
+  let [, symbols, , upvars, debugSymbols] = layout.block;
 
   return {
     evalSymbols: evalSymbols(layout),
     upvars: upvars,
     scopeValues: layout.scope?.() ?? null,
+    debugSymbols,
     isStrictMode: layout.isStrictMode,
     moduleName: layout.moduleName,
     owner: layout.owner,

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -253,16 +253,16 @@ export class ConstantsImpl
       };
 
       definition.handle = this.value(definition);
+
+      if (debugName) {
+        definition.debugName = debugName;
+      }
+
       this.componentDefinitionCache.set(definitionState, definition);
       this.componentDefinitionCount++;
     }
 
-    if (definition && debugName !== undefined) {
-      return { ...definition, debugName };
-    } else {
-
     return definition;
-    }
   }
 
   resolvedComponent(

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -201,7 +201,8 @@ export class ConstantsImpl
   component(
     definitionState: ComponentDefinitionState,
     owner: object,
-    isOptional?: true
+    isOptional?: true,
+    debugName?: string
   ): ComponentDefinition | null {
     let definition = this.componentDefinitionCache.get(definitionState);
 
@@ -256,7 +257,12 @@ export class ConstantsImpl
       this.componentDefinitionCount++;
     }
 
+    if (definition && debugName !== undefined) {
+      return { ...definition, debugName };
+    } else {
+
     return definition;
+    }
   }
 
   resolvedComponent(

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -60,6 +60,7 @@ import { ConcreteBounds } from '../../bounds';
 import { hasCustomDebugRenderTreeLifecycle } from '../../component/interfaces';
 import { resolveComponent } from '../../component/resolve';
 import { isCurriedType, isCurriedValue, resolveCurriedValue } from '../../curried-value';
+import { getDebugName } from '../../debug-render-tree';
 import { APPEND_OPCODES } from '../../opcodes';
 import createClassListRef from '../../references/class-list';
 import { ARGS, CONSTANTS } from '../../symbols';
@@ -417,7 +418,7 @@ APPEND_OPCODES.add(Op.BeginComponentTransaction, (vm, { op1: _state }) => {
   if (import.meta.env.DEV) {
     let { definition, manager } = check(vm.fetchValue(_state), CheckComponentInstance);
 
-    name = definition.resolvedName ?? manager.getDebugName(definition.state);
+    name = getDebugName(definition, manager);
   }
 
   vm.beginCacheGroup(name);
@@ -674,7 +675,7 @@ APPEND_OPCODES.add(Op.GetComponentSelf, (vm, { op1: _state, op2: _names }) => {
         vm.updateWith(new DebugRenderTreeUpdateOpcode(bucket));
       });
     } else {
-      let name = definition.resolvedName ?? manager.getDebugName(definition.state);
+      let name = getDebugName(definition, manager);
 
       vm.env.debugRenderTree.create(instance, {
         type: 'component',

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -505,7 +505,7 @@ export class ComponentElementOperations implements ElementOperations {
       }
 
       let { element, constructing } = vm.elements();
-      let name = manager.getDebugName(definition.state);
+      let name = definition.resolvedName ?? manager.getDebugName(definition.state);
       let instance = manager.getDebugInstance(state);
 
       assert(constructing, `Expected a constructing element in addModifier`);

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -198,6 +198,9 @@ export default class DebugRenderTreeImpl<TBucket extends object>
   }
 }
 
-export function getDebugName(definition: ComponentDefinition, manager = definition.manager): string {
+export function getDebugName(
+  definition: ComponentDefinition,
+  manager = definition.manager
+): string {
   return definition.resolvedName ?? definition.debugName ?? manager.getDebugName(definition.state);
 }

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -1,6 +1,7 @@
 import type {
   Bounds,
   CapturedRenderNode,
+  ComponentDefinition,
   DebugRenderTree,
   Nullable,
   RenderNode,
@@ -37,7 +38,7 @@ export class Ref<T extends object> {
     this.value = null;
   }
 
-  toString(): String {
+  toString(): string {
     let label = `Ref ${this.id}`;
 
     if (this.value === null) {
@@ -195,4 +196,8 @@ export default class DebugRenderTreeImpl<TBucket extends object>
     let lastNode = bounds.lastNode();
     return { parentElement, firstNode, lastNode };
   }
+}
+
+export function getDebugName(definition: ComponentDefinition, manager = definition.manager): string {
+  return definition.resolvedName ?? definition.debugName ?? manager.getDebugName(definition.state);
 }

--- a/packages/@glimmer/runtime/lib/render.ts
+++ b/packages/@glimmer/runtime/lib/render.ts
@@ -83,7 +83,7 @@ function renderInvocation(
   // Prefix argument names with `@` symbol
   const argNames = argList.map(([name]) => `@${name}`);
 
-  let reified = vm[CONSTANTS].component(definition, owner);
+  let reified = vm[CONSTANTS].component(definition, owner, undefined, '{ROOT}');
 
   vm.pushFrame();
 

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -682,6 +682,14 @@ export interface PrecompileOptions extends PreprocessOptions {
 
 export interface PrecompileOptionsWithLexicalScope extends PrecompileOptions {
   lexicalScope: (variable: string) => boolean;
+
+  /**
+   * If `emit.debugSymbols` is set to `true`, the name of lexical local variables
+   * will be included in the wire format.
+   */
+  emit?: {
+    debugSymbols?: boolean;
+  },
 }
 
 export interface PreprocessOptions {

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -689,19 +689,23 @@ export interface PrecompileOptionsWithLexicalScope extends PrecompileOptions {
    */
   emit?: {
     debugSymbols?: boolean;
-  },
+  };
 }
 
 export interface PreprocessOptions {
-  strictMode?: boolean;
-  locals?: string[];
-  meta?: {
-    moduleName?: string;
-  };
-  plugins?: {
-    ast?: ASTPluginBuilder[];
-  };
-  parseOptions?: HandlebarsParseOptions;
+  strictMode?: boolean | undefined;
+  locals?: string[] | undefined;
+  meta?:
+    | {
+        moduleName?: string | undefined;
+      }
+    | undefined;
+  plugins?:
+    | {
+        ast?: ASTPluginBuilder[] | undefined;
+      }
+    | undefined;
+  parseOptions?: HandlebarsParseOptions | undefined;
   customizeComponentName?: ((input: string) => string) | undefined;
 
   /**
@@ -711,7 +715,7 @@ export interface PreprocessOptions {
     (to preserve as much as possible) and we also avoid any
     escaping/unescaping of HTML entity codes.
    */
-  mode?: 'codemod' | 'precompile';
+  mode?: 'codemod' | 'precompile' | undefined;
 }
 
 export interface Syntax {

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -646,7 +646,7 @@ export interface ASTPlugin {
 }
 
 export interface ASTPluginEnvironment {
-  meta?: object;
+  meta?: object | undefined;
   syntax: Syntax;
 }
 


### PR DESCRIPTION
This change introduces a new `emit.debugSymbols` option that can be used to enable debug symbols when using lexical scope.
