### PR TITLE
Use our own local copy of @glimemr/syntax when we run prettier to make sure we didn't break prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,11 @@
   },
   "packageManager": "pnpm@10.0.0",
   "pnpm": {
+    "notes": {
+      "override:@glimemr/syntax": "when we run prettier, we want to use our local copy of prettier, not the one it declared in its package.json. This ensures that we don't accidentally break prettier as we make changes to @glimmer/syntax"
+    },
     "overrides": {
+      "@glimmer/syntax": "workspace:*",
       "@rollup/pluginutils": "^5.0.2",
       "@types/node": "$@types/node",
       "typescript": "$typescript"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@glimmer/syntax': workspace:*
   '@rollup/pluginutils': ^5.0.2
   '@types/node': ^20.17.10
   typescript: ^5.7.3


### PR DESCRIPTION
it works:
```

❯ pnpm why @glimmer/syntax -r
Legend: production dependency, optional only, dev only

glimmer-engine@0.92.0 <repo> (PRIVATE)

devDependencies:
@glimmer-workspace/integration-tests link:packages/@glimmer-workspace/integration-tests
├─┬ @glimmer/compiler link:packages/@glimmer/compiler
│ └── @glimmer/syntax link:packages/@glimmer/syntax
└── @glimmer/syntax link:packages/@glimmer/syntax

@glimmer-workspace/integration-tests@0.92.0 <repo>/packages/@glimmer-workspace/integration-tests (PRIVATE)

dependencies:
@glimmer/compiler link:../../@glimmer/compiler
└── @glimmer/syntax link:../../@glimmer/syntax
@glimmer/syntax link:../../@glimmer/syntax

@glimmer-test/integration-tests@0.92.0 <repo>/packages/@glimmer-workspace/integration-tests/test (PRIVATE)

dependencies:
@glimmer-workspace/integration-tests link:..
├─┬ @glimmer/compiler link:../../../@glimmer/compiler
│ └── @glimmer/syntax link:../../../@glimmer/syntax
└── @glimmer/syntax link:../../../@glimmer/syntax
@glimmer/compiler link:../../../@glimmer/compiler
└── @glimmer/syntax link:../../../@glimmer/syntax
@glimmer/syntax link:../../../@glimmer/syntax

@glimmer/compiler@0.93.1 <repo>/packages/@glimmer/compiler

dependencies:
@glimmer/syntax link:../syntax

@glimmer-test/compiler@0.92.0 <repo>/packages/@glimmer/compiler/test (PRIVATE)

dependencies:
@glimmer/compiler link:..
└── @glimmer/syntax link:../../syntax
@glimmer/syntax link:../../syntax

@glimmer/node@0.93.1 <repo>/packages/@glimmer/node

devDependencies:
@glimmer/compiler link:../compiler
└── @glimmer/syntax link:../syntax

@glimmer-test/syntax@0.92.0 <repo>/packages/@glimmer/syntax/test (PRIVATE)

dependencies:
@glimmer-workspace/integration-tests link:../../../@glimmer-workspace/integration-tests
├─┬ @glimmer/compiler link:../../compiler
│ └── @glimmer/syntax link:..
└── @glimmer/syntax link:..
@glimmer/syntax link:..
```