### PR TITLE
Feature/pass args to debugger

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/suites/debugger.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/debugger.ts
@@ -28,8 +28,12 @@ export class DebuggerSuite extends RenderTest {
       callbackExecuted++;
       this.assert.strictEqual(context.foo, expectedContext.foo, 'reading from the context');
       this.assert.strictEqual(get('foo'), expectedContext.foo, 'reading from a local');
-      this.assert.strictEqual(get('@a'), expectedContext.a, 'reading from an unused named args');
-      this.assert.strictEqual(get('@used'), expectedContext.used, 'reading from a used named args');
+      this.assert.strictEqual(
+        get('this.args.a'),
+        expectedContext.a,
+        'reading from an unused named arg (available on this.args)'
+      );
+      this.assert.strictEqual(get('@used'), expectedContext.used, 'reading from a used named arg');
     });
 
     this.registerComponent(

--- a/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
@@ -116,7 +116,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[3][componentNameExpr[1]];
+    let componentName = block[2][componentNameExpr[1]];
     assert.strictEqual(componentName, 'ooFX', 'customized component name was used');
   });
 
@@ -140,7 +140,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[3][componentNameExpr[1]];
+    let componentName = block[2][componentNameExpr[1]];
     assert.strictEqual(componentName, 'rental', 'customized component name was used');
   });
 
@@ -163,7 +163,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[3][componentNameExpr[1]];
+    let componentName = block[2][componentNameExpr[1]];
     assert.strictEqual(componentName, 'my-component', 'original component name was used');
   });
 
@@ -186,7 +186,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[3][componentNameExpr[1]];
+    let componentName = block[2][componentNameExpr[1]];
     assert.strictEqual(componentName, 'MyComponent', 'original component name was used');
   });
 

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/append.ts
@@ -98,7 +98,6 @@ export const APPEND_KEYWORDS = keywords('Append')
       node: ASTv2.AppendContent;
       state: NormalizationState;
     }): Result<mir.Statement> {
-      scope.setHasDebugger();
       return Ok(new mir.Debugger({ loc: node.loc, scope }));
     },
   })

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
@@ -56,7 +56,7 @@ export class ContentEncoder {
   private visitContent(stmt: mir.Statement): WireFormat.Statement | WireStatements {
     switch (stmt.type) {
       case 'Debugger':
-        return [SexpOpcodes.Debugger, stmt.scope.getDebugInfo()];
+        return [SexpOpcodes.Debugger, ...stmt.scope.getDebugInfo(), {}];
       case 'AppendComment':
         return this.AppendComment(stmt);
       case 'AppendTextNode':

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/index.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/index.ts
@@ -10,12 +10,7 @@ import { CONTENT } from './content';
 export function visit(template: mir.Template): WireFormat.SerializedTemplateBlock {
   let statements = CONTENT.list(template.body);
   let scope = template.scope;
-  let block: WireFormat.SerializedTemplateBlock = [
-    statements,
-    scope.symbols,
-    scope.hasDebugger,
-    scope.upvars,
-  ];
+  let block: WireFormat.SerializedTemplateBlock = [statements, scope.symbols, scope.upvars];
 
   if (LOCAL_TRACE_LOGGING) {
     let debug = new WireFormatDebugger(block);

--- a/packages/@glimmer/compiler/lib/wire-encoding.md
+++ b/packages/@glimmer/compiler/lib/wire-encoding.md
@@ -130,9 +130,9 @@ when otherwise explicitly stated.
 
 ## Flags
 
-| 0        | 1        | 2        | 3        | 4          | 5           |
-| -------- | -------- | -------- | -------- | ---------- | ----------- |
-| reserved | reserved | reserved | reserved | has upvars | hasDebugger |
+| 0        | 1        | 2        | 3        | 4          |
+| -------- | -------- | -------- | -------- | ---------- |
+| reserved | reserved | reserved | reserved | has upvars |
 
 # Expression
 

--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -16,7 +16,7 @@ export default class WireFormatDebugger {
   private upvars: string[];
   private symbols: string[];
 
-  constructor([_statements, symbols, _hasDebugger, upvars]: SerializedTemplateBlock) {
+  constructor([_statements, symbols, upvars]: SerializedTemplateBlock) {
     this.upvars = upvars;
     this.symbols = symbols;
   }

--- a/packages/@glimmer/compiler/test/compiler-test.ts
+++ b/packages/@glimmer/compiler/test/compiler-test.ts
@@ -36,12 +36,7 @@ function test(desc: string, template: string, ...expectedStatements: BuilderStat
 
     let statements = buildStatements(expectedStatements, symbols);
 
-    let expected: SerializedTemplateBlock = [
-      statements,
-      symbols.toSymbols(),
-      false,
-      symbols.toUpvars(),
-    ];
+    let expected: SerializedTemplateBlock = [statements, symbols.toSymbols(), symbols.toUpvars()];
 
     let debugExpected = new WireFormatDebugger(expected).format(expected);
     let debugActual = new WireFormatDebugger(actual.block).format(actual.block);

--- a/packages/@glimmer/constants/lib/syscall-ops.ts
+++ b/packages/@glimmer/constants/lib/syscall-ops.ts
@@ -6,7 +6,6 @@ import type {
   VmAppendText,
   VmAssertSame,
   VmBeginComponentTransaction,
-  VmBindDebuggerScope,
   VmBindDynamicScope,
   VmCaptureArgs,
   VmChildScope,
@@ -86,7 +85,6 @@ import type {
   VmSetBlock,
   VmSetBlocks,
   VmSetNamedVariables,
-  VmSetupForDebugger,
   VmSetVariable,
   VmSize,
   VmSpreadBlock,
@@ -174,8 +172,6 @@ export const VM_PUT_COMPONENT_OPERATIONS_OP = 89 satisfies VmPutComponentOperati
 export const VM_GET_COMPONENT_SELF_OP = 90 satisfies VmGetComponentSelf;
 export const VM_GET_COMPONENT_TAG_NAME_OP = 91 satisfies VmGetComponentTagName;
 export const VM_GET_COMPONENT_LAYOUT_OP = 92 satisfies VmGetComponentLayout;
-export const VM_BIND_DEBUGGER_SCOPE_OP = 93 satisfies VmBindDebuggerScope;
-export const VM_SETUP_FOR_DEBUGGER_OP = 94 satisfies VmSetupForDebugger;
 export const VM_POPULATE_LAYOUT_OP = 95 satisfies VmPopulateLayout;
 export const VM_INVOKE_COMPONENT_LAYOUT_OP = 96 satisfies VmInvokeComponentLayout;
 export const VM_BEGIN_COMPONENT_TRANSACTION_OP = 97 satisfies VmBeginComponentTransaction;

--- a/packages/@glimmer/debug-util/lib/debug-brand.ts
+++ b/packages/@glimmer/debug-util/lib/debug-brand.ts
@@ -80,7 +80,6 @@ export interface DebugProgramSymbolTable {
   readonly upvars: readonly string[];
   readonly named: Dict<number>;
   readonly blocks: Dict<number>;
-  readonly hasDebugger: boolean;
 }
 
 export type LocalDebugType = keyof LocalDebugMap;

--- a/packages/@glimmer/debug/lib/dism/opcode.ts
+++ b/packages/@glimmer/debug/lib/dism/opcode.ts
@@ -272,15 +272,12 @@ function describeProgramSymbolTable(
 ) {
   const debug = dev(classified.options.debug);
 
-  const hasDebugger = debug.hasDebugger
-    ? frag`(${as.kw('has debugger')})`
-    : frag`(${as.dim('no debugger')})`.subtle();
   const keywords = labelledList('keywords', debug.keywords);
   const upvars = labelledList('upvars', debug.upvars);
   const atNames = labelledList('@-names', Object.keys(debug.named));
   const blocks = labelledList('blocks', Object.keys(debug.blocks));
 
-  const fields = join([hasDebugger, keywords, atNames, upvars, blocks], ' ');
+  const fields = join([keywords, atNames, upvars, blocks], ' ');
 
   const full = frag` ${value(debug, { ref: 'debug' })}`.subtle();
 

--- a/packages/@glimmer/debug/lib/opcode-metadata.ts
+++ b/packages/@glimmer/debug/lib/opcode-metadata.ts
@@ -10,7 +10,6 @@ import {
   VM_APPEND_TEXT_OP,
   VM_ASSERT_SAME_OP,
   VM_BEGIN_COMPONENT_TRANSACTION_OP,
-  VM_BIND_DEBUGGER_SCOPE_OP,
   VM_BIND_DYNAMIC_SCOPE_OP,
   VM_CAPTURE_ARGS_OP,
   VM_CHILD_SCOPE_OP,
@@ -94,7 +93,6 @@ import {
   VM_SET_BLOCKS_OP,
   VM_SET_NAMED_VARIABLES_OP,
   VM_SET_VARIABLE_OP,
-  VM_SETUP_FOR_DEBUGGER_OP,
   VM_SPREAD_BLOCK_OP,
   VM_STATIC_ATTR_OP,
   VM_SYSCALL_SIZE,
@@ -693,20 +691,6 @@ if (LOCAL_DEBUG) {
     ops: ['state:register'],
   };
 
-  METADATA[VM_BIND_DEBUGGER_SCOPE_OP] = {
-    name: 'BindDebuggerScope',
-    mnemonic: 'debugger_scope',
-    stackChange: 0,
-    ops: ['state:register'],
-  };
-
-  METADATA[VM_SETUP_FOR_DEBUGGER_OP] = {
-    name: 'SetupForDebugger',
-    mnemonic: 'debugger_setup',
-    stackChange: 0,
-    ops: ['state:register'],
-  };
-
   METADATA[VM_POPULATE_LAYOUT_OP] = {
     name: 'PopulateLayout',
     mnemonic: 'comp_layoutput',
@@ -751,6 +735,6 @@ if (LOCAL_DEBUG) {
     name: 'Debugger',
     mnemonic: 'debugger',
     stackChange: 0,
-    ops: ['symbols:const/any', 'debugInfo:const/i32[]'],
+    ops: ['symbols:const/any'],
   };
 }

--- a/packages/@glimmer/debug/lib/stack-check.ts
+++ b/packages/@glimmer/debug/lib/stack-check.ts
@@ -511,7 +511,6 @@ export const CheckBlockSymbolTable: Checker<BlockSymbolTable> = LOCAL_DEBUG
 
 export const CheckProgramSymbolTable: Checker<ProgramSymbolTable> = LOCAL_DEBUG
   ? CheckInterface({
-      hasDebugger: CheckBoolean,
       symbols: CheckArray(CheckString),
     })
   : new NoopChecker();

--- a/packages/@glimmer/interfaces/lib/compile/operands.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/operands.d.ts
@@ -33,7 +33,11 @@ export interface IsStrictModeOperand {
 
 export interface DebugSymbolsOperand {
   type: DebugSymbolsOperandType;
-  value: undefined;
+  value: {
+    locals: Record<string, number>;
+    upvars: Record<string, number>;
+    lexical: Record<string, number>;
+  };
 }
 
 export interface BlockOperand {

--- a/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
@@ -72,6 +72,8 @@ export type SexpOpcode = keyof SexpOpcodeMap;
 export namespace Core {
   export type Expression = Expressions.Expression;
 
+  export type DebugSymbols = [locals: Record<string, number>, upvars: Record<string, number>];
+
   export type CallArgs = [Params, Hash];
   export type Path = [string, ...string[]];
   export type ConcatParams = PresentArray<Expression>;
@@ -80,10 +82,9 @@ export namespace Core {
   export type Blocks = Nullable<[string[], SerializedInlineBlock[]]>;
   export type Args = [Params, Hash];
   export type NamedBlock = [string, SerializedInlineBlock];
-  export type DebugInfo = number[];
   export type ElementParameters = Nullable<PresentArray<ElementParameter>>;
 
-  export type Syntax = Path | Params | ConcatParams | Hash | Blocks | Args | DebugInfo;
+  export type Syntax = Path | Params | ConcatParams | Hash | Blocks | Args;
 }
 
 export type CoreSyntax = Core.Syntax;
@@ -254,7 +255,12 @@ export namespace Statements {
     | TrustingDynamicAttr
     | TrustingComponentAttr;
 
-  export type Debugger = [DebuggerOpcode, Core.DebugInfo];
+  export type Debugger = [
+    op: DebuggerOpcode,
+    locals: Record<string, number>,
+    upvars: Record<string, number>,
+    lexical: Record<string, number>,
+  ];
   export type InElement = [
     op: InElementOpcode,
     block: SerializedInlineBlock,
@@ -366,7 +372,6 @@ export type SerializedInlineBlock = [statements: Statements.Statement[], paramet
 export type SerializedTemplateBlock = [
   statements: Statements.Statement[],
   locals: string[],
-  hasDebugger: boolean,
   upvars: string[],
   lexicalSymbols?: string[],
 ];

--- a/packages/@glimmer/interfaces/lib/runtime/scope.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/scope.d.ts
@@ -1,4 +1,4 @@
-import type { Dict, Nullable } from '../core.js';
+import type { Nullable } from '../core.js';
 import type { Reference } from '../references.js';
 import type { CompilableBlock } from '../template.js';
 import type { BlockSymbolTable } from '../tier1/symbol-table.js';
@@ -25,8 +25,6 @@ export interface Scope {
   getSelf(): Reference;
   getSymbol(symbol: number): Reference;
   getBlock(symbol: number): Nullable<ScopeBlock>;
-  getDebuggerScope(): Nullable<Dict<ScopeSlot>>;
-  bindDebuggerScope(map: Nullable<Dict<ScopeSlot>>): void;
   bind(symbol: number, value: ScopeSlot): void;
   bindSelf(self: Reference): void;
   bindSymbol(symbol: number, value: Reference): void;

--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -110,11 +110,16 @@ export interface BlockSymbolNames {
   upvars: Nullable<string[]>;
 }
 
+export interface DebuggerInfo {
+  locals: Record<string, number>;
+  lexical: Record<string, number>;
+  upvars: Record<string, number>;
+}
+
 export interface BlockMetadata {
   symbols: BlockSymbolNames;
   scopeValues: unknown[] | null;
   isStrictMode: boolean;
-  hasDebugger: boolean;
   moduleName: string;
   owner: Owner | null;
   size: number;

--- a/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
+++ b/packages/@glimmer/interfaces/lib/tier1/symbol-table.d.ts
@@ -1,5 +1,4 @@
 export interface ProgramSymbolTable {
-  hasDebugger: boolean;
   symbols: string[];
 }
 

--- a/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
+++ b/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
@@ -96,8 +96,6 @@ export type VmPutComponentOperations = 89;
 export type VmGetComponentSelf = 90;
 export type VmGetComponentTagName = 91;
 export type VmGetComponentLayout = 92;
-export type VmBindDebuggerScope = 93;
-export type VmSetupForDebugger = 94;
 export type VmPopulateLayout = 95;
 export type VmInvokeComponentLayout = 96;
 export type VmBeginComponentTransaction = 97;
@@ -193,8 +191,6 @@ export type VmOp =
   | VmGetComponentSelf
   | VmGetComponentTagName
   | VmGetComponentLayout
-  | VmBindDebuggerScope
-  | VmSetupForDebugger
   | VmPopulateLayout
   | VmInvokeComponentLayout
   | VmBeginComponentTransaction

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -55,13 +55,12 @@ class CompilableTemplateImpl<S extends SymbolTable> implements CompilableTemplat
 }
 
 export function compilable(layout: LayoutWithContext, moduleName: string): CompilableProgram {
-  let [statements, symbols, hasDebugger] = layout.block;
+  let [statements, symbols] = layout.block;
   return new CompilableTemplateImpl(
     statements,
     meta(layout),
     {
       symbols,
-      hasDebugger,
     },
     moduleName
   );

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -193,7 +193,7 @@ export class EncoderImpl implements Encoder {
             return encodeHandle(constants.value(this.meta.isStrictMode));
 
           case HighLevelOperands.DebugSymbols:
-            return encodeHandle(constants.value(this.meta.symbols));
+            return encodeHandle(constants.value(operand.value));
 
           case HighLevelOperands.Block:
             return encodeHandle(constants.value(compilableBlock(operand.value, this.meta)));

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
@@ -51,7 +51,6 @@ import {
   VM_SET_BLOCKS_OP,
   VM_SET_NAMED_VARIABLES_OP,
   VM_SET_VARIABLE_OP,
-  VM_SETUP_FOR_DEBUGGER_OP,
   VM_VIRTUAL_ROOT_SCOPE_OP,
 } from '@glimmer/constants';
 import { unwrap } from '@glimmer/debug-util';
@@ -195,9 +194,7 @@ function InvokeStaticComponent(
 ): void {
   let { symbolTable } = layout;
 
-  let bailOut =
-    symbolTable.hasDebugger ||
-    hasCapability(capabilities, InternalComponentCapabilities.prepareArgs);
+  let bailOut = hasCapability(capabilities, InternalComponentCapabilities.prepareArgs);
 
   if (bailOut) {
     InvokeNonStaticComponent(op, {
@@ -464,7 +461,6 @@ export function invokePreparedComponent(
 
   op(VM_VIRTUAL_ROOT_SCOPE_OP, $s0);
   op(VM_SET_VARIABLE_OP, 0);
-  op(VM_SETUP_FOR_DEBUGGER_OP, $s0);
 
   if (bindableAtNames) op(VM_SET_NAMED_VARIABLES_OP, $s0);
   if (bindableBlocks) op(VM_SET_BLOCKS_OP, $s0);

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
@@ -106,7 +106,7 @@ export function CompilePositional(
 }
 
 export function meta(layout: LayoutWithContext): BlockMetadata {
-  let [, locals, hasDebugger, upvars, lexicalSymbols] = layout.block;
+  let [, locals, upvars, lexicalSymbols] = layout.block;
 
   return {
     symbols: {
@@ -114,18 +114,10 @@ export function meta(layout: LayoutWithContext): BlockMetadata {
       upvars,
       lexical: lexicalSymbols,
     },
-    hasDebugger,
     scopeValues: layout.scope?.() ?? null,
     isStrictMode: layout.isStrictMode,
     moduleName: layout.moduleName,
     owner: layout.owner,
     size: locals.length,
   };
-}
-
-export function getDebuggerSymbols(layout: LayoutWithContext): Nullable<string[]> {
-  let { block } = layout;
-  let [, symbols, hasDebugger] = block;
-
-  return hasDebugger ? symbols : null;
 }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/stdlib.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/stdlib.ts
@@ -121,7 +121,6 @@ export const STDLIB_META: BlockMetadata = {
     locals: null,
     upvars: null,
   },
-  hasDebugger: false,
   moduleName: 'stdlib',
 
   // TODO: ??

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
@@ -38,8 +38,12 @@ export function labelOperand(value: string): LabelOperand {
   return { type: HighLevelOperands.Label, value };
 }
 
-export function debugSymbolsOperand(): DebugSymbolsOperand {
-  return { type: HighLevelOperands.DebugSymbols, value: undefined };
+export function debugSymbolsOperand(
+  locals: Record<string, number>,
+  upvars: Record<string, number>,
+  lexical: Record<string, number>
+): DebugSymbolsOperand {
+  return { type: HighLevelOperands.DebugSymbols, value: { locals, upvars, lexical } };
 }
 
 export function isStrictMode(): IsStrictModeOperand {

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -163,9 +163,9 @@ STATEMENTS.add(SexpOpcodes.Yield, (op, [, to, params]) => YieldBlock(op, to, par
 
 STATEMENTS.add(SexpOpcodes.AttrSplat, (op, [, to]) => YieldBlock(op, to, null));
 
-STATEMENTS.add(SexpOpcodes.Debugger, (op, [, debugInfo]) =>
-  op(VM_DEBUGGER_OP, debugSymbolsOperand(), debugInfo)
-);
+STATEMENTS.add(SexpOpcodes.Debugger, (op, [, locals, upvars, lexical]) => {
+  op(VM_DEBUGGER_OP, debugSymbolsOperand(locals, upvars, lexical));
+});
 
 STATEMENTS.add(SexpOpcodes.Append, (op, [, value]) => {
   // Special case for static values

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -30,7 +30,7 @@ export class WrappedBuilder implements CompilableProgram {
     public moduleName: string
   ) {
     let { block } = layout;
-    let [, symbols, hasDebugger] = block;
+    let [, symbols] = block;
 
     symbols = symbols.slice();
 
@@ -43,7 +43,6 @@ export class WrappedBuilder implements CompilableProgram {
     }
 
     this.symbolTable = {
-      hasDebugger,
       symbols,
     };
 

--- a/packages/@glimmer/program/lib/util/default-template.ts
+++ b/packages/@glimmer/program/lib/util/default-template.ts
@@ -4,12 +4,7 @@ import { SexpOpcodes as op } from '@glimmer/wire-format';
 /**
  * Default component template, which is a plain yield
  */
-const DEFAULT_TEMPLATE_BLOCK: SerializedTemplateBlock = [
-  [[op.Yield, 1, null]],
-  ['&default'],
-  false,
-  [],
-];
+const DEFAULT_TEMPLATE_BLOCK: SerializedTemplateBlock = [[[op.Yield, 1, null]], ['&default'], []];
 
 export const DEFAULT_TEMPLATE: SerializedTemplateWithLazyBlock = {
   // random uuid

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -51,7 +51,6 @@ import {
   VM_RESOLVE_DYNAMIC_COMPONENT_OP,
   VM_SET_BLOCKS_OP,
   VM_SET_NAMED_VARIABLES_OP,
-  VM_SETUP_FOR_DEBUGGER_OP,
   VM_STATIC_COMPONENT_ATTR_OP,
   VM_VIRTUAL_ROOT_SCOPE_OP,
 } from '@glimmer/constants';
@@ -838,15 +837,6 @@ APPEND_OPCODES.add(VM_VIRTUAL_ROOT_SCOPE_OP, (vm, { op1: register }) => {
   }
 
   vm.pushRootScope(table.symbols.length + 1, owner);
-});
-
-APPEND_OPCODES.add(VM_SETUP_FOR_DEBUGGER_OP, (vm, { op1: register }) => {
-  let state = check(vm.fetchValue(check(register, CheckRegister)), CheckFinishedComponentInstance);
-
-  if (state.table.hasDebugger) {
-    let lookup = (state.lookup = dict<ScopeSlot>());
-    vm.scope().bindDebuggerScope(lookup);
-  }
 });
 
 APPEND_OPCODES.add(VM_SET_NAMED_VARIABLES_OP, (vm, { op1: register }) => {


### PR DESCRIPTION
This commit eliminates debugger infrastructure that derived from the old partial/eval infrastructure.

Instead, it passes the in-scope values as a constant to the `debugger` wire format opcode and uses it directly in the scope inspector.

This will be followed up with support for accessing strict-mode lexical variables.