### PR TITLE
set hoist-workspace-packages=false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 ignore-workspace-root-check=true
 auto-install-peers=true
 strict-peer-dependencies=true
+hoist-workspace-packages=false


### PR DESCRIPTION
This is part of the effort to harmonize the ember and glimmer monorepos. 

We upgraded ember to use pnpm 10 to match this repo, but discovered that starting at pnpm 9, pnpm defaults to hoisting all workspace packages such that they are erroneously resolvable by *all* dependencies. 

This setting is more strict and correct and avoids specific confusing problems in ember's build.