### PR TITLE
Implement trackedObject, trackedSet, trackedWeakSet, trackedMap, and trackedWeakMap

### DIFF
--- a/packages/@glimmer/validator/lib/collections/map.ts
+++ b/packages/@glimmer/validator/lib/collections/map.ts
@@ -1,0 +1,133 @@
+class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
+  private collection = createStorage(null, () => false);
+
+  private storages: Map<K, TrackedStorage<null>> = new Map();
+
+  private vals: Map<K, V>;
+
+  private readStorageFor(key: K): void {
+    const { storages } = this;
+    let storage = storages.get(key);
+
+    if (storage === undefined) {
+      storage = createStorage(null, () => false);
+      storages.set(key, storage);
+    }
+
+    getValue(storage);
+  }
+
+  private dirtyStorageFor(key: K): void {
+    const storage = this.storages.get(key);
+
+    if (storage) {
+      setValue(storage, null);
+    }
+  }
+
+  constructor();
+  constructor(entries: readonly (readonly [K, V])[] | null);
+  constructor(iterable: Iterable<readonly [K, V]>);
+  constructor(
+    existing?: readonly (readonly [K, V])[] | Iterable<readonly [K, V]> | null
+  ) {
+    // TypeScript doesn't correctly resolve the overloads for calling the `Map`
+    // constructor for the no-value constructor. This resolves that.
+    this.vals = existing ? new Map(existing) : new Map();
+  }
+
+  // **** KEY GETTERS ****
+  get(key: K): V | undefined {
+    // entangle the storage for the key
+    this.readStorageFor(key);
+
+    return this.vals.get(key);
+  }
+
+  has(key: K): boolean {
+    this.readStorageFor(key);
+
+    return this.vals.has(key);
+  }
+
+  // **** ALL GETTERS ****
+  entries() {
+    getValue(this.collection);
+
+    return this.vals.entries();
+  }
+
+  keys() {
+    getValue(this.collection);
+
+    return this.vals.keys();
+  }
+
+  values() {
+    getValue(this.collection);
+
+    return this.vals.values();
+  }
+
+  forEach(fn: (value: V, key: K, map: Map<K, V>) => void): void {
+    getValue(this.collection);
+
+    this.vals.forEach(fn);
+  }
+
+  get size(): number {
+    getValue(this.collection);
+
+    return this.vals.size;
+  }
+
+  [Symbol.iterator]() {
+    getValue(this.collection);
+
+    return this.vals[Symbol.iterator]();
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.vals[Symbol.toStringTag];
+  }
+
+  // **** KEY SETTERS ****
+  set(key: K, value: V): this {
+    this.dirtyStorageFor(key);
+    setValue(this.collection, null);
+
+    this.vals.set(key, value);
+
+    return this;
+  }
+
+  delete(key: K): boolean {
+    this.dirtyStorageFor(key);
+    setValue(this.collection, null);
+
+    this.storages.delete(key);
+    return this.vals.delete(key);
+  }
+
+  // **** ALL SETTERS ****
+  clear(): void {
+    this.storages.forEach((s) => setValue(s, null));
+    this.storages.clear();
+
+    setValue(this.collection, null);
+    this.vals.clear();
+  }
+}
+
+// So instanceof works
+Object.setPrototypeOf(TrackedMap.prototype, Map.prototype);
+
+export function trackedMap<Key = unknown, Value = unknown>(
+  data?: Map<Key, Value>,
+  options?: { equals?: (a: T, b: T) => boolean; description?: string }
+): Map<Key, Value> {
+  return new TrackedMap(data ?? [], {
+    equals: options?.equals ?? Object.is,
+    description: options?.description,
+  });
+}

