### PR TITLE
Bring back cjs for glimmer syntax

### DIFF
--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -20,6 +20,9 @@
           "types": "./dist/dev/index.d.ts",
           "default": "./dist/dev/index.js"
         },
+        "require": {
+          "default": "./dist/dev/index.cjs"
+        },
         "default": {
           "types": "./dist/prod/index.d.ts",
           "default": "./dist/prod/index.js"

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -9,6 +9,9 @@
   },
   "type": "module",
   "exports": "./index.ts",
+  "repo-meta": {
+    "supportcjs": true
+  },
   "publishConfig": {
     "access": "public",
     "exports": {

--- a/repo-metadata/metadata.json
+++ b/repo-metadata/metadata.json
@@ -515,7 +515,8 @@
       "type": "module",
       "private": false,
       "repo-meta": {
-        "built": true
+        "built": true,
+        "supportcjs": true
       },
       "entryPoints": {
         ".": [[["default"], "./index.ts"]]


### PR DESCRIPTION
womp


Node < 22 + linting usually is what needs cjs 

https://github.com/emberjs/ember.js/actions/runs/13252868862/job/36994277577?pr=20842#step:4:18