### PR TITLE
Re-add support for tsconfig's moduleResolution=node10

### DIFF
--- a/.meta-updater/main.mjs
+++ b/.meta-updater/main.mjs
@@ -104,6 +104,7 @@ export default () =>
                 },
               });
             } else {
+              update(publishConfig, 'types', 'dist/dev/index.d.ts');
               update(publishConfig, 'exports', {
                 '.': {
                   development: {

--- a/packages/@glimmer-workspace/benchmark-env/package.json
+++ b/packages/@glimmer-workspace/benchmark-env/package.json
@@ -20,7 +20,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -28,7 +28,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -23,7 +23,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -22,7 +22,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -22,7 +22,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -22,7 +22,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -22,7 +22,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -22,7 +22,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -23,7 +23,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -22,7 +22,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -23,7 +23,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -23,7 +23,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -28,7 +28,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -23,7 +23,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -23,7 +23,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -22,7 +22,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -23,7 +23,8 @@
           "default": "./dist/prod/index.js"
         }
       }
-    }
+    },
+    "types": "dist/dev/index.d.ts"
   },
   "files": [
     "dist"


### PR DESCRIPTION
This feels crazy to add support for the node10 moduleResolution setting, but as pointed out in:
https://github.com/emberjs/ember.js/issues/20876

Some projects aren't up to date enough to use more modern moduleResolution settings -- and every TS dep needs to be compat with both in order to allow a consumer to migrate.


From the [tsconfig docs](https://www.typescriptlang.org/tsconfig/#moduleResolution)


> Default: Node10 if [module](https://www.typescriptlang.org/tsconfig/#module) is CommonJS; Node16 if [module](https://www.typescriptlang.org/tsconfig/#module) is Node16 or  Node18; NodeNext if [module](https://www.typescriptlang.org/tsconfig/#module) is NodeNext; Bundler if [module](https://www.typescriptlang.org/tsconfig/#module) is Preserve; Classic otherwise.


_No one should be using Node10 if they're writing ESM_.

`moduleResolution: node` was renamed to `moduleResolution: node10` with the release of TypeScript 5.0, which was released in March of 2023, which at the time, ember LTS was 4.8 with 4.12 being released on May 2023.

So it is within the TS Rolling support policy to be reasonable to have dropped support for `moduleResolution: node10`, and earlier TS versions.
(assuming config changes't aren't covered under [semver-ts](https://www.semver-ts.org/) -- I opened [this issue on semver-ts](https://github.com/semver-ts/semver-ts/issues/31))

However, supporting node10 might be easy, as this PR is one line change in each published package.json