--- a/packages/@glimmer/validator/lib/collections/object.ts
+++ b/packages/@glimmer/validator/lib/collections/object.ts
@@ -1,0 +1,118 @@
+class TrackedObjectImplementation<T extends object> {
+  static fromEntries<T = unknown>(entries: Iterable<readonly [PropertyKey, T]>) {
+    return new TrackedObject(Object.fromEntries(entries));
+  }
+
+  constructor(...args: Record<PropertyKey, never> extends T ? [] | [T] : [T]);
+  constructor(obj = {}) {
+    const proto = Object.getPrototypeOf(obj);
+    const descs = Object.getOwnPropertyDescriptors(obj);
+
+    const clone = Object.create(proto);
+
+    for (const prop in descs) {
+      Object.defineProperty(clone, prop, descs[prop]!);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    return new Proxy(clone, {
+      get(target, prop) {
+        self.#readStorageFor(prop);
+
+        return target[prop];
+      },
+
+      has(target, prop) {
+        self.#readStorageFor(prop);
+
+        return prop in target;
+      },
+
+      ownKeys(target: T) {
+        getValue(self.#collection);
+
+        return Reflect.ownKeys(target);
+      },
+
+      set(target, prop, value) {
+        target[prop] = value;
+
+        self.#dirtyStorageFor(prop);
+        self.#dirtyCollection();
+
+        return true;
+      },
+
+      deleteProperty(target, prop) {
+        if (prop in target) {
+          delete target[prop];
+          self.#dirtyStorageFor(prop);
+          self.#storages.delete(prop);
+          self.#dirtyCollection();
+        }
+
+        return true;
+      },
+
+      getPrototypeOf() {
+        return TrackedObjectImplementation.prototype;
+      },
+    });
+  }
+
+  #storages = new Map();
+
+  #collection = createStorage(null, () => false);
+
+  #readStorageFor(key: PropertyKey) {
+    let storage = this.#storages.get(key);
+
+    if (storage === undefined) {
+      storage = createStorage(null, () => false);
+      this.#storages.set(key, storage);
+    }
+
+    getValue(storage);
+  }
+
+  #dirtyStorageFor(key: PropertyKey) {
+    const storage = this.#storages.get(key);
+
+    if (storage) {
+      setValue(storage, null);
+    }
+  }
+
+  #dirtyCollection() {
+    setValue(this.#collection, null);
+  }
+}
+
+interface TrackedObject {
+  fromEntries<T = unknown>(
+    entries: Iterable<readonly [PropertyKey, T]>
+  ): {
+    [k: string]: T;
+  };
+
+  new <T extends Record<PropertyKey, unknown>>(
+    ...args: Record<PropertyKey, never> extends T ? [] | [T] : [T]
+  ): T;
+}
+
+const TrackedObject: TrackedObject = TrackedObjectImplementation as unknown as TrackedObject;
+
+export function trackedObject<ObjectType extends object>(
+  data?: ObjectType,
+  options?: {
+    equals?: (a: ObjectType[keyof ObjectType], b: ObjectType[keyof ObjectType]) => boolean;
+    description?: string;
+  }
+): ObjectType {
+  return new TrackedObject(data ?? [], {
+    equals: options?.equals ?? Object.is,
+    description: options?.description,
+  });
+}

