### PR TITLE
Remove Partial infra and rename eval -> debugger

### DIFF
--- a/bin/opcodes.json
+++ b/bin/opcodes.json
@@ -91,7 +91,7 @@
     "GetComponentSelf",
     "GetComponentTagName",
     "GetComponentLayout",
-    "SetupForEval",
+    "SetupForDebug",
     "PopulateLayout",
     "InvokeComponentLayout",
     "BeginComponentTransaction",

--- a/packages/@glimmer/constants/lib/syscall-ops.ts
+++ b/packages/@glimmer/constants/lib/syscall-ops.ts
@@ -6,8 +6,8 @@ import type {
   VmAppendText,
   VmAssertSame,
   VmBeginComponentTransaction,
+  VmBindDebuggerScope,
   VmBindDynamicScope,
-  VmBindEvalScope,
   VmCaptureArgs,
   VmChildScope,
   VmCloseElement,
@@ -86,7 +86,7 @@ import type {
   VmSetBlock,
   VmSetBlocks,
   VmSetNamedVariables,
-  VmSetupForEval,
+  VmSetupForDebugger,
   VmSetVariable,
   VmSize,
   VmSpreadBlock,
@@ -174,8 +174,8 @@ export const VM_PUT_COMPONENT_OPERATIONS_OP = 89 satisfies VmPutComponentOperati
 export const VM_GET_COMPONENT_SELF_OP = 90 satisfies VmGetComponentSelf;
 export const VM_GET_COMPONENT_TAG_NAME_OP = 91 satisfies VmGetComponentTagName;
 export const VM_GET_COMPONENT_LAYOUT_OP = 92 satisfies VmGetComponentLayout;
-export const VM_BIND_EVAL_SCOPE_OP = 93 satisfies VmBindEvalScope;
-export const VM_SETUP_FOR_EVAL_OP = 94 satisfies VmSetupForEval;
+export const VM_BIND_DEBUGGER_SCOPE_OP = 93 satisfies VmBindDebuggerScope;
+export const VM_SETUP_FOR_DEBUGGER_OP = 94 satisfies VmSetupForDebugger;
 export const VM_POPULATE_LAYOUT_OP = 95 satisfies VmPopulateLayout;
 export const VM_INVOKE_COMPONENT_LAYOUT_OP = 96 satisfies VmInvokeComponentLayout;
 export const VM_BEGIN_COMPONENT_TRANSACTION_OP = 97 satisfies VmBeginComponentTransaction;

--- a/packages/@glimmer/debug/lib/opcode-metadata.ts
+++ b/packages/@glimmer/debug/lib/opcode-metadata.ts
@@ -9,8 +9,8 @@ import {
   VM_APPEND_TEXT_OP,
   VM_ASSERT_SAME_OP,
   VM_BEGIN_COMPONENT_TRANSACTION_OP,
+  VM_BIND_DEBUGGER_SCOPE_OP,
   VM_BIND_DYNAMIC_SCOPE_OP,
-  VM_BIND_EVAL_SCOPE_OP,
   VM_CAPTURE_ARGS_OP,
   VM_CHILD_SCOPE_OP,
   VM_CLOSE_ELEMENT_OP,
@@ -93,7 +93,7 @@ import {
   VM_SET_BLOCKS_OP,
   VM_SET_NAMED_VARIABLES_OP,
   VM_SET_VARIABLE_OP,
-  VM_SETUP_FOR_EVAL_OP,
+  VM_SETUP_FOR_DEBUGGER_OP,
   VM_SPREAD_BLOCK_OP,
   VM_STATIC_ATTR_OP,
   VM_SYSCALL_SIZE,
@@ -1293,9 +1293,9 @@ if (LOCAL_DEBUG) {
     check: true,
   };
 
-  METADATA[VM_BIND_EVAL_SCOPE_OP] = {
-    name: 'BindEvalScope',
-    mnemonic: 'eval_scope',
+  METADATA[VM_BIND_DEBUGGER_SCOPE_OP] = {
+    name: 'BindDebuggerScope',
+    mnemonic: 'debugger_scope',
     before: null,
     stackChange: 0,
     ops: [
@@ -1308,9 +1308,9 @@ if (LOCAL_DEBUG) {
     check: true,
   };
 
-  METADATA[VM_SETUP_FOR_EVAL_OP] = {
-    name: 'SetupForEval',
-    mnemonic: 'eval_setup',
+  METADATA[VM_SETUP_FOR_DEBUGGER_OP] = {
+    name: 'SetupForDebugger',
+    mnemonic: 'debugger_setup',
     before: null,
     stackChange: 0,
     ops: [

--- a/packages/@glimmer/interfaces/lib/runtime/scope.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/scope.d.ts
@@ -18,19 +18,13 @@ export interface Scope {
   getSelf(): Reference;
   getSymbol(symbol: number): Reference;
   getBlock(symbol: number): Nullable<ScopeBlock>;
-  getEvalScope(): Nullable<Dict<ScopeSlot>>;
-  getPartialMap(): Nullable<Dict<Reference>>;
+  getDebuggerScope(): Nullable<Dict<ScopeSlot>>;
   bind(symbol: number, value: ScopeSlot): void;
   bindSelf(self: Reference): void;
   bindSymbol(symbol: number, value: Reference): void;
   bindBlock(symbol: number, value: Nullable<ScopeBlock>): void;
-  bindEvalScope(map: Nullable<Dict<ScopeSlot>>): void;
-  bindPartialMap(map: Dict<Reference>): void;
+  bindDebuggerScope(map: Nullable<Dict<ScopeSlot>>): void;
   child(): Scope;
-}
-
-export interface PartialScope extends Scope {
-  bindEvalScope(scope: Nullable<Dict<ScopeSlot>>): void;
 }
 
 export interface DynamicScope {

--- a/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
+++ b/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
@@ -96,8 +96,8 @@ export type VmPutComponentOperations = 89;
 export type VmGetComponentSelf = 90;
 export type VmGetComponentTagName = 91;
 export type VmGetComponentLayout = 92;
-export type VmBindEvalScope = 93;
-export type VmSetupForEval = 94;
+export type VmBindDebuggerScope = 93;
+export type VmSetupForDebugger = 94;
 export type VmPopulateLayout = 95;
 export type VmInvokeComponentLayout = 96;
 export type VmBeginComponentTransaction = 97;
@@ -193,8 +193,8 @@ export type VmOp =
   | VmGetComponentSelf
   | VmGetComponentTagName
   | VmGetComponentLayout
-  | VmBindEvalScope
-  | VmSetupForEval
+  | VmBindDebuggerScope
+  | VmSetupForDebugger
   | VmPopulateLayout
   | VmInvokeComponentLayout
   | VmBeginComponentTransaction

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
@@ -51,7 +51,7 @@ import {
   VM_SET_BLOCKS_OP,
   VM_SET_NAMED_VARIABLES_OP,
   VM_SET_VARIABLE_OP,
-  VM_SETUP_FOR_EVAL_OP,
+  VM_SETUP_FOR_DEBUGGER_OP,
   VM_VIRTUAL_ROOT_SCOPE_OP,
 } from '@glimmer/constants';
 import { unwrap } from '@glimmer/debug-util';
@@ -463,7 +463,7 @@ export function invokePreparedComponent(
 
   op(VM_VIRTUAL_ROOT_SCOPE_OP, $s0);
   op(VM_SET_VARIABLE_OP, 0);
-  op(VM_SETUP_FOR_EVAL_OP, $s0);
+  op(VM_SETUP_FOR_DEBUGGER_OP, $s0);
 
   if (bindableAtNames) op(VM_SET_NAMED_VARIABLES_OP, $s0);
   if (bindableBlocks) op(VM_SET_BLOCKS_OP, $s0);

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -39,7 +39,7 @@ export { hash } from './lib/helpers/hash';
 export { invokeHelper } from './lib/helpers/invoke';
 export { on } from './lib/modifiers/on';
 export { renderComponent, renderMain, renderSync } from './lib/render';
-export { DynamicScopeImpl, PartialScopeImpl } from './lib/scope';
+export { DynamicScopeImpl, ScopeImpl } from './lib/scope';
 export type { SafeString } from './lib/upsert';
 export { UpdatingVM, type VM } from './lib/vm';
 export {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/-debug-strip.ts
@@ -36,7 +36,7 @@ import {
 import { REFERENCE, UNDEFINED_REFERENCE } from '@glimmer/reference';
 import { COMPUTE } from '@glimmer/validator';
 
-import { PartialScopeImpl } from '../../scope';
+import { ScopeImpl } from '../../scope';
 import { VMArgumentsImpl } from '../../vm/arguments';
 import { ComponentElementOperations } from './component';
 
@@ -92,7 +92,7 @@ export const CheckCapturedArguments: Checker<CapturedArguments> = CheckInterface
   named: wrap(() => CheckDict(CheckReference)),
 });
 
-export const CheckScope: Checker<Scope> = wrap(() => CheckInstanceof(PartialScopeImpl));
+export const CheckScope: Checker<Scope> = wrap(() => CheckInstanceof(ScopeImpl));
 
 export const CheckComponentManager: Checker<InternalComponentManager<unknown>> = CheckInterface({
   getCapabilities: CheckFunction,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -50,7 +50,7 @@ import {
   VM_RESOLVE_DYNAMIC_COMPONENT_OP,
   VM_SET_BLOCKS_OP,
   VM_SET_NAMED_VARIABLES_OP,
-  VM_SETUP_FOR_EVAL_OP,
+  VM_SETUP_FOR_DEBUGGER_OP,
   VM_STATIC_COMPONENT_ATTR_OP,
   VM_VIRTUAL_ROOT_SCOPE_OP,
 } from '@glimmer/constants';
@@ -838,12 +838,12 @@ APPEND_OPCODES.add(VM_VIRTUAL_ROOT_SCOPE_OP, (vm, { op1: register }) => {
   vm.pushRootScope(table.symbols.length + 1, owner);
 });
 
-APPEND_OPCODES.add(VM_SETUP_FOR_EVAL_OP, (vm, { op1: register }) => {
+APPEND_OPCODES.add(VM_SETUP_FOR_DEBUGGER_OP, (vm, { op1: register }) => {
   let state = check(vm.fetchValue(check(register, CheckRegister)), CheckFinishedComponentInstance);
 
   if (state.table.hasEval) {
     let lookup = (state.lookup = dict<ScopeSlot>());
-    vm.scope().bindEvalScope(lookup);
+    vm.scope().bindDebuggerScope(lookup);
   }
 });
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -53,15 +53,15 @@ class ScopeInspector {
     let parts = path.split('.');
     let [head, ...tail] = path.split('.') as [string, ...string[]];
 
-    let evalScope = scope.getEvalScope()!;
+    let debuggerScope = scope.getDebuggerScope()!;
     let ref: Reference;
 
     if (head === 'this') {
       ref = scope.getSelf();
     } else if (locals[head]) {
       ref = unwrap(locals[head]);
-    } else if (head.indexOf('@') === 0 && evalScope[head]) {
-      ref = evalScope[head] as Reference;
+    } else if (head.indexOf('@') === 0 && debuggerScope[head]) {
+      ref = debuggerScope[head] as Reference;
     } else {
       ref = this.scope.getSelf();
       tail = parts;

--- a/packages/@glimmer/runtime/lib/scope.ts
+++ b/packages/@glimmer/runtime/lib/scope.ts
@@ -3,7 +3,6 @@ import type {
   DynamicScope,
   Nullable,
   Owner,
-  PartialScope,
   Scope,
   ScopeBlock,
   ScopeSlot,
@@ -42,17 +41,17 @@ export function isScopeReference(s: ScopeSlot): s is Reference {
   return true;
 }
 
-export class PartialScopeImpl implements PartialScope {
-  static root(self: Reference<unknown>, size = 0, owner: Owner): PartialScope {
+export class ScopeImpl implements Scope {
+  static root(self: Reference<unknown>, size = 0, owner: Owner): Scope {
     let refs: Reference<unknown>[] = new Array(size + 1).fill(UNDEFINED_REFERENCE);
 
-    return new PartialScopeImpl(refs, owner, null, null, null).init({ self });
+    return new ScopeImpl(refs, owner, null, null).init({ self });
   }
 
   static sized(size = 0, owner: Owner): Scope {
     let refs: Reference<unknown>[] = new Array(size + 1).fill(UNDEFINED_REFERENCE);
 
-    return new PartialScopeImpl(refs, owner, null, null, null);
+    return new ScopeImpl(refs, owner, null, null);
   }
 
   constructor(
@@ -60,10 +59,8 @@ export class PartialScopeImpl implements PartialScope {
     readonly slots: Array<ScopeSlot>,
     readonly owner: Owner,
     private callerScope: Scope | null,
-    // named arguments and blocks passed to a layout that uses eval
-    private evalScope: Dict<ScopeSlot> | null,
-    // locals in scope when the partial was invoked
-    private partialMap: Dict<Reference<unknown>> | null
+    // named arguments and blocks passed to a layout that uses debugger
+    private debuggerScope: Dict<ScopeSlot> | null
   ) {}
 
   init({ self }: { self: Reference<unknown> }): this {
@@ -84,12 +81,8 @@ export class PartialScopeImpl implements PartialScope {
     return block === UNDEFINED_REFERENCE ? null : (block as ScopeBlock);
   }
 
-  getEvalScope(): Nullable<Dict<ScopeSlot>> {
-    return this.evalScope;
-  }
-
-  getPartialMap(): Nullable<Dict<Reference<unknown>>> {
-    return this.partialMap;
+  getDebuggerScope(): Nullable<Dict<ScopeSlot>> {
+    return this.debuggerScope;
   }
 
   bind(symbol: number, value: ScopeSlot) {
@@ -108,12 +101,8 @@ export class PartialScopeImpl implements PartialScope {
     this.set<Nullable<ScopeBlock>>(symbol, value);
   }
 
-  bindEvalScope(map: Nullable<Dict<ScopeSlot>>) {
-    this.evalScope = map;
-  }
-
-  bindPartialMap(map: Dict<Reference<unknown>>) {
-    this.partialMap = map;
+  bindDebuggerScope(map: Nullable<Dict<ScopeSlot>>) {
+    this.debuggerScope = map;
   }
 
   bindCallerScope(scope: Nullable<Scope>): void {
@@ -125,13 +114,7 @@ export class PartialScopeImpl implements PartialScope {
   }
 
   child(): Scope {
-    return new PartialScopeImpl(
-      this.slots.slice(),
-      this.owner,
-      this.callerScope,
-      this.evalScope,
-      this.partialMap
-    );
+    return new ScopeImpl(this.slots.slice(), this.owner, this.callerScope, this.debuggerScope);
   }
 
   private get<T extends ScopeSlot>(index: number): T {

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -8,7 +8,6 @@ import type {
   JitConstants,
   Nullable,
   Owner,
-  PartialScope,
   RenderResult,
   RichIteratorResult,
   RuntimeContext,
@@ -53,7 +52,7 @@ import {
   JumpIfNotModifiedOpcode,
 } from '../compiled/opcodes/vm';
 import { APPEND_OPCODES } from '../opcodes';
-import { PartialScopeImpl } from '../scope';
+import { ScopeImpl } from '../scope';
 import { VMArgumentsImpl } from './arguments';
 import { LowLevelVM } from './low-level';
 import RenderResultImpl from './render-result';
@@ -240,7 +239,7 @@ export class VM implements PublicVM {
     context: CompileTimeCompilationContext,
     { handle, self, dynamicScope, treeBuilder, numSymbols, owner }: InitOptions
   ) {
-    let scope = PartialScopeImpl.root(self, numSymbols, owner);
+    let scope = ScopeImpl.root(self, numSymbols, owner);
     let state = vmState(runtime.program.heap.getaddr(handle), scope, dynamicScope);
     let vm = initVM(context)(runtime, state, treeBuilder);
     vm.pushUpdating();
@@ -256,7 +255,7 @@ export class VM implements PublicVM {
       runtime,
       vmState(
         runtime.program.heap.getaddr(handle),
-        PartialScopeImpl.root(UNDEFINED_REFERENCE, 0, owner),
+        ScopeImpl.root(UNDEFINED_REFERENCE, 0, owner),
         dynamicScope
       ),
       treeBuilder
@@ -437,8 +436,8 @@ export class VM implements PublicVM {
     return child;
   }
 
-  pushRootScope(size: number, owner: Owner): PartialScope {
-    let scope = PartialScopeImpl.sized(size, owner);
+  pushRootScope(size: number, owner: Owner): Scope {
+    let scope = ScopeImpl.sized(size, owner);
     this.#stacks.scope.push(scope);
     return scope;
   }

--- a/packages/@glimmer/vm/lib/opcodes.toml
+++ b/packages/@glimmer/vm/lib/opcodes.toml
@@ -666,15 +666,15 @@ format = ["GetComponentLayout", "state:register"]
 operand-stack = [[], ["ProgramSymbolTable", "handle"]]
 operation = "Get the component layout from the manager."
 
-[syscall.eval_scope]
+[syscall.debugger_scope]
 
-format = ["BindEvalScope", "state:register"]
-operation = "Populate the eval lookup if necessary."
+format = ["BindDebuggerScope", "state:register"]
+operation = "Populate the debugger lookup if necessary."
 
-[syscall.eval_setup]
+[syscall.debugger_setup]
 
-format = ["SetupForEval", "state:register"]
-operation = "Setup for eval"
+format = ["SetupForDebugger", "state:register"]
+operation = "Setup for debugger"
 
 [syscall.comp_layoutput]
 


### PR DESCRIPTION
This PR removes leftover infrastructure from the old "partial" system and renames all uses of "eval" (which referred to partials + debugger) to `debugger`. This properly reflects the current use-case and clarifies the internals.