### PR TITLE
Move curried types to constants

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/modes/jit/register.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/modes/jit/register.ts
@@ -6,6 +6,7 @@ import type {
   TemplateFactory,
 } from '@glimmer/interfaces';
 import type { CurriedValue } from '@glimmer/runtime';
+import { CURRIED_COMPONENT } from '@glimmer/constants';
 import {
   getInternalComponentManager,
   setComponentTemplate,
@@ -13,7 +14,6 @@ import {
   setInternalModifierManager,
 } from '@glimmer/manager';
 import { curry, templateOnlyComponent } from '@glimmer/runtime';
-import { CurriedTypes } from '@glimmer/vm';
 
 import type { ComponentKind, ComponentTypes } from '../../components';
 import type { UserHelper } from '../../helpers';
@@ -168,11 +168,5 @@ export function componentHelper(
 
   if (definition === null) return null;
 
-  return curry(
-    CurriedTypes.Component,
-    constants.resolvedComponent(definition, name),
-    {},
-    null,
-    true
-  );
+  return curry(CURRIED_COMPONENT, constants.resolvedComponent(definition, name), {}, null, true);
 }

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
@@ -1,5 +1,5 @@
+import { CURRIED_COMPONENT, CURRIED_HELPER } from '@glimmer/constants';
 import { ASTv2, generateSyntaxError, src } from '@glimmer/syntax';
-import { CurriedTypes } from '@glimmer/vm';
 
 import type { NormalizationState } from '../context';
 
@@ -103,7 +103,7 @@ export const APPEND_KEYWORDS = keywords('Append')
     },
   })
   .kw('component', {
-    assert: assertCurryKeyword(CurriedTypes.Component),
+    assert: assertCurryKeyword(CURRIED_COMPONENT),
 
     translate(
       { node, state }: { node: ASTv2.AppendContent; state: NormalizationState },
@@ -124,7 +124,7 @@ export const APPEND_KEYWORDS = keywords('Append')
     },
   })
   .kw('helper', {
-    assert: assertCurryKeyword(CurriedTypes.Helper),
+    assert: assertCurryKeyword(CURRIED_HELPER),
 
     translate(
       { node, state }: { node: ASTv2.AppendContent; state: NormalizationState },

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
@@ -1,6 +1,6 @@
 import type { ASTv2 } from '@glimmer/syntax';
+import { CURRIED_COMPONENT } from '@glimmer/constants';
 import { generateSyntaxError } from '@glimmer/syntax';
-import { CurriedTypes } from '@glimmer/vm';
 
 import type { NormalizationState } from '../context';
 
@@ -362,7 +362,7 @@ export const BLOCK_KEYWORDS = keywords('Block')
     },
   })
   .kw('component', {
-    assert: assertCurryKeyword(CurriedTypes.Component),
+    assert: assertCurryKeyword(CURRIED_COMPONENT),
 
     translate(
       { node, state }: { node: ASTv2.InvokeBlock; state: NormalizationState },

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/call.ts
@@ -1,4 +1,4 @@
-import { CurriedTypes } from '@glimmer/vm';
+import { CURRIED_COMPONENT, CURRIED_HELPER, CURRIED_MODIFIER } from '@glimmer/constants';
 
 import { keywords } from './impl';
 import { curryKeyword } from './utils/curry';
@@ -14,6 +14,6 @@ export const CALL_KEYWORDS = keywords('Call')
   .kw('log', logKeyword)
   .kw('if', ifUnlessInlineKeyword('if'))
   .kw('unless', ifUnlessInlineKeyword('unless'))
-  .kw('component', curryKeyword(CurriedTypes.Component))
-  .kw('helper', curryKeyword(CurriedTypes.Helper))
-  .kw('modifier', curryKeyword(CurriedTypes.Modifier));
+  .kw('component', curryKeyword(CURRIED_COMPONENT))
+  .kw('helper', curryKeyword(CURRIED_HELPER))
+  .kw('modifier', curryKeyword(CURRIED_MODIFIER));

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/curry.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/utils/curry.ts
@@ -1,6 +1,6 @@
 import type { CurriedType } from '@glimmer/interfaces';
+import { CURRIED_COMPONENT, CURRIED_HELPER, CURRIED_MODIFIER } from '@glimmer/constants';
 import { ASTv2, generateSyntaxError } from '@glimmer/syntax';
-import { CurriedTypes } from '@glimmer/vm';
 
 import type { NormalizationState } from '../../context';
 import type { KeywordDelegate } from '../impl';
@@ -10,9 +10,9 @@ import * as mir from '../../../2-encoding/mir';
 import { VISIT_EXPRS } from '../../visitors/expressions';
 
 const CurriedTypeToReadableType = {
-  [CurriedTypes.Component]: 'component',
-  [CurriedTypes.Helper]: 'helper',
-  [CurriedTypes.Modifier]: 'modifier',
+  [CURRIED_COMPONENT]: 'component',
+  [CURRIED_HELPER]: 'helper',
+  [CURRIED_MODIFIER]: 'modifier',
 } as const;
 
 export function assertCurryKeyword(curriedType: CurriedType) {
@@ -24,7 +24,7 @@ export function assertCurryKeyword(curriedType: CurriedType) {
     args: ASTv2.Args;
   }> => {
     let readableType = CurriedTypeToReadableType[curriedType];
-    let stringsAllowed = curriedType === CurriedTypes.Component;
+    let stringsAllowed = curriedType === CURRIED_COMPONENT;
 
     let { args } = node;
 

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/strict-mode.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/strict-mode.ts
@@ -1,6 +1,6 @@
 import type { HasSourceSpan } from '@glimmer/syntax';
+import { CURRIED_COMPONENT, CURRIED_HELPER } from '@glimmer/constants';
 import { generateSyntaxError, loc } from '@glimmer/syntax';
-import { CurriedTypes } from '@glimmer/vm';
 
 import type { Result } from '../../../shared/result';
 import type * as mir from '../../2-encoding/mir';
@@ -363,9 +363,9 @@ export default class StrictModeValidationPass {
   Curry(expression: mir.Curry): Result<null> {
     let resolution: ResolutionType;
 
-    if (expression.curriedType === CurriedTypes.Component) {
+    if (expression.curriedType === CURRIED_COMPONENT) {
       resolution = COMPONENT_RESOLUTION;
-    } else if (expression.curriedType === CurriedTypes.Helper) {
+    } else if (expression.curriedType === CURRIED_HELPER) {
       resolution = HELPER_RESOLUTION;
     } else {
       resolution = MODIFIER_RESOLUTION;

--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -5,9 +5,9 @@ import type {
   SerializedTemplateBlock,
   WireFormat,
 } from '@glimmer/interfaces';
+import { CURRIED_COMPONENT, CURRIED_HELPER, CURRIED_MODIFIER } from '@glimmer/constants';
 import { exhausted } from '@glimmer/debug-util';
 import { dict } from '@glimmer/util';
-import { CurriedTypes } from '@glimmer/vm';
 import { SexpOpcodes as Op } from '@glimmer/wire-format';
 
 import { inflateAttrName, inflateTagName } from './utils';
@@ -248,11 +248,11 @@ export default class WireFormatDebugger {
 
   private formatCurryType(value: CurriedType) {
     switch (value) {
-      case CurriedTypes.Component:
+      case CURRIED_COMPONENT:
         return 'component';
-      case CurriedTypes.Helper:
+      case CURRIED_HELPER:
         return 'helper';
-      case CurriedTypes.Modifier:
+      case CURRIED_MODIFIER:
         return 'modifier';
       default:
         throw exhausted(value);

--- a/packages/@glimmer/constants/index.ts
+++ b/packages/@glimmer/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/builder-constants';
+export * from './lib/curried';
 export * from './lib/dom';
 export * from './lib/immediate';
 export * from './lib/syscall-ops';

--- a/packages/@glimmer/constants/lib/curried.ts
+++ b/packages/@glimmer/constants/lib/curried.ts
@@ -1,0 +1,5 @@
+import type { CurriedComponent, CurriedHelper, CurriedModifier } from '@glimmer/interfaces';
+
+export const CURRIED_COMPONENT = 0 satisfies CurriedComponent;
+export const CURRIED_HELPER = 1 satisfies CurriedHelper;
+export const CURRIED_MODIFIER = 2 satisfies CurriedModifier;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -26,6 +26,7 @@ import type {
 } from '@glimmer/interfaces';
 import type { Reference } from '@glimmer/reference';
 import {
+  CURRIED_COMPONENT,
   VM_BEGIN_COMPONENT_TRANSACTION_OP,
   VM_CAPTURE_ARGS_OP,
   VM_COMMIT_COMPONENT_TRANSACTION_OP,
@@ -70,7 +71,7 @@ import { registerDestructor } from '@glimmer/destroyable';
 import { managerHasCapability } from '@glimmer/manager';
 import { isConstRef, valueForRef } from '@glimmer/reference';
 import { assign, dict, EMPTY_STRING_ARRAY, enumerate } from '@glimmer/util';
-import { $t0, $t1, CurriedTypes, InternalComponentCapabilities } from '@glimmer/vm';
+import { $t0, $t1, InternalComponentCapabilities } from '@glimmer/vm';
 
 import type { CurriedValue } from '../../curried-value';
 import type { UpdatingVM } from '../../vm';
@@ -270,7 +271,7 @@ APPEND_OPCODES.add(VM_PREPARE_ARGS_OP, (vm, { op1: register }) => {
 
   let { definition } = instance;
 
-  if (isCurriedType(definition, CurriedTypes.Component)) {
+  if (isCurriedType(definition, CURRIED_COMPONENT)) {
     assert(
       !definition.manager,
       "If the component definition was curried, we don't yet have a manager"

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -1,4 +1,6 @@
 import {
+  CURRIED_COMPONENT,
+  CURRIED_HELPER,
   VM_APPEND_DOCUMENT_FRAGMENT_OP,
   VM_APPEND_HTML_OP,
   VM_APPEND_NODE_OP,
@@ -17,7 +19,7 @@ import {
 import { hasInternalComponentManager, hasInternalHelperManager } from '@glimmer/manager';
 import { isConstRef, valueForRef } from '@glimmer/reference';
 import { isObject } from '@glimmer/util';
-import { ContentType, CurriedType } from '@glimmer/vm';
+import { ContentType } from '@glimmer/vm';
 
 import { isCurriedType } from '../../curried-value';
 import { isEmpty, isFragment, isNode, isSafeString, shouldCoerce } from '../../dom/normalize';
@@ -30,14 +32,11 @@ function toContentType(value: unknown) {
   if (shouldCoerce(value)) {
     return ContentType.String;
   } else if (
-    isCurriedType(value, CurriedType.Component) ||
+    isCurriedType(value, CURRIED_COMPONENT) ||
     hasInternalComponentManager(value as object)
   ) {
     return ContentType.Component;
-  } else if (
-    isCurriedType(value, CurriedType.Helper) ||
-    hasInternalHelperManager(value as object)
-  ) {
+  } else if (isCurriedType(value, CURRIED_HELPER) || hasInternalHelperManager(value as object)) {
     return ContentType.Helper;
   } else if (isSafeString(value)) {
     return ContentType.SafeString;
@@ -55,12 +54,12 @@ function toDynamicContentType(value: unknown) {
     return ContentType.String;
   }
 
-  if (isCurriedType(value, CurriedType.Component) || hasInternalComponentManager(value)) {
+  if (isCurriedType(value, CURRIED_COMPONENT) || hasInternalComponentManager(value)) {
     return ContentType.Component;
   } else {
     if (
       import.meta.env.DEV &&
-      !isCurriedType(value, CurriedType.Helper) &&
+      !isCurriedType(value, CURRIED_HELPER) &&
       !hasInternalHelperManager(value)
     ) {
       throw new Error(

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -12,6 +12,7 @@ import type {
 import type { Reference } from '@glimmer/reference';
 import type { Revision, Tag } from '@glimmer/validator';
 import {
+  CURRIED_MODIFIER,
   VM_CLOSE_ELEMENT_OP,
   VM_COMMENT_OP,
   VM_DYNAMIC_ATTR_OP,
@@ -39,7 +40,7 @@ import { getInternalModifierManager } from '@glimmer/manager';
 import { createComputeRef, isConstRef, valueForRef } from '@glimmer/reference';
 import { isObject } from '@glimmer/util';
 import { consumeTag, CURRENT_TAG, validateTag, valueForTag } from '@glimmer/validator';
-import { $t0, CurriedTypes } from '@glimmer/vm';
+import { $t0 } from '@glimmer/vm';
 
 import type { CurriedValue } from '../../curried-value';
 import type { DynamicAttribute } from '../../vm/attributes/dynamic';
@@ -210,7 +211,7 @@ APPEND_OPCODES.add(VM_DYNAMIC_MODIFIER_OP, (vm) => {
 
     let hostDefinition: CurriedValue | ModifierDefinitionState;
 
-    if (isCurriedType(value, CurriedTypes.Modifier)) {
+    if (isCurriedType(value, CURRIED_MODIFIER)) {
       let {
         definition: resolvedDefinition,
         owner: curriedOwner,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -9,6 +9,7 @@ import type {
 } from '@glimmer/interfaces';
 import type { Reference } from '@glimmer/reference';
 import {
+  CURRIED_HELPER,
   decodeHandle,
   VM_CONCAT_OP,
   VM_CURRY_OP,
@@ -49,7 +50,7 @@ import {
   valueForRef,
 } from '@glimmer/reference';
 import { assign, isObject } from '@glimmer/util';
-import { $v0, CurriedTypes } from '@glimmer/vm';
+import { $v0 } from '@glimmer/vm';
 
 import { isCurriedType, resolveCurriedValue } from '../../curried-value';
 import { APPEND_OPCODES } from '../../opcodes';
@@ -106,7 +107,7 @@ APPEND_OPCODES.add(VM_DYNAMIC_HELPER_OP, (vm) => {
 
     let definition = valueForRef(ref);
 
-    if (isCurriedType(definition, CurriedTypes.Helper)) {
+    if (isCurriedType(definition, CURRIED_HELPER)) {
       let { definition: resolvedDef, owner, positional, named } = resolveCurriedValue(definition);
 
       let helper = resolveHelper(resolvedDef, ref);

--- a/packages/@glimmer/runtime/lib/references/curry-value.ts
+++ b/packages/@glimmer/runtime/lib/references/curry-value.ts
@@ -8,10 +8,10 @@ import type {
   RuntimeResolver,
 } from '@glimmer/interfaces';
 import type { Reference } from '@glimmer/reference';
+import { CURRIED_COMPONENT } from '@glimmer/constants';
 import { expect } from '@glimmer/debug-util';
 import { createComputeRef, valueForRef } from '@glimmer/reference';
 import { isObject } from '@glimmer/util';
-import { CurriedTypes } from '@glimmer/vm';
 
 import { curry, isCurriedType } from '../curried-value';
 
@@ -34,7 +34,7 @@ export default function createCurryRef(
 
     if (isCurriedType(value, type)) {
       curriedDefinition = args ? curry(type, value, owner, args) : args;
-    } else if (type === CurriedTypes.Component && typeof value === 'string' && value) {
+    } else if (type === CURRIED_COMPONENT && typeof value === 'string' && value) {
       // Only components should enter this path, as helpers and modifiers do not
       // support string based resolution
 

--- a/packages/@glimmer/vm/index.ts
+++ b/packages/@glimmer/vm/index.ts
@@ -1,9 +1,6 @@
 export { ContentType } from './lib/content';
 export {
   ARG_SHIFT,
-  /** @deprecated */
-  CurriedTypes as CurriedType,
-  CurriedTypes,
   InternalComponentCapabilities,
   /** @deprecated */
   InternalComponentCapabilities as InternalComponentCapability,

--- a/packages/@glimmer/vm/lib/flags.ts
+++ b/packages/@glimmer/vm/lib/flags.ts
@@ -4,9 +4,6 @@ import type {
   CreateArgsCapability,
   CreateCallerCapability,
   CreateInstanceCapability,
-  CurriedComponent,
-  CurriedHelper,
-  CurriedModifier,
   DynamicLayoutCapability,
   DynamicScopeCapability,
   DynamicTagCapability,
@@ -23,12 +20,6 @@ import type {
   WillDestroyCapability,
   WrappedCapability,
 } from '@glimmer/interfaces';
-
-export const CurriedTypes = {
-  Component: 0 satisfies CurriedComponent,
-  Helper: 1 satisfies CurriedHelper,
-  Modifier: 2 satisfies CurriedModifier,
-} as const;
 
 export const InternalComponentCapabilities = {
   Empty: 0 satisfies EmptyCapability,


### PR DESCRIPTION
Curried types were still not using constants after the previous cleanups in e18b5b6176175ea509cc42b87c94eef4c11a6e50 and cdf810ee9b3df089c7614c936ec16a1fb18ae424, and this commit finishes the job.