### PR TITLE
fix link-all: Extensions must match path on disk. It was TS that created a problem, and node fixed it.

### DIFF
--- a/bin/link-all.mts
+++ b/bin/link-all.mts
@@ -25,7 +25,7 @@ import { mkdirp } from 'mkdirp';
 import { rimraf } from 'rimraf';
 import { x as untar } from 'tar';
 
-import { packages } from './packages.mjs';
+import { packages } from './packages.mts';
 
 const dist = new URL('../dist', import.meta.url).pathname;
 const pkgs = packages('@glimmer');


### PR DESCRIPTION
… Node fixed it