--- a/packages/@glimmer/validator/lib/collections/set.ts
+++ b/packages/@glimmer/validator/lib/collections/set.ts
@@ -1,0 +1,164 @@
+class TrackedSet<T = unknown> implements Set<T> {
+  private collection = createStorage(null, () => false);
+
+  private storages: Map<T, TrackedStorage<null>> = new Map();
+
+  private vals: Set<T>;
+
+  private storageFor(key: T): TrackedStorage<null> {
+    const storages = this.storages;
+    let storage = storages.get(key);
+
+    if (storage === undefined) {
+      storage = createStorage(null, () => false);
+      storages.set(key, storage);
+    }
+
+    return storage;
+  }
+
+  private dirtyStorageFor(key: T): void {
+    const storage = this.storages.get(key);
+
+    if (storage) {
+      setValue(storage, null);
+    }
+  }
+
+  constructor();
+  constructor(values: readonly T[] | null);
+  constructor(iterable: Iterable<T>);
+  constructor(existing?: readonly T[] | Iterable<T> | null) {
+    this.vals = new Set(existing);
+  }
+
+  // **** KEY GETTERS ****
+  has(value: T): boolean {
+    getValue(this.storageFor(value));
+
+    return this.vals.has(value);
+  }
+
+  // **** ALL GETTERS ****
+  entries() {
+    getValue(this.collection);
+
+    return this.vals.entries();
+  }
+
+  keys() {
+    getValue(this.collection);
+
+    return this.vals.keys();
+  }
+
+  values() {
+    getValue(this.collection);
+
+    return this.vals.values();
+  }
+
+  union<U>(other: ReadonlySetLike<U>): Set<T | U> {
+    getValue(this.collection);
+
+    return this.vals.union(other);
+  }
+
+  intersection<U>(other: ReadonlySetLike<U>): Set<T & U> {
+    getValue(this.collection);
+
+    return this.vals.intersection(other);
+  }
+
+  difference<U>(other: ReadonlySetLike<U>): Set<T> {
+    getValue(this.collection);
+
+    return this.vals.difference(other);
+  }
+
+  symmetricDifference<U>(other: ReadonlySetLike<U>): Set<T | U> {
+    getValue(this.collection);
+
+    return this.vals.symmetricDifference(other);
+  }
+
+  isSubsetOf(other: ReadonlySetLike<unknown>): boolean {
+    getValue(this.collection);
+
+    return this.vals.isSubsetOf(other);
+  }
+
+  isSupersetOf(other: ReadonlySetLike<unknown>): boolean {
+    getValue(this.collection);
+
+    return this.vals.isSupersetOf(other);
+  }
+
+  isDisjointFrom(other: ReadonlySetLike<unknown>): boolean {
+    getValue(this.collection);
+
+    return this.vals.isDisjointFrom(other);
+  }
+
+  forEach(fn: (value1: T, value2: T, set: Set<T>) => void): void {
+    getValue(this.collection);
+
+    this.vals.forEach(fn);
+  }
+
+  get size(): number {
+    getValue(this.collection);
+
+    return this.vals.size;
+  }
+
+  [Symbol.iterator]() {
+    getValue(this.collection);
+
+    return this.vals[Symbol.iterator]();
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.vals[Symbol.toStringTag];
+  }
+
+  // **** KEY SETTERS ****
+  add(value: T): this {
+    this.dirtyStorageFor(value);
+    setValue(this.collection, null);
+
+    this.vals.add(value);
+
+    return this;
+  }
+
+  delete(value: T): boolean {
+    this.dirtyStorageFor(value);
+    setValue(this.collection, null);
+
+    this.storages.delete(value);
+    return this.vals.delete(value);
+  }
+
+  // **** ALL SETTERS ****
+  clear(): void {
+    this.storages.forEach((s) => setValue(s, null));
+    setValue(this.collection, null);
+
+    this.storages.clear();
+    this.vals.clear();
+  }
+}
+
+// So instanceof works
+Object.setPrototypeOf(TrackedSet.prototype, Set.prototype);
+
+export function trackedSet<Value = unknown>(
+  data?: Set<Value>,
+  options?: { equals?: (a: Value, b: Value) => boolean; description?: string }
+): Set<Value> {
+  return new TrackedSet(data ?? [], {
+    equals: options?.equals ?? Object.is,
+    description: options?.description,
+  });
+}

