### PR TITLE
Printer bug: empty string literal args are dropped

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/printer.ts
+++ b/packages/@glimmer/syntax/lib/generation/printer.ts
@@ -285,7 +285,9 @@ export default class Printer {
     let { name, value } = attr;
 
     this.buffer += name;
-    if (value.type !== 'TextNode' || value.chars.length > 0) {
+    const isAttribute = !name.startsWith('@');
+    const shouldElideValue = isAttribute && value.type == 'TextNode' && value.chars.length === 0;
+    if (!shouldElideValue) {
       this.buffer += '=';
       this.AttrNodeValue(value);
     }

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -94,6 +94,9 @@ let templates = [
 
   // Comment in Angle Bracket component
   '<Foo {{!-- This is a comment --}} attribute></Foo>',
+
+  // Empty string literal args
+  `<Hello @world="" />`
 ];
 
 QUnit.module('[glimmer-syntax] Code generation', () => {

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -95,8 +95,8 @@ let templates = [
   // Comment in Angle Bracket component
   '<Foo {{!-- This is a comment --}} attribute></Foo>',
 
-  // Empty string literal args
-  `<Hello @world="" />`
+  // Empty string literal: arguments use ="" while attributes are valueless
+  `<Hello @world="" data-foo />`,
 ];
 
 QUnit.module('[glimmer-syntax] Code generation', () => {


### PR DESCRIPTION
The printer (in all modes, not just the hacked-on "codemod mode") loses empty string literal arguments:

```diff
-<Hello @world="" />
+<Hello @world />
```
