### PR TITLE
Fix rendering non-object, yet stringable values (Symbol?), moves Reflect.getPrototypeOf to Object.getPrototypeOf

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/render-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/render-test.ts
@@ -1,0 +1,21 @@
+import { defineComponent, jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+class RenderingTest extends RenderTest {
+  static suiteName = '<rendering>';
+
+  query(selector: string) {
+    let el = (s: string) => (this.element as unknown as HTMLElement).querySelector(s);
+    return el(selector) as Element;
+  }
+
+  @test
+  'Symbols are rendered as strings'() {
+    const sym = Symbol('hello world');
+    const Bar = defineComponent({ sym }, '<div>{{sym}}</div>');
+
+    this.renderComponent(Bar);
+    this.assertHTML(`<div>Symbol(hello world)</div>`);
+  }
+}
+
+jitSuite(RenderingTest);

--- a/packages/@glimmer/manager/lib/internal/api.ts
+++ b/packages/@glimmer/manager/lib/internal/api.ts
@@ -72,7 +72,7 @@ function getManager<M extends InternalManager>(
       return manager;
     }
 
-    pointer = getPrototypeOf(pointer);
+    pointer = getPrototypeOf(pointer) as object | null;
   }
 
   return undefined;

--- a/packages/@glimmer/manager/lib/internal/api.ts
+++ b/packages/@glimmer/manager/lib/internal/api.ts
@@ -24,7 +24,14 @@ const HELPER_MANAGERS = new WeakMap<object, CustomHelperManager | Helper>();
 
 ///////////
 
-const getPrototypeOf = Reflect.getPrototypeOf;
+/**
+ * There is also Reflect.getPrototypeOf,
+ * which errors when non-objects are passed.
+ *
+ * Since our conditional for figuring out whether to render primitives or not
+ * may contain non-object values, we don't want to throw errors when we call this.
+ */
+const getPrototypeOf = Object.getPrototypeOf;
 
 function setManager<Def extends object>(
   map: WeakMap<object, object>,


### PR DESCRIPTION
Failing test from https://github.com/emberjs/ember.js/pull/20842

Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf

![image](https://github.com/user-attachments/assets/ee699e69-ca30-4c78-9a87-931d74fbc7b8)