--- a/packages/@glimmer/validator/lib/collections/weak-map.ts
+++ b/packages/@glimmer/validator/lib/collections/weak-map.ts
@@ -1,0 +1,78 @@
+class TrackedWeakMap<K extends object = object, V = unknown> implements WeakMap<K, V> {
+  private storages: WeakMap<K, TrackedStorage<null>> = new WeakMap();
+
+  private vals: WeakMap<K, V>;
+
+  private readStorageFor(key: K): void {
+    const { storages } = this;
+    let storage = storages.get(key);
+
+    if (storage === undefined) {
+      storage = createStorage(null, () => false);
+      storages.set(key, storage);
+    }
+
+    getValue(storage);
+  }
+
+  private dirtyStorageFor(key: K): void {
+    const storage = this.storages.get(key);
+
+    if (storage) {
+      setValue(storage, null);
+    }
+  }
+
+  constructor();
+  constructor(iterable: Iterable<readonly [K, V]>);
+  constructor(entries: readonly [K, V][] | null);
+  constructor(existing?: readonly [K, V][] | Iterable<readonly [K, V]> | null) {
+    // TypeScript doesn't correctly resolve the overloads for calling the `Map`
+    // constructor for the no-value constructor. This resolves that.
+    this.vals = existing ? new WeakMap(existing) : new WeakMap();
+  }
+
+  get(key: K): V | undefined {
+    this.readStorageFor(key);
+
+    return this.vals.get(key);
+  }
+
+  has(key: K): boolean {
+    this.readStorageFor(key);
+
+    return this.vals.has(key);
+  }
+
+  set(key: K, value: V): this {
+    this.dirtyStorageFor(key);
+
+    this.vals.set(key, value);
+
+    return this;
+  }
+
+  delete(key: K): boolean {
+    this.dirtyStorageFor(key);
+
+    this.storages.delete(key);
+    return this.vals.delete(key);
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.vals[Symbol.toStringTag];
+  }
+}
+
+// So instanceof works
+Object.setPrototypeOf(TrackedWeakMap.prototype, WeakMap.prototype);
+
+export function trackedWeakMap<Key extends WeakKey, Value = unknown>(
+  data?: WeakMap<Key, Value>,
+  options?: { equals?: (a: T, b: T) => boolean; description?: string }
+): WeakMap<Key, Value> {
+  return new TrackedWeakMap(data ?? [], {
+    equals: options?.equals ?? Object.is,
+    description: options?.description,
+  });
+}

--- a/packages/@glimmer/validator/lib/collections/weak-set.ts
+++ b/packages/@glimmer/validator/lib/collections/weak-set.ts
@@ -1,0 +1,68 @@
+class TrackedWeakSet<T extends object = object> implements WeakSet<T> {
+  private storages: WeakMap<T, TrackedStorage<null>> = new WeakMap();
+
+  private vals: WeakSet<T>;
+
+  private storageFor(key: T): TrackedStorage<null> {
+    const storages = this.storages;
+    let storage = storages.get(key);
+
+    if (storage === undefined) {
+      storage = createStorage(null, () => false);
+      storages.set(key, storage);
+    }
+
+    return storage;
+  }
+
+  private dirtyStorageFor(key: T): void {
+    const storage = this.storages.get(key);
+
+    if (storage) {
+      setValue(storage, null);
+    }
+  }
+
+  constructor(values?: readonly T[] | null) {
+    this.vals = new WeakSet(values);
+  }
+
+  has(value: T): boolean {
+    getValue(this.storageFor(value));
+
+    return this.vals.has(value);
+  }
+
+  add(value: T): this {
+    // Add to vals first to get better error message
+    this.vals.add(value);
+
+    this.dirtyStorageFor(value);
+
+    return this;
+  }
+
+  delete(value: T): boolean {
+    this.dirtyStorageFor(value);
+
+    this.storages.delete(value);
+    return this.vals.delete(value);
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.vals[Symbol.toStringTag];
+  }
+}
+
+// So instanceof works
+Object.setPrototypeOf(TrackedWeakSet.prototype, WeakSet.prototype);
+
+export function trackedWeakSet<Value = unknown>(
+  data?: WeakSet<Value>,
+  options?: { equals?: (a: Value, b: Value) => boolean; description?: string }
+): WeakSet<Value> {
+  return new TrackedWeakSet(data ?? [], {
+    equals: options?.equals ?? Object.is,
+    description: options?.description,
+  });
+}


### PR DESCRIPTION
RFC: https://github.com/emberjs/rfcs/pull/1068

Followup to: https://github.com/glimmerjs/glimmer-vm/pull/1713

Changes from the tracked-built-ins implementation (as described by the RFC)
- use tags directly, don't use cache / tracked-storage apis (these don't exist anyway)
- defaults to Object.is for the equals function
- has overridable equals function
  - to get `tracked-built-ins` behavior back, you set `equals: () => false`
- `description` is currently unused, but @wycats has plans -- `description` is meant for debugger hints