### PR TITLE
Fix exports

### DIFF
--- a/.meta-updater/main.mjs
+++ b/.meta-updater/main.mjs
@@ -79,13 +79,15 @@ export default () =>
             update(actual, 'files', ['dist']);
 
             update(publishConfig, 'exports', {
-              development: {
-                types: './dist/dev/index.d.ts',
-                default: './dist/dev/index.js',
-              },
-              default: {
-                types: './dist/prod/index.d.ts',
-                default: './dist/prod/index.js',
+              '.': {
+                development: {
+                  types: './dist/dev/index.d.ts',
+                  default: './dist/dev/index.js',
+                },
+                default: {
+                  types: './dist/prod/index.d.ts',
+                  default: './dist/prod/index.js',
+                },
               },
             });
           } else {

--- a/packages/@glimmer-workspace/benchmark-env/package.json
+++ b/packages/@glimmer-workspace/benchmark-env/package.json
@@ -10,13 +10,15 @@
   },
   "publishConfig": {
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -13,13 +13,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -13,13 +13,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -13,13 +13,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -13,13 +13,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -13,13 +13,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -13,13 +13,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/vm-babel-plugins/package.json
+++ b/packages/@glimmer/vm-babel-plugins/package.json
@@ -15,13 +15,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -12,13 +12,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -13,13 +13,15 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "development": {
-        "types": "./dist/dev/index.d.ts",
-        "default": "./dist/dev/index.js"
-      },
-      "default": {
-        "types": "./dist/prod/index.d.ts",
-        "default": "./dist/prod/index.js"
+      ".": {
+        "development": {
+          "types": "./dist/dev/index.d.ts",
+          "default": "./dist/dev/index.js"
+        },
+        "default": {
+          "types": "./dist/prod/index.d.ts",
+          "default": "./dist/prod/index.js"
+        }
       }
     }
   },


### PR DESCRIPTION
This is the biggest downside to having publishConfig handle exports -- things get out of sync!

But also, this repo doesn't doesn't test with TS 5.1, and TS 5.1 (supported by ember) doesn't support `exports.default`