### PR TITLE
Improve benchmark setup, consistently rely on publishConfig

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -12,8 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  EXPERIMENT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  CONTROL_BRANCH_NAME: 'main'
   FIDELITY: 100
   THROTTLE: 4
   FORK_NAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ instrumentation.*.json
 .cache
 **/*.tgz
 tracerbench-results
+.rollup.cache

--- a/bin/published-packages.mts
+++ b/bin/published-packages.mts
@@ -1,0 +1,42 @@
+import { $ } from 'zx';
+import chalk from 'chalk';
+import { packages } from './packages.mjs';
+
+/*
+  Example JSON entry:
+
+  {
+    name: '@glimmer/validator',
+    version: '0.92.3',
+    path: '/home/ykatz/Code/Ember/glimmer-vm/packages/@glimmer/validator',
+    private: false,
+    dependencies: {
+      '@glimmer/env': [Object],
+      '@glimmer/global-context': [Object],
+      '@glimmer/interfaces': [Object],
+      '@glimmer/util': [Object]
+    },
+    devDependencies: {
+      '@glimmer-workspace/build-support': [Object],
+      '@glimmer/debug-util': [Object],
+      '@glimmer/local-debug-flags': [Object],
+      eslint: [Object],
+      publint: [Object],
+      rollup: [Object],
+      typescript: [Object]
+    }
+  }
+*/
+
+/**
+ * @typedef {} PackageEntry
+ */
+
+const entries = await packages('@glimmer');
+
+const quiet = process.argv.includes('--quiet') || process.argv.includes('-q');
+
+for (const entry of entries) {
+  console.log(entry.name);
+  if (!quiet) console.error(chalk.gray(`  ${entry.path}`));
+}

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -2,18 +2,15 @@
   "compilerOptions": {
     "composite": true,
     "skipLibCheck": true,
-
     "baseUrl": ".",
     "allowJs": true,
     "checkJs": true,
     "outDir": "../ts-dist/bin",
-
     "target": "es2020",
     "module": "esnext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "verbatimModuleSyntax": true,
-
     "strict": true,
     "suppressImplicitAnyIndexErrors": false,
     "useDefineForClassFields": false,

--- a/packages/@glimmer-workspace/benchmark-env/package.json
+++ b/packages/@glimmer-workspace/benchmark-env/package.json
@@ -3,6 +3,7 @@
   "version": "0.84.3",
   "private": true,
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer-workspace/benchmark-env",
+  "type": "module",
   "main": "index.ts",
   "scripts": {
     "test:lint": "eslint .",

--- a/packages/@glimmer-workspace/integration-tests/test/chaos-rehydration-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/chaos-rehydration-test.ts
@@ -89,11 +89,10 @@ abstract class AbstractChaosMonkeyTest extends RenderTest {
 
     let removedNodeDisplay: Nullable<string>;
     switch (nodeToRemove.nodeType) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
       case COMMENT_NODE:
         removedNodeDisplay = `<!--${nodeToRemove.nodeValue}-->`;
         break;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+
       case ELEMENT_NODE:
         removedNodeDisplay = castToBrowser(nodeToRemove, ['HTML', 'SVG']).outerHTML;
         break;

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -4,29 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/compiler",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
-  "exports": {
-    "types": "./index.ts",
-    "development": "./index.ts",
-    "import": "./dist/index.js"
-  },
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/dev/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/debug-util/package.json
+++ b/packages/@glimmer/debug-util/package.json
@@ -6,32 +6,9 @@
   "description": "Common utilities used in Glimmer with debug-specific behavior",
   "repository": "https://github.com/tildeio/glimmer/tree/main/packages/@glimmer/debug-util",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
-  "publishConfig": {
-    "access": "public",
-    "types": "dist/dev/index.d.ts",
-    "exports": {
-      ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
-        },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
-      }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
-  },
-  "files": [
-    "dist"
-  ],
+  "exports": "./index.ts",
   "scripts": {
-    "build": "rollup -c rollup.config.mjs",
     "test:lint": "eslint .",
-    "test:publint": "publint",
     "test:types": "tsc --noEmit -p ../tsconfig.json"
   },
   "dependencies": {

--- a/packages/@glimmer/debug/package.json
+++ b/packages/@glimmer/debug/package.json
@@ -7,29 +7,7 @@
   "sideEffects": false,
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/debug",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
-  "exports": {
-    "types": "./index.ts",
-    "development": "./index.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "types": "dist/dev/index.d.ts",
-    "exports": {
-      ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "import": "./dist/dev/index.js"
-        }
-      }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
-  },
-  "files": [
-    "dist"
-  ],
+  "exports": "./index.ts",
   "scripts": {
     "test:lint": "eslint .",
     "test:types": "tsc --noEmit -p ../tsconfig.json"

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -5,22 +5,29 @@
   "description": "Utilities for creating and managing a destroyable hierarchy of objects",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/destroyable",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/encoder",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/global-context",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "./dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/interfaces/package.json
+++ b/packages/@glimmer/interfaces/package.json
@@ -4,13 +4,7 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/interfaces",
   "type": "module",
-  "types": "index.d.ts",
-  "exports": {
-    "types": "./index.d.ts"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
+  "exports": "./index.d.ts",
   "files": [
     "lib",
     "index.d.ts"

--- a/packages/@glimmer/local-debug-babel-plugin/package.json
+++ b/packages/@glimmer/local-debug-babel-plugin/package.json
@@ -9,5 +9,5 @@
   },
   "type": "module",
   "private": true,
-  "main": "index.js"
+  "exports": "./index.js"
 }

--- a/packages/@glimmer/local-debug-flags/package.json
+++ b/packages/@glimmer/local-debug-flags/package.json
@@ -10,8 +10,7 @@
   },
   "type": "module",
   "private": true,
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "scripts": {
     "test:lint": "eslint .",
     "test:types": "tsc --noEmit -p ../tsconfig.json"

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/program",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/node",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/opcode-compiler",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -5,24 +5,29 @@
   "description": "Implementation for the owner in Glimmer apps",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/owner",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/program",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -9,24 +9,29 @@
     "directory": "packages/@glimmer/reference"
   },
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -5,22 +5,29 @@
   "description": "Minimal runtime needed to render Glimmer templates",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/runtime",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/syntax",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -5,24 +5,29 @@
   "description": "Common utilities used in Glimmer",
   "repository": "https://github.com/tildeio/glimmer/tree/main/packages/@glimmer/util",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -9,11 +9,12 @@
     "directory": "packages/@glimmer/validator"
   },
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": {
+    "types": "./index.ts",
+    "development": "./index.ts"
+  },
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
         "types": "./dist/dev/index.d.ts",
