### PR TITLE
Explore alternate array implementation

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/render-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/render-test.ts
@@ -439,7 +439,7 @@ export class RenderTest implements IRenderTest {
         let key = Array.isArray(items[index]) ? items[index][0] : index;
         let value = Array.isArray(items[index]) ? items[index][1] : items[index];
 
-        QUnit.assert.equal(el.textContent, `${key}.${value}`);
+        QUnit.assert.equal(el.textContent, `${key}.${value}`, `Comparing the rendered key.value`);
       }
     );
   }
@@ -497,7 +497,10 @@ export class RenderTest implements IRenderTest {
   }
 
   protected assertEachInReactivity(
-    Klass: new (...args: any[]) => { collection: number[]; update: () => void }
+    Klass: new (...args: any[]) => {
+      collection: (string | number)[] | Map<unknown, string | number>;
+      update: () => void;
+    }
   ) {
     let instance: TestComponent | undefined;
 
@@ -533,7 +536,9 @@ export class RenderTest implements IRenderTest {
     let { collection } = instance;
 
     this.assertEachCompareResults(
-      Symbol.iterator in collection ? Array.from(collection) : Object.entries(collection)
+      Symbol.iterator in collection
+        ? Array.from(collection as string[])
+        : Object.entries(collection)
     );
 
     instance.update();
@@ -541,12 +546,21 @@ export class RenderTest implements IRenderTest {
     this.rerender();
 
     this.assertEachCompareResults(
-      Symbol.iterator in collection ? Array.from(collection) : Object.entries(collection)
+      Symbol.iterator in collection
+        ? Array.from(collection as string[])
+        : Object.entries(collection)
     );
   }
 
   protected assertEachReactivity(
-    Klass: new (...args: any[]) => { collection: number[]; update: () => void }
+    Klass: new (...args: any[]) => {
+      collection:
+        | (string | number)[]
+        | Set<number | string>
+        | Map<unknown, unknown>
+        | Record<string, unknown>;
+      update: () => void;
+    }
   ) {
     let instance: TestComponent | undefined;
 
@@ -579,13 +593,23 @@ export class RenderTest implements IRenderTest {
       throw new Error('The instance is not defined');
     }
 
-    this.assertEachCompareResults(Array.from(instance.collection).map((v, i) => [i, v]));
+    function getEntries() {
+      if (!instance) return [];
+
+      if (instance.collection instanceof Map) {
+        return Array.from(instance.collection.entries());
+      }
+
+      return Array.from(instance.collection as (string | number)[]);
+    }
+
+    this.assertEachCompareResults((getEntries() as string[]).map((v, i) => [i, v]));
 
     instance.update();
 
     this.rerender();
 
-    this.assertEachCompareResults(Array.from(instance.collection).map((v, i) => [i, v]));
+    this.assertEachCompareResults((getEntries() as string[]).map((v, i) => [i, v]));
 
     this.assertStableRerender();
   }

--- a/packages/@glimmer/validator/test/collections/array-test.ts
+++ b/packages/@glimmer/validator/test/collections/array-test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import-x/no-extraneous-dependencies */
+
 
 import { trackedArray } from '@glimmer/validator';
 import { expectTypeOf } from 'expect-type';
@@ -6,6 +6,7 @@ import { expectTypeOf } from 'expect-type';
 import { module, test } from '../-utils';
 
 expectTypeOf<ReturnType<typeof trackedArray>>().toMatchTypeOf<Array<unknown>>();
+expectTypeOf<ReturnType<typeof trackedArray<number>>>().toMatchTypeOf<Array<number>>();
 
 module('@glimmer/validator: trackedArray()', () => {
   test('Can get values on array directly', (assert) => {

--- a/packages/@glimmer/validator/test/package.json
+++ b/packages/@glimmer/validator/test/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@glimmer/global-context": "workspace:*",
     "@glimmer/interfaces": "workspace:*",
-    "@glimmer/validator": "workspace:*"
+    "@glimmer/validator": "workspace:*",
+    "expect-type": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1571,6 +1571,9 @@ importers:
       '@glimmer/validator':
         specifier: workspace:*
         version: link:..
+      expect-type:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   packages/@glimmer/vm:
     dependencies:


### PR DESCRIPTION
based off warp-drive's resource-array


Notes from: #1748

- [ ] fix the array implementation / compare with Vue's version: https://github.com/vuejs/core/blob/main/packages/reactivity/src/arrayInstrumentations.ts 
      (this is mainly because the version of trackedArray we have (from tracked-built-ins) doesn't pass all our tests -- so I need to compare with someone else's implementation to see what's different)