### PR TITLE
Add failing test for invalid attribute name

### DIFF
--- a/packages/@glimmer/compiler/test/compiler-test.ts
+++ b/packages/@glimmer/compiler/test/compiler-test.ts
@@ -58,6 +58,19 @@ QUnit.test(
   }
 );
 
+QUnit.test(
+  'invalid html attribute throws syntax error',
+  (assert) => {
+    const template = strip`
+    <a * >Link</a>
+  `;
+    assert.throws(
+      () => compile(template),
+      /"\*" is not a valid attribute name/u
+    );
+  }
+);
+
 test('HTML text content', 'content', s`content`);
 
 test('Text curlies', '<div>{{title}}<span>{{title}}</span></div>', [


### PR DESCRIPTION
If you leave a stray character inside element space, glimmer will compile it as an HTM attribute and attempt to setAttribute at runtime, which the browser will reject. This is very confusing to debug. It should probably be a direct compile error instead.