@@ -24,9 +25,7 @@
         "require": "./dist/dev/index.cjs",
         "import": "./dist/prod/index.js"
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/vm-babel-plugins/package.json
+++ b/packages/@glimmer/vm-babel-plugins/package.json
@@ -5,25 +5,31 @@
   "description": "Compiles out VM assertion and deprecation utilities and debug tooling based on environment",
   "repository": "https://github.com/glimmerjs/glimmer.js",
   "author": "Tom Dale <tom@tomdale.net>",
-  "type": "module",
   "private": false,
-  "main": "index.ts",
-  "types": "index.ts",
+  "type": "module",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -4,24 +4,29 @@
   "license": "MIT",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/vm",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -5,24 +5,29 @@
   "description": "",
   "repository": "https://github.com/glimmerjs/glimmer-vm/tree/main/packages/@glimmer/wire-format",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "exports": "./index.ts",
   "publishConfig": {
     "access": "public",
-    "types": "dist/dev/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/dev/index.d.ts",
-        "development": {
-          "require": "./dist/dev/index.cjs",
-          "import": "./dist/dev/index.js"
+        "require": {
+          "development": {
+            "types": "./dist/dev/index.d.cts",
+            "default": "./dist/dev/index.cjs"
+          }
         },
-        "require": "./dist/dev/index.cjs",
-        "import": "./dist/prod/index.js"
+        "default": {
+          "development": {
+            "types": "./dist/dev/index.d.ts",
+            "default": "./dist/dev/index.js"
+          },
+          "default": {
+            "types": "./dist/prod/index.d.ts",
+            "default": "./dist/prod/index.js"
+          }
+        }
       }
-    },
-    "main": null,
-    "module": "dist/dev/index.js"
+    }
   },
   "files": [
     "dist"


### PR DESCRIPTION
This PR has two related changes:

1. Clean up and document recent changes in the benchmark script. One of these changes is replacing ad-hoc rewrites of `package.json` files with a firm reliance on the `publishConfig` field, which should be reliable (since that's what we use when actually publishing).
2. Update all of the `package.json` files for published packages to have consistent `publishConfig` fields. This change also removed a bunch of historical cruft from the `package.json` files, which helped us to support environments during the ecosystem transition to package.json `exports` fields.