### PR TITLE
Root package.json needs a repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "0.92.0",
   "license": "MIT",
   "description": "Glimmer compiles Handlebars templates into document fragments rather than string buffers",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/glimmerjs/glimmer-vm.git",
+  },
   "author": "Tilde, Inc.",
   "type": "module",
   "exports": null,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Glimmer compiles Handlebars templates into document fragments rather than string buffers",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/glimmerjs/glimmer-vm.git",
+    "url": "git+https://github.com/glimmerjs/glimmer-vm.git"
   },
   "author": "Tilde, Inc.",
   "type": "module",


### PR DESCRIPTION
Should fix the error that occurred during release https://github.com/glimmerjs/glimmer-vm/actions/runs/12895171828/job/35955992819#step:5:31