### PR TITLE
Fix #1668: Node does not use the 'development' condition with default require() - this PR removes the `development` condition under `require` for `@glimmer/syntax` and dependents.

### DIFF
--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -10,10 +10,8 @@
     "exports": {
       ".": {
         "require": {
-          "development": {
-            "types": "./dist/dev/index.d.cts",
-            "default": "./dist/dev/index.cjs"
-          }
+          "types": "./dist/dev/index.d.cts",
+          "default": "./dist/dev/index.cjs"
         },
         "default": {
           "development": {

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -11,10 +11,8 @@
     "exports": {
       ".": {
         "require": {
-          "development": {
-            "types": "./dist/dev/index.d.cts",
-            "default": "./dist/dev/index.cjs"
-          }
+          "types": "./dist/dev/index.d.cts",
+          "default": "./dist/dev/index.cjs"
         },
         "default": {
           "development": {

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -11,10 +11,8 @@
     "exports": {
       ".": {
         "require": {
-          "development": {
-            "types": "./dist/dev/index.d.cts",
-            "default": "./dist/dev/index.cjs"
-          }
+          "types": "./dist/dev/index.d.cts",
+          "default": "./dist/dev/index.cjs"
         },
         "default": {
           "development": {


### PR DESCRIPTION
Tested locally with `require('@glimmer/syntax')` until doing so did not error with `ERR_REQUIRE_ESM` (node 22)


With the existing published version, the following are broken:
- ember-template-recast
- prettier
- any cjs-node tooling wanting to parse templates 

This is because node does not use the `development` condition when it resolves requires.