### PR TITLE
Revert "Prepare Release"

### DIFF
--- a/.release-plan.json
+++ b/.release-plan.json
@@ -1,217 +1,63 @@
 {
   "solution": {
     "@glimmer/compiler": {
-      "impact": "patch",
-      "oldVersion": "0.94.8",
-      "newVersion": "0.94.9",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/syntax"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/wire-format"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/compiler/package.json"
+      "oldVersion": "0.94.8"
     },
     "@glimmer/destroyable": {
+      "oldVersion": "0.94.6"
+    },
+    "@glimmer/encoder": {
+      "oldVersion": "0.93.6"
+    },
+    "@glimmer/global-context": {
+      "oldVersion": "0.93.2"
+    },
+    "@glimmer/interfaces": {
+      "oldVersion": "0.94.5"
+    },
+    "@glimmer/manager": {
       "impact": "patch",
       "oldVersion": "0.94.6",
       "newVersion": "0.94.7",
       "constraints": [
         {
           "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/global-context"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/destroyable/package.json"
-    },
-    "@glimmer/encoder": {
-      "impact": "patch",
-      "oldVersion": "0.93.6",
-      "newVersion": "0.93.7",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/vm"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/encoder/package.json"
-    },
-    "@glimmer/global-context": {
-      "impact": "patch",
-      "oldVersion": "0.93.2",
-      "newVersion": "0.93.3",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/global-context/package.json"
-    },
-    "@glimmer/interfaces": {
-      "impact": "patch",
-      "oldVersion": "0.94.5",
-      "newVersion": "0.94.6",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/interfaces/package.json"
-    },
-    "@glimmer/manager": {
-      "impact": "patch",
-      "oldVersion": "0.94.7",
-      "newVersion": "0.94.8",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/destroyable"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/global-context"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/reference"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/validator"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/vm"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
+          "reason": "Appears in changelog section :bug: Bug Fix"
         }
       ],
       "pkgJSONPath": "./packages/@glimmer/manager/package.json"
     },
     "@glimmer/node": {
       "impact": "patch",
-      "oldVersion": "0.94.7",
-      "newVersion": "0.94.8",
+      "oldVersion": "0.94.6",
+      "newVersion": "0.94.7",
       "constraints": [
         {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @glimmer/runtime"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/@glimmer/node/package.json"
     },
     "@glimmer/opcode-compiler": {
       "impact": "patch",
-      "oldVersion": "0.94.7",
-      "newVersion": "0.94.8",
+      "oldVersion": "0.94.6",
+      "newVersion": "0.94.7",
       "constraints": [
         {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @glimmer/manager"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/encoder"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/vm"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/wire-format"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/@glimmer/opcode-compiler/package.json"
     },
     "@glimmer/owner": {
-      "impact": "patch",
-      "oldVersion": "0.93.2",
-      "newVersion": "0.93.3",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/owner/package.json"
+      "oldVersion": "0.93.2"
     },
     "@glimmer/program": {
       "impact": "patch",
-      "oldVersion": "0.94.7",
-      "newVersion": "0.94.8",
+      "oldVersion": "0.94.6",
+      "newVersion": "0.94.7",
       "constraints": [
         {
           "impact": "patch",
@@ -220,62 +66,17 @@
         {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @glimmer/manager"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/vm"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/wire-format"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/@glimmer/program/package.json"
     },
     "@glimmer/reference": {
-      "impact": "patch",
-      "oldVersion": "0.94.6",
-      "newVersion": "0.94.7",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/global-context"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/validator"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/reference/package.json"
+      "oldVersion": "0.94.6"
     },
     "@glimmer/runtime": {
       "impact": "patch",
-      "oldVersion": "0.94.7",
-      "newVersion": "0.94.8",
+      "oldVersion": "0.94.6",
+      "newVersion": "0.94.7",
       "constraints": [
         {
           "impact": "patch",
@@ -284,154 +85,28 @@
         {
           "impact": "patch",
           "reason": "Has dependency `workspace:*` on @glimmer/manager"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/destroyable"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/reference"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/global-context"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/validator"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/vm"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/owner"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
         }
       ],
       "pkgJSONPath": "./packages/@glimmer/runtime/package.json"
     },
     "@glimmer/syntax": {
-      "impact": "patch",
-      "oldVersion": "0.94.7",
-      "newVersion": "0.94.8",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :bug: Bug Fix"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/util"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/wire-format"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/syntax/package.json"
+      "oldVersion": "0.94.7"
     },
     "@glimmer/util": {
-      "impact": "patch",
-      "oldVersion": "0.94.6",
-      "newVersion": "0.94.7",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/util/package.json"
+      "oldVersion": "0.94.6"
     },
     "@glimmer/validator": {
-      "impact": "patch",
-      "oldVersion": "0.94.6",
-      "newVersion": "0.94.7",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/global-context"
-        },
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/validator/package.json"
+      "oldVersion": "0.94.6"
     },
     "@glimmer/vm": {
-      "impact": "patch",
-      "oldVersion": "0.94.6",
-      "newVersion": "0.94.7",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/vm/package.json"
+      "oldVersion": "0.94.6"
     },
     "@glimmer/vm-babel-plugins": {
-      "impact": "patch",
-      "oldVersion": "0.93.3",
-      "newVersion": "0.93.4",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/vm-babel-plugins/package.json"
+      "oldVersion": "0.93.3"
     },
     "@glimmer/wire-format": {
-      "impact": "patch",
-      "oldVersion": "0.94.6",
-      "newVersion": "0.94.7",
-      "constraints": [
-        {
-          "impact": "patch",
-          "reason": "Has dependency `workspace:*` on @glimmer/interfaces"
-        },
-        {
-          "impact": "patch",
-          "reason": "Appears in changelog section :house: Internal"
-        }
-      ],
-      "pkgJSONPath": "./packages/@glimmer/wire-format/package.json"
+      "oldVersion": "0.94.6"
     }
   },
-  "description": "## Release (2025-03-04)\n\n@glimmer/compiler 0.94.9 (patch)\n@glimmer/destroyable 0.94.7 (patch)\n@glimmer/encoder 0.93.7 (patch)\n@glimmer/global-context 0.93.3 (patch)\n@glimmer/interfaces 0.94.6 (patch)\n@glimmer/manager 0.94.8 (patch)\n@glimmer/node 0.94.8 (patch)\n@glimmer/opcode-compiler 0.94.8 (patch)\n@glimmer/owner 0.93.3 (patch)\n@glimmer/program 0.94.8 (patch)\n@glimmer/reference 0.94.7 (patch)\n@glimmer/runtime 0.94.8 (patch)\n@glimmer/syntax 0.94.8 (patch)\n@glimmer/util 0.94.7 (patch)\n@glimmer/validator 0.94.7 (patch)\n@glimmer/vm 0.94.7 (patch)\n@glimmer/vm-babel-plugins 0.93.4 (patch)\n@glimmer/wire-format 0.94.7 (patch)\n\n#### :bug: Bug Fix\n* `@glimmer/syntax`\n  * [#1722](https://github.com/glimmerjs/glimmer-vm/pull/1722) Printer bug: empty string literal args are dropped ([@ef4](https://github.com/ef4))\n  * [#1720](https://github.com/glimmerjs/glimmer-vm/pull/1720) Printer quoting bug ([@ef4](https://github.com/ef4))\n* `@glimmer/compiler`, `@glimmer/syntax`\n  * [#1717](https://github.com/glimmerjs/glimmer-vm/pull/1717) Fix source slicing for whitespace-stripping comments ([@chancancode](https://github.com/chancancode))\n\n#### :house: Internal\n* Other\n  * [#1728](https://github.com/glimmerjs/glimmer-vm/pull/1728) Set node-version to 22 in plan-release/publish ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n  * [#1727](https://github.com/glimmerjs/glimmer-vm/pull/1727) Update release-plan ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n  * [#1723](https://github.com/glimmerjs/glimmer-vm/pull/1723) Add .npmrc to turbo.json ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n  * [#1721](https://github.com/glimmerjs/glimmer-vm/pull/1721) set hoist-workspace-packages=false ([@ef4](https://github.com/ef4))\n* `@glimmer-workspace/repo-metadata`\n  * [#1726](https://github.com/glimmerjs/glimmer-vm/pull/1726) Move prettier tests to the smoke-tests project ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n* `@glimmer-workspace/bin`\n  * [#1718](https://github.com/glimmerjs/glimmer-vm/pull/1718) Fix accidental success in tests due to ansi-output not matching non-ansi string. ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n* `@glimmer/syntax`\n  * [#1719](https://github.com/glimmerjs/glimmer-vm/pull/1719) @handlebars/parser 2.1.0 causes errors due to an unreleased fix -- downgrade for now ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n* `@glimmer-workspace/meta-updater`, `@glimmer-workspace/bin`, `@glimmer-workspace/benchmark-env`, `@glimmer-workspace/build-support`, `@glimmer-workspace/eslint-plugin`, `@glimmer-workspace/integration-tests`, `@glimmer-workspace/test-utils`, `@glimmer/compiler`, `@glimmer/constants`, `@glimmer/debug-util`, `@glimmer/debug`, `@glimmer/destroyable`, `@glimmer/encoder`, `@glimmer/global-context`, `@glimmer/interfaces`, `@glimmer/local-debug-flags`, `@glimmer/manager`, `@glimmer/node`, `@glimmer/opcode-compiler`, `@glimmer/owner`, `@glimmer/program`, `@glimmer/reference`, `@glimmer/runtime`, `@glimmer/syntax`, `@glimmer/util`, `@glimmer/validator`, `@glimmer/vm-babel-plugins`, `@glimmer/vm`, `@glimmer/wire-format`, `@glimmer-workspace/repo-metadata`\n  * [#1714](https://github.com/glimmerjs/glimmer-vm/pull/1714) Dep upgrades from https://github.com/glimmerjs/glimmer-vm/pull/1690/ ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### Committers: 3\n- Edward Faulkner ([@ef4](https://github.com/ef4))\n- Godfrey Chan ([@chancancode](https://github.com/chancancode))\n- [@NullVoxPopuli](https://github.com/NullVoxPopuli)\n"
+  "description": "## Release (2025-02-11)\n\n@glimmer/manager 0.94.7 (patch)\n@glimmer/node 0.94.7 (patch)\n@glimmer/opcode-compiler 0.94.7 (patch)\n@glimmer/program 0.94.7 (patch)\n@glimmer/runtime 0.94.7 (patch)\n\n#### :bug: Bug Fix\n* `@glimmer-workspace/integration-tests`, `@glimmer/manager`\n  * [#1710](https://github.com/glimmerjs/glimmer-vm/pull/1710) Fix rendering non-object, yet stringable values (Symbol?), moves Reflect.getPrototypeOf to Object.getPrototypeOf ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### :house: Internal\n* `@glimmer-workspace/bin`\n  * [#1711](https://github.com/glimmerjs/glimmer-vm/pull/1711) Pull benchmark changes from feature/emit-fn-calls ([@NullVoxPopuli](https://github.com/NullVoxPopuli))\n\n#### Committers: 1\n- [@NullVoxPopuli](https://github.com/NullVoxPopuli)\n"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,5 @@
 # Changelog
 
-## Release (2025-03-04)
-
-@glimmer/compiler 0.94.9 (patch)
-@glimmer/destroyable 0.94.7 (patch)
-@glimmer/encoder 0.93.7 (patch)
-@glimmer/global-context 0.93.3 (patch)
-@glimmer/interfaces 0.94.6 (patch)
-@glimmer/manager 0.94.8 (patch)
-@glimmer/node 0.94.8 (patch)
-@glimmer/opcode-compiler 0.94.8 (patch)
-@glimmer/owner 0.93.3 (patch)
-@glimmer/program 0.94.8 (patch)
-@glimmer/reference 0.94.7 (patch)
-@glimmer/runtime 0.94.8 (patch)
-@glimmer/syntax 0.94.8 (patch)
-@glimmer/util 0.94.7 (patch)
-@glimmer/validator 0.94.7 (patch)
-@glimmer/vm 0.94.7 (patch)
-@glimmer/vm-babel-plugins 0.93.4 (patch)
-@glimmer/wire-format 0.94.7 (patch)
-
-#### :bug: Bug Fix
-* `@glimmer/syntax`
-  * [#1722](https://github.com/glimmerjs/glimmer-vm/pull/1722) Printer bug: empty string literal args are dropped ([@ef4](https://github.com/ef4))
-  * [#1720](https://github.com/glimmerjs/glimmer-vm/pull/1720) Printer quoting bug ([@ef4](https://github.com/ef4))
-* `@glimmer/compiler`, `@glimmer/syntax`
-  * [#1717](https://github.com/glimmerjs/glimmer-vm/pull/1717) Fix source slicing for whitespace-stripping comments ([@chancancode](https://github.com/chancancode))
-
-#### :house: Internal
-* Other
-  * [#1728](https://github.com/glimmerjs/glimmer-vm/pull/1728) Set node-version to 22 in plan-release/publish ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-  * [#1727](https://github.com/glimmerjs/glimmer-vm/pull/1727) Update release-plan ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-  * [#1723](https://github.com/glimmerjs/glimmer-vm/pull/1723) Add .npmrc to turbo.json ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-  * [#1721](https://github.com/glimmerjs/glimmer-vm/pull/1721) set hoist-workspace-packages=false ([@ef4](https://github.com/ef4))
-* `@glimmer-workspace/repo-metadata`
-  * [#1726](https://github.com/glimmerjs/glimmer-vm/pull/1726) Move prettier tests to the smoke-tests project ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-* `@glimmer-workspace/bin`
-  * [#1718](https://github.com/glimmerjs/glimmer-vm/pull/1718) Fix accidental success in tests due to ansi-output not matching non-ansi string. ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-* `@glimmer/syntax`
-  * [#1719](https://github.com/glimmerjs/glimmer-vm/pull/1719) @handlebars/parser 2.1.0 causes errors due to an unreleased fix -- downgrade for now ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-* `@glimmer-workspace/meta-updater`, `@glimmer-workspace/bin`, `@glimmer-workspace/benchmark-env`, `@glimmer-workspace/build-support`, `@glimmer-workspace/eslint-plugin`, `@glimmer-workspace/integration-tests`, `@glimmer-workspace/test-utils`, `@glimmer/compiler`, `@glimmer/constants`, `@glimmer/debug-util`, `@glimmer/debug`, `@glimmer/destroyable`, `@glimmer/encoder`, `@glimmer/global-context`, `@glimmer/interfaces`, `@glimmer/local-debug-flags`, `@glimmer/manager`, `@glimmer/node`, `@glimmer/opcode-compiler`, `@glimmer/owner`, `@glimmer/program`, `@glimmer/reference`, `@glimmer/runtime`, `@glimmer/syntax`, `@glimmer/util`, `@glimmer/validator`, `@glimmer/vm-babel-plugins`, `@glimmer/vm`, `@glimmer/wire-format`, `@glimmer-workspace/repo-metadata`
-  * [#1714](https://github.com/glimmerjs/glimmer-vm/pull/1714) Dep upgrades from https://github.com/glimmerjs/glimmer-vm/pull/1690/ ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-
-#### Committers: 3
-- Edward Faulkner ([@ef4](https://github.com/ef4))
-- Godfrey Chan ([@chancancode](https://github.com/chancancode))
-- [@NullVoxPopuli](https://github.com/NullVoxPopuli)
-
 ## Release (2025-02-11)
 
 @glimmer/manager 0.94.7 (patch)

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/compiler",
-  "version": "0.94.9",
+  "version": "0.94.8",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/destroyable",
-  "version": "0.94.7",
+  "version": "0.94.6",
   "license": "MIT",
   "description": "Utilities for creating and managing a destroyable hierarchy of objects",
   "repository": {

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/encoder",
-  "version": "0.93.7",
+  "version": "0.93.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/global-context",
-  "version": "0.93.3",
+  "version": "0.93.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/interfaces/package.json
+++ b/packages/@glimmer/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/interfaces",
-  "version": "0.94.6",
+  "version": "0.94.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/manager",
-  "version": "0.94.8",
+  "version": "0.94.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/node",
-  "version": "0.94.8",
+  "version": "0.94.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/opcode-compiler",
-  "version": "0.94.8",
+  "version": "0.94.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/owner",
-  "version": "0.93.3",
+  "version": "0.93.2",
   "license": "MIT",
   "description": "Implementation for the owner in Glimmer apps",
   "repository": {

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/program",
-  "version": "0.94.8",
+  "version": "0.94.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/reference",
-  "version": "0.94.7",
+  "version": "0.94.6",
   "license": "MIT",
   "description": "Objects used to track values and their dirtiness in Glimmer",
   "repository": {

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/runtime",
-  "version": "0.94.8",
+  "version": "0.94.7",
   "license": "MIT",
   "description": "Minimal runtime needed to render Glimmer templates",
   "repository": {

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/syntax",
-  "version": "0.94.8",
+  "version": "0.94.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/util",
-  "version": "0.94.7",
+  "version": "0.94.6",
   "license": "MIT",
   "description": "Common utilities used in Glimmer",
   "repository": {

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/validator",
-  "version": "0.94.7",
+  "version": "0.94.6",
   "license": "MIT",
   "description": "Objects used to track values and their dirtiness in Glimmer",
   "repository": {

--- a/packages/@glimmer/vm-babel-plugins/package.json
+++ b/packages/@glimmer/vm-babel-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/vm-babel-plugins",
-  "version": "0.93.4",
+  "version": "0.93.3",
   "license": "MIT",
   "description": "Compiles out VM assertion and deprecation utilities and debug tooling based on environment",
   "repository": {

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/vm",
-  "version": "0.94.7",
+  "version": "0.94.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/wire-format",
-  "version": "0.94.7",
+  "version": "0.94.6",
   "license": "MIT",
   "description": "",
   "repository": {

--- a/repo-metadata/metadata.json
+++ b/repo-metadata/metadata.json
@@ -153,7 +153,7 @@
     {
       "root": "packages/@glimmer/compiler",
       "name": "@glimmer/compiler",
-      "version": "0.94.9",
+      "version": "0.94.8",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -261,7 +261,7 @@
     {
       "root": "packages/@glimmer/destroyable",
       "name": "@glimmer/destroyable",
-      "version": "0.94.7",
+      "version": "0.94.6",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -287,7 +287,7 @@
     {
       "root": "packages/@glimmer/encoder",
       "name": "@glimmer/encoder",
-      "version": "0.93.7",
+      "version": "0.93.6",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -300,7 +300,7 @@
     {
       "root": "packages/@glimmer/global-context",
       "name": "@glimmer/global-context",
-      "version": "0.93.3",
+      "version": "0.93.2",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -313,7 +313,7 @@
     {
       "root": "packages/@glimmer/interfaces",
       "name": "@glimmer/interfaces",
-      "version": "0.94.6",
+      "version": "0.94.5",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -353,7 +353,7 @@
     {
       "root": "packages/@glimmer/manager",
       "name": "@glimmer/manager",
-      "version": "0.94.8",
+      "version": "0.94.7",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -380,7 +380,7 @@
     {
       "root": "packages/@glimmer/node",
       "name": "@glimmer/node",
-      "version": "0.94.8",
+      "version": "0.94.7",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -393,7 +393,7 @@
     {
       "root": "packages/@glimmer/opcode-compiler",
       "name": "@glimmer/opcode-compiler",
-      "version": "0.94.8",
+      "version": "0.94.7",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -406,7 +406,7 @@
     {
       "root": "packages/@glimmer/owner",
       "name": "@glimmer/owner",
-      "version": "0.93.3",
+      "version": "0.93.2",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -432,7 +432,7 @@
     {
       "root": "packages/@glimmer/program",
       "name": "@glimmer/program",
-      "version": "0.94.8",
+      "version": "0.94.7",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -458,7 +458,7 @@
     {
       "root": "packages/@glimmer/reference",
       "name": "@glimmer/reference",
-      "version": "0.94.7",
+      "version": "0.94.6",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -484,7 +484,7 @@
     {
       "root": "packages/@glimmer/runtime",
       "name": "@glimmer/runtime",
-      "version": "0.94.8",
+      "version": "0.94.7",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -497,7 +497,7 @@
     {
       "root": "packages/@glimmer/syntax",
       "name": "@glimmer/syntax",
-      "version": "0.94.8",
+      "version": "0.94.7",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -524,7 +524,7 @@
     {
       "root": "packages/@glimmer/util",
       "name": "@glimmer/util",
-      "version": "0.94.7",
+      "version": "0.94.6",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -550,7 +550,7 @@
     {
       "root": "packages/@glimmer/validator",
       "name": "@glimmer/validator",
-      "version": "0.94.7",
+      "version": "0.94.6",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -577,7 +577,7 @@
     {
       "root": "packages/@glimmer/vm",
       "name": "@glimmer/vm",
-      "version": "0.94.7",
+      "version": "0.94.6",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -590,7 +590,7 @@
     {
       "root": "packages/@glimmer/vm-babel-plugins",
       "name": "@glimmer/vm-babel-plugins",
-      "version": "0.93.4",
+      "version": "0.93.3",
       "type": "module",
       "private": false,
       "repo-meta": {
@@ -603,7 +603,7 @@
     {
       "root": "packages/@glimmer/wire-format",
       "name": "@glimmer/wire-format",
-      "version": "0.94.7",
+      "version": "0.94.6",
       "type": "module",
       "private": false,
       "repo-meta": {


### PR DESCRIPTION
Reverts glimmerjs/glimmer-vm#1715

We need to change how initial install works in the release scripts. In particular, we need to skip postinstall, and then prepark manually 