### PR TITLE
Restore {{debugger}} behavior

### DIFF
--- a/packages/@glimmer-workspace/build/lib/config.js
+++ b/packages/@glimmer-workspace/build/lib/config.js
@@ -363,6 +363,10 @@ export class Package {
                         passes: 3,
                         keep_fargs: false,
                         keep_fnames: false,
+                        /**
+                         * Required for {{debugger}} to work
+                         */
+                        drop_debugger: false,
                         // unsafe_arrows: true,
                         // unsafe_comps: true,
                         // unsafe_math: true,
@@ -382,6 +386,10 @@ export class Package {
                         passes: 3,
                         keep_fargs: false,
                         keep_fnames: false,
+                        /**
+                         * Required for {{debugger}} to work
+                         */
+                        drop_debugger: false,
                       },
                       format: {
                         comments: 'all',


### PR DESCRIPTION
Resolves: https://github.com/emberjs/ember.js/issues/20871

## Before

```js
function debugCallback(context, get) {
    // eslint-disable-next-line no-console
    console.info("Use `context`, and `get(<path>)` to debug this template."), get("this");
}
```


## After

```js
function debugCallback(context, get) {
    // eslint-disable-next-line no-console
    console.info("Use `context`, and `get(<path>)` to debug this template."), get("this");
    // eslint-disable-next-line no-debugger
    debugger;
}

```