### PR TITLE
Maintain opcode stack consistency in non-interactive mode

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -147,12 +147,11 @@ APPEND_OPCODES.add(VM_CLOSE_ELEMENT_OP, (vm) => {
 });
 
 APPEND_OPCODES.add(VM_MODIFIER_OP, (vm, { op1: handle }) => {
+  let args = check(vm.stack.pop(), CheckArguments);
   if (!vm.env.isInteractive) {
     return;
   }
-
   let owner = vm.getOwner();
-  let args = check(vm.stack.pop(), CheckArguments);
   let definition = vm.constants.getValue<ModifierDefinition>(handle);
 
   let { manager } = definition;
@@ -189,13 +188,14 @@ APPEND_OPCODES.add(VM_MODIFIER_OP, (vm, { op1: handle }) => {
 });
 
 APPEND_OPCODES.add(VM_DYNAMIC_MODIFIER_OP, (vm) => {
+  let { stack } = vm;
+  let ref = check(stack.pop(), CheckReference);
+  let args = check(stack.pop(), CheckArguments).capture();
+
   if (!vm.env.isInteractive) {
     return;
   }
 
-  let { stack } = vm;
-  let ref = check(stack.pop(), CheckReference);
-  let args = check(stack.pop(), CheckArguments).capture();
   let { positional: outerPositional, named: outerNamed } = args;
 
   let { constructing } = vm.tree();


### PR DESCRIPTION
When testing our glimmer & ember monorepo integration branches, the glimmer local debug infrastructure is present within ember's tests. That exposed failing assertions when exercising modifiers in non-interactive mode. By early exiting, they violate the expectation that they always consume a certain number of arguments from the stack.

This change ensures they always consume the same arguments even in non-interactive mode.