### PR TITLE
Printer quoting bug

### DIFF
--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -152,6 +152,8 @@ QUnit.module('[glimmer-syntax] Code generation - source -> source', () => {
     ' {{#foo}}\n  {{bar}}\n {{/foo}}',
 
     `<span class="stampFont" style="font-family: 'stampfont'">&#xf000;</span>`,
+    `<Reply @message='He said "yes"' />`,
+
   ].forEach(buildTest);
 });
 

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -152,9 +152,38 @@ QUnit.module('[glimmer-syntax] Code generation - source -> source', () => {
     ' {{#foo}}\n  {{bar}}\n {{/foo}}',
 
     `<span class="stampFont" style="font-family: 'stampfont'">&#xf000;</span>`,
-    `<Reply @message='He said "yes"' />`,
 
+    // preserves single quoting when it avoids introducing &quot;
+    `<div class='He said "yes"'></div>`,
   ].forEach(buildTest);
+
+  test('falls back to using entity encoding when necessary for correctness', (assert) => {
+    let ast = parse(`<div class='transform-target'></div>`, {
+      mode: 'codemod',
+      parseOptions: { ignoreStandalone: true },
+      plugins: {
+        ast: [
+          function (_env) {
+            return {
+              name: 'test',
+              visitor: {
+                TextNode(x) {
+                  if (x.chars === 'transform-target') {
+                    x.chars = 'He said "can\'t"';
+                  }
+                },
+              },
+            };
+          },
+        ],
+      },
+    });
+
+    assert.strictEqual(
+      print(ast, { entityEncoding: 'raw' }),
+      `<div class="He said &quot;can't&quot;"></div>`
+    );
+  });
 });
 
 QUnit.module('[glimmer-syntax] Code generation - override', () => {


### PR DESCRIPTION
I hit this printer bug while testing `@embroider/template-tag-codemod` against http://github.com/rust-lang/crates.io.

The printer replaces `'` with `"`, even when there were already `"` characters inside the string literal, and they don't get escaped, resulting in a syntax error.

The real line that triggered this was: https://github.com/rust-lang/crates.io/blob/54ad496796eaf3499fc2b6fb96d167b3e94d7d70/app/components/crate-row.hbs#L12

