### PR TITLE
[ Pending RFC ] create Cell

### DIFF
--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -12,6 +12,7 @@ if (globalObj[GLIMMER_VALIDATOR_REGISTRATION] === true) {
 
 globalObj[GLIMMER_VALIDATOR_REGISTRATION] = true;
 
+export { Cell } from './lib/cell';
 export { debug } from './lib/debug';
 export { dirtyTagFor, tagFor, type TagMeta, tagMetaFor } from './lib/meta';
 export { trackedData } from './lib/tracked-data';

--- a/packages/@glimmer/validator/lib/cell.ts
+++ b/packages/@glimmer/validator/lib/cell.ts
@@ -1,0 +1,54 @@
+import type { UpdatableTag } from '@glimmer/interfaces';
+
+import { consumeTag } from './tracking';
+import { createUpdatableTag, DIRTY_TAG } from './validators';
+
+type Equality<T> = (a: T, b: T) => boolean;
+
+export class Cell<Value> {
+  static create<T>(value: T, equals: Equality<T> = Object.is): Cell<T> {
+    return new Cell(value, equals);
+  }
+
+  #value: Value;
+  readonly #equals: Equality<Value>;
+  readonly #tag: UpdatableTag;
+
+  private constructor(value: Value, equals: Equality<Value>) {
+    this.#value = value;
+    this.#equals = equals;
+    this.#tag = createUpdatableTag();
+  }
+
+  get current() {
+    consumeTag(this.#tag);
+
+    return this.#value;
+  }
+
+  read(): Value {
+    consumeTag(this.#tag);
+
+    return this.#value;
+  }
+
+  set(value: Value): boolean {
+    if (this.#equals(this.#value, value)) {
+      return false;
+    }
+
+    this.#value = value;
+
+    DIRTY_TAG(this.#tag);
+
+    return true;
+  }
+
+  update(updater: (value: Value) => Value): void {
+    this.set(updater(this.read()));
+  }
+
+  freeze(): void {
+    throw new Error(`Not Implemented`);
+  }
+}

--- a/packages/@glimmer/validator/test/-utils.ts
+++ b/packages/@glimmer/validator/test/-utils.ts
@@ -1,2 +1,3 @@
 export const module = QUnit.module;
 export const test = QUnit.test;
+export const skip = QUnit.skip;

--- a/packages/@glimmer/validator/test/cell-test.ts
+++ b/packages/@glimmer/validator/test/cell-test.ts
@@ -1,0 +1,28 @@
+import { Cell } from '@glimmer/validator';
+
+import { module, skip, test } from './-utils';
+
+module('Cell', () => {
+  test('creates reactive storage', (assert) => {
+    const cell = Cell.create('hello');
+    assert.strictEqual(cell.read(), 'hello');
+  });
+
+  test('updates when set', (assert) => {
+    const cell = Cell.create('hello');
+    cell.set('world');
+    assert.strictEqual(cell.read(), 'world');
+  });
+
+  test('updates when update() is called', (assert) => {
+    const cell = Cell.create('hello');
+    cell.update((value) => value + ' world');
+    assert.strictEqual(cell.read(), 'hello world');
+  });
+
+  skip('is frozen when freeze() is called', (assert) => {
+    const cell = Cell.create('hello');
+    cell.freeze();
+    assert.throws(() => cell.set('world'));
+  });
+});


### PR DESCRIPTION
I want to RFC Resources, but we don't really have an implemented way to have reactivity in them right now.

We have:
 - `trackedData` in `@glimmer/validator` -- this whole package should not be used by ember users tho, and most of its exports are not-RFC'd and should be considered private API 
 - `@glimmer/tracking/primitives/storage` -- this would work as an implementation of "Cell", but isn't implemented yet
 - `@tracked` - requires creating class state, which many would feel is too cumbersome / verbose when for the "simple" cases, like